### PR TITLE
docs: Add README and benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,135 @@
+# freesasa-zig
+
+Solvent Accessible Surface Area (SASA) calculator implemented in Zig, ported from [FreeSASA](https://github.com/mittinatten/freesasa).
+
+## Overview
+
+SASA (Solvent Accessible Surface Area) measures the surface area of a biomolecule that is accessible to solvent molecules. This implementation uses the Shrake-Rupley algorithm with Golden Section Spiral test points.
+
+## Features
+
+- Shrake-Rupley algorithm implementation
+- JSON input/output format
+- Configurable test points and probe radius
+- Memory-safe implementation with explicit allocators
+
+## Building
+
+Requires Zig 0.14.0 or later.
+
+```bash
+zig build
+```
+
+Run tests:
+
+```bash
+zig build test
+```
+
+## Usage
+
+```bash
+# Basic usage
+./zig-out/bin/freesasa_zig <input.json> [output.json]
+
+# Example
+./zig-out/bin/freesasa_zig examples/input_1a0q.json output.json
+```
+
+### Input Format
+
+JSON file with atom coordinates and van der Waals radii:
+
+```json
+{
+  "x": [1.0, 2.0, 3.0],
+  "y": [1.0, 2.0, 3.0],
+  "z": [1.0, 2.0, 3.0],
+  "r": [1.7, 1.55, 1.52]
+}
+```
+
+### Output Format
+
+```json
+{
+  "total_area": 1234.56,
+  "atom_areas": [10.5, 20.3, ...]
+}
+```
+
+## Preparing Input Data
+
+Use the provided Python scripts to convert structure files:
+
+```bash
+# Convert mmCIF/PDB to input JSON
+./scripts/cif_to_input_json.py structure.cif output.json
+
+# Generate reference SASA using FreeSASA (for validation)
+./scripts/calc_reference_sasa.py structure.cif reference.json
+```
+
+Requirements: Python 3.11+, gemmi, freesasa (installed automatically via PEP 723)
+
+## Algorithm
+
+### Shrake-Rupley Method
+
+1. Generate uniformly distributed test points on a unit sphere using Golden Section Spiral
+2. For each atom:
+   - Scale test points by (van der Waals radius + probe radius)
+   - Translate to atom position
+   - Count points not buried inside neighboring atoms
+   - SASA = 4π × r² × (exposed points / total points)
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `n_points` | 100 | Test points per atom |
+| `probe_radius` | 1.4 Å | Water molecule radius |
+
+## Validation
+
+Tested against FreeSASA reference implementation:
+
+| Structure | Atoms | Reference (Å²) | Zig (Å²) | Difference |
+|-----------|-------|----------------|----------|------------|
+| 1A0Q | 3183 | 18923.28 | 19211.19 | 1.52% |
+
+## Project Structure
+
+```
+freesasa-zig/
+├── src/
+│   ├── main.zig           # CLI entry point
+│   ├── types.zig          # Data structures (Vec3, AtomInput, etc.)
+│   ├── json_parser.zig    # JSON input parsing
+│   ├── json_writer.zig    # JSON output writing
+│   ├── test_points.zig    # Golden Section Spiral generation
+│   └── shrake_rupley.zig  # Core SASA algorithm
+├── scripts/
+│   ├── cif_to_input_json.py   # Structure to JSON converter
+│   └── calc_reference_sasa.py # Reference SASA calculator
+├── examples/
+│   └── input_1a0q.json    # Example input (PDB 1A0Q)
+└── plans/
+    └── phase-1-shrake-rupley.md
+```
+
+## Roadmap
+
+- [x] Phase 1: Basic Shrake-Rupley implementation
+- [ ] Phase 2: Optimization (neighbor lists, SIMD, parallelism)
+- [ ] Phase 3: Production features (CLI options, error handling)
+
+## License
+
+MIT
+
+## References
+
+- Shrake, A., & Rupley, J. A. (1973). Environment and exposure to solvent of protein atoms. Lysozyme and insulin. *Journal of Molecular Biology*, 79(2), 351-371.
+- [FreeSASA](https://github.com/mittinatten/freesasa) - Original C implementation

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "freesasa>=2.0",
+#     "gemmi>=0.7.4",
+# ]
+# ///
+"""Benchmark freesasa-zig against FreeSASA Python bindings.
+
+Usage:
+    ./benchmark.py <input_file> [--runs N] [--zig-binary PATH]
+
+Examples:
+    ./benchmark.py examples/1A0Q.cif.gz
+    ./benchmark.py examples/input_1a0q.json --runs 5
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean, stdev
+
+import freesasa
+import gemmi
+
+
+@dataclass
+class BenchmarkResult:
+    """Benchmark results for a single implementation."""
+
+    name: str
+    times: list[float]
+    total_area: float
+    n_atoms: int
+
+    @property
+    def mean_time(self) -> float:
+        return mean(self.times)
+
+    @property
+    def stdev_time(self) -> float:
+        return stdev(self.times) if len(self.times) > 1 else 0.0
+
+    @property
+    def min_time(self) -> float:
+        return min(self.times)
+
+    @property
+    def max_time(self) -> float:
+        return max(self.times)
+
+
+def prepare_inputs(
+    input_path: Path,
+) -> tuple[Path, Path | None]:
+    """Prepare input files for both implementations.
+
+    Returns (json_path, pdb_path) for zig and freesasa respectively.
+    """
+    # Check if input is already JSON
+    if input_path.suffix == ".json":
+        # Need to create PDB for FreeSASA
+        # This is a limitation - we'd need the original structure
+        # For now, just return the JSON path and None for PDB
+        return input_path, None
+
+    # Input is a structure file (CIF/PDB)
+    st = gemmi.read_structure(str(input_path))
+    st.remove_hydrogens()
+    st.remove_alternative_conformations()
+    st.remove_ligands_and_waters()
+    st.remove_empty_chains()
+
+    # Create JSON for Zig
+    xs, ys, zs, rs = [], [], [], []
+    for cra in st[0].all():
+        atom = cra.atom
+        xs.append(atom.pos.x)
+        ys.append(atom.pos.y)
+        zs.append(atom.pos.z)
+        rs.append(atom.element.vdw_r)
+
+    json_tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+    json.dump({"x": xs, "y": ys, "z": zs, "r": rs}, open(json_tmp.name, "w"))
+
+    # Create PDB for FreeSASA
+    pdb_tmp = tempfile.NamedTemporaryFile(suffix=".pdb", delete=False)
+    st.write_pdb(pdb_tmp.name)
+
+    return Path(json_tmp.name), Path(pdb_tmp.name)
+
+
+def benchmark_zig(
+    json_path: Path,
+    zig_binary: Path,
+    runs: int,
+) -> BenchmarkResult:
+    """Benchmark the Zig implementation."""
+    times = []
+    total_area = 0.0
+    n_atoms = 0
+
+    for i in range(runs):
+        output_tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+
+        start = time.perf_counter()
+        result = subprocess.run(
+            [str(zig_binary), str(json_path), output_tmp.name],
+            capture_output=True,
+            text=True,
+        )
+        elapsed = time.perf_counter() - start
+
+        if result.returncode != 0:
+            print(f"Zig error: {result.stderr}", file=sys.stderr)
+            sys.exit(1)
+
+        times.append(elapsed)
+
+        # Parse output on first run
+        if i == 0:
+            with open(output_tmp.name) as f:
+                data = json.load(f)
+                total_area = data["total_area"]
+                n_atoms = len(data["atom_areas"])
+
+        Path(output_tmp.name).unlink()
+
+    return BenchmarkResult(
+        name="Zig",
+        times=times,
+        total_area=total_area,
+        n_atoms=n_atoms,
+    )
+
+
+def benchmark_freesasa(
+    pdb_path: Path | None,
+    json_path: Path | None,
+    runs: int,
+) -> BenchmarkResult | None:
+    """Benchmark the FreeSASA Python implementation."""
+    if pdb_path is None:
+        return None
+
+    times = []
+    total_area = 0.0
+    n_atoms = 0
+
+    for i in range(runs):
+        start = time.perf_counter()
+        structure = freesasa.Structure(str(pdb_path))
+        result = freesasa.calc(structure)
+        elapsed = time.perf_counter() - start
+
+        times.append(elapsed)
+
+        if i == 0:
+            total_area = result.totalArea()
+            n_atoms = result.nAtoms()
+
+    return BenchmarkResult(
+        name="FreeSASA (Python)",
+        times=times,
+        total_area=total_area,
+        n_atoms=n_atoms,
+    )
+
+
+def print_results(results: list[BenchmarkResult], runs: int) -> None:
+    """Print benchmark results in a formatted table."""
+    print(f"\n{'=' * 60}")
+    print(f"Benchmark Results ({runs} runs)")
+    print(f"{'=' * 60}\n")
+
+    # Table header
+    print(
+        f"{'Implementation':<20} {'Mean (s)':<12} {'Std (s)':<12} {'Min (s)':<12} {'Max (s)':<12}"
+    )
+    print("-" * 68)
+
+    for r in results:
+        print(
+            f"{r.name:<20} {r.mean_time:<12.4f} {r.stdev_time:<12.4f} "
+            f"{r.min_time:<12.4f} {r.max_time:<12.4f}"
+        )
+
+    print()
+
+    # SASA comparison
+    print(f"{'Implementation':<20} {'Atoms':<10} {'Total SASA (Å²)':<20}")
+    print("-" * 50)
+
+    for r in results:
+        print(f"{r.name:<20} {r.n_atoms:<10} {r.total_area:<20.2f}")
+
+    if len(results) == 2:
+        diff = abs(results[0].total_area - results[1].total_area)
+        diff_pct = diff / results[1].total_area * 100
+        speedup = results[1].mean_time / results[0].mean_time
+
+        print()
+        print(f"SASA difference: {diff:.2f} Å² ({diff_pct:.2f}%)")
+        print(f"Speedup: {speedup:.2f}x")
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_file", type=Path, help="Input file (CIF, PDB, or JSON)")
+    parser.add_argument("--runs", type=int, default=3, help="Number of benchmark runs")
+    parser.add_argument(
+        "--zig-binary",
+        type=Path,
+        default=Path("zig-out/bin/freesasa_zig"),
+        help="Path to Zig binary",
+    )
+    args = parser.parse_args()
+
+    if not args.input_file.exists():
+        print(f"Error: File not found: {args.input_file}", file=sys.stderr)
+        return 1
+
+    if not args.zig_binary.exists():
+        print(f"Error: Zig binary not found: {args.zig_binary}", file=sys.stderr)
+        print("Run 'zig build' first.", file=sys.stderr)
+        return 1
+
+    print(f"Input: {args.input_file}")
+    print(f"Runs: {args.runs}")
+
+    # Prepare inputs
+    json_path, pdb_path = prepare_inputs(args.input_file)
+
+    results = []
+
+    # Benchmark Zig
+    print("\nBenchmarking Zig implementation...")
+    zig_result = benchmark_zig(json_path, args.zig_binary, args.runs)
+    results.append(zig_result)
+
+    # Benchmark FreeSASA (if PDB available)
+    if pdb_path:
+        print("Benchmarking FreeSASA (Python)...")
+        freesasa_result = benchmark_freesasa(pdb_path, json_path, args.runs)
+        if freesasa_result:
+            results.append(freesasa_result)
+        pdb_path.unlink()
+
+    # Cleanup temp JSON if we created it
+    if json_path != args.input_file:
+        json_path.unlink()
+
+    print_results(results, args.runs)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add comprehensive README with usage, algorithm description, and project structure
- Add benchmark.py script to compare Zig vs FreeSASA performance

## Benchmark Results (1A0Q, 3183 atoms)

| Implementation | Time (s) | SASA (Å²) |
|----------------|----------|-----------|
| Zig (naive) | 1.50 | 19211.19 |
| FreeSASA (C) | 0.05 | 18923.28 |

Speedup: 0.03x (Zig is ~30x slower - expected for O(n²×m) naive algorithm)

## Test plan
- [x] README renders correctly
- [x] `./scripts/benchmark.py examples/1A0Q.cif.gz` runs successfully