### PR TITLE
feat: Add ProtOr and OONS classifiers (Phase 9.4)

### DIFF
--- a/src/classifier.zig
+++ b/src/classifier.zig
@@ -7,9 +7,60 @@
 //! 1. Look up by (residue_name, atom_name)
 //! 2. Fall back to ("ANY", atom_name)
 //! 3. Fall back to element-based radius guessing
+//!
+//! ## Available Built-in Classifiers
+//!
+//! - **NACCESS**: Default classifier, NACCESS-compatible radii (João Rodrigues)
+//! - **ProtOr**: Hybridization-based radii from Tsai et al. 1999
+//! - **OONS**: Ooi, Oobatake, Nemethy, Scheraga radii (older FreeSASA default)
+//!
+//! ## Usage
+//!
+//! ```zig
+//! const classifier = @import("classifier.zig");
+//! const naccess = @import("classifier_naccess.zig");
+//! const protor = @import("classifier_protor.zig");
+//! const oons = @import("classifier_oons.zig");
+//!
+//! // Get classifier by type
+//! const classifier_type = classifier.ClassifierType.naccess;
+//!
+//! // Or use built-in classifiers directly
+//! const r = naccess.getRadius("ALA", "CA");
+//! ```
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+
+/// Built-in classifier types
+pub const ClassifierType = enum {
+    /// NACCESS-compatible radii (default)
+    /// Based on naccess.config from FreeSASA (João Rodrigues)
+    naccess,
+
+    /// ProtOr radii based on hybridization state
+    /// Reference: Tsai et al. 1999, J. Mol. Biol. 290:253-266
+    protor,
+
+    /// OONS radii (older FreeSASA default)
+    /// Reference: Ooi, Oobatake, Nemethy, Scheraga
+    oons,
+
+    pub fn name(self: ClassifierType) []const u8 {
+        return switch (self) {
+            .naccess => "NACCESS",
+            .protor => "ProtOr",
+            .oons => "OONS",
+        };
+    }
+
+    pub fn fromString(s: []const u8) ?ClassifierType {
+        if (std.ascii.eqlIgnoreCase(s, "naccess")) return .naccess;
+        if (std.ascii.eqlIgnoreCase(s, "protor")) return .protor;
+        if (std.ascii.eqlIgnoreCase(s, "oons")) return .oons;
+        return null;
+    }
+};
 
 /// Atom polarity classification
 pub const AtomClass = enum {

--- a/src/classifier_oons.zig
+++ b/src/classifier_oons.zig
@@ -1,0 +1,410 @@
+//! OONS classifier - Ooi, Oobatake, Nemethy, Scheraga radii
+//!
+//! This was the default classifier in older versions of FreeSASA.
+//! OONS uses larger radii for aliphatic carbons (2.00 Å) compared to NACCESS (1.87 Å).
+
+const std = @import("std");
+const classifier = @import("classifier.zig");
+const AtomClass = classifier.AtomClass;
+const AtomProperties = classifier.AtomProperties;
+
+/// Atom type with radius and polarity class
+const AtomType = struct {
+    radius: f64,
+    class: AtomClass,
+};
+
+/// OONS atom types
+const atom_types = struct {
+    const C_ALI = AtomType{ .radius = 2.00, .class = .apolar }; // Aliphatic carbon
+    const C_ARO = AtomType{ .radius = 1.75, .class = .apolar }; // Aromatic carbon
+    const C_CAR = AtomType{ .radius = 1.55, .class = .polar }; // Carbonyl carbon (polar in OONS)
+    const N = AtomType{ .radius = 1.55, .class = .polar }; // Nitrogen
+    const O = AtomType{ .radius = 1.40, .class = .polar }; // Oxygen
+    const S = AtomType{ .radius = 2.00, .class = .polar }; // Sulfur (polar in OONS)
+    const P = AtomType{ .radius = 1.80, .class = .polar }; // Phosphorus
+    const SE = AtomType{ .radius = 1.90, .class = .polar }; // Selenium
+    const U_POL = AtomType{ .radius = 1.50, .class = .polar }; // Unknown polar (ASX, GLX)
+    const WATER = AtomType{ .radius = 1.40, .class = .polar }; // Water
+};
+
+/// ANY atoms (fallback for all residues)
+/// Key format: "ANY :ATOM" (9 chars)
+const any_atoms = std.StaticStringMap(AtomType).initComptime(.{
+    // Backbone
+    .{ "ANY :C   ", atom_types.C_CAR },
+    .{ "ANY :O   ", atom_types.O },
+    .{ "ANY :CA  ", atom_types.C_ALI },
+    .{ "ANY :N   ", atom_types.N },
+    .{ "ANY :CB  ", atom_types.C_ALI },
+    .{ "ANY :OXT ", atom_types.O },
+
+    // DNA/RNA phosphate
+    .{ "ANY :P   ", atom_types.P },
+    .{ "ANY :OP1 ", atom_types.O },
+    .{ "ANY :OP2 ", atom_types.O },
+    .{ "ANY :OP3 ", atom_types.O },
+    .{ "ANY :O5' ", atom_types.O },
+
+    // DNA/RNA sugar
+    .{ "ANY :C5' ", atom_types.C_ALI },
+    .{ "ANY :C4' ", atom_types.C_ARO },
+    .{ "ANY :O4' ", atom_types.O },
+    .{ "ANY :C3' ", atom_types.C_ARO },
+    .{ "ANY :O3' ", atom_types.O },
+    .{ "ANY :C2' ", atom_types.C_ARO },
+    .{ "ANY :O2' ", atom_types.O },
+    .{ "ANY :C1' ", atom_types.C_ARO },
+
+    // DNA/RNA base
+    .{ "ANY :N1  ", atom_types.N },
+    .{ "ANY :N2  ", atom_types.N },
+    .{ "ANY :N3  ", atom_types.N },
+    .{ "ANY :N4  ", atom_types.N },
+    .{ "ANY :N6  ", atom_types.N },
+    .{ "ANY :N7  ", atom_types.N },
+    .{ "ANY :N9  ", atom_types.N },
+    .{ "ANY :C2  ", atom_types.C_ARO },
+    .{ "ANY :C4  ", atom_types.C_ARO },
+    .{ "ANY :C5  ", atom_types.C_ARO },
+    .{ "ANY :C6  ", atom_types.C_ARO },
+    .{ "ANY :C7  ", atom_types.C_ARO },
+    .{ "ANY :C8  ", atom_types.C_ARO },
+    .{ "ANY :O2  ", atom_types.O },
+    .{ "ANY :O4  ", atom_types.O },
+    .{ "ANY :O6  ", atom_types.O },
+
+    // Methylation
+    .{ "ANY :CM2 ", atom_types.C_ALI },
+});
+
+/// Residue-specific atom lookup
+/// Key format: "RES :ATOM" (9 chars, space-padded)
+const residue_atoms = std.StaticStringMap(AtomType).initComptime(.{
+    // === Amino Acid Side Chains ===
+
+    // ARG
+    .{ "ARG :CG  ", atom_types.C_ALI },
+    .{ "ARG :CD  ", atom_types.C_ALI },
+    .{ "ARG :NE  ", atom_types.N },
+    .{ "ARG :CZ  ", atom_types.C_ALI },
+    .{ "ARG :NH1 ", atom_types.N },
+    .{ "ARG :NH2 ", atom_types.N },
+
+    // ASN
+    .{ "ASN :CG  ", atom_types.C_CAR },
+    .{ "ASN :OD1 ", atom_types.O },
+    .{ "ASN :ND2 ", atom_types.N },
+
+    // ASP
+    .{ "ASP :CG  ", atom_types.C_CAR },
+    .{ "ASP :OD1 ", atom_types.O },
+    .{ "ASP :OD2 ", atom_types.O },
+
+    // CYS
+    .{ "CYS :SG  ", atom_types.S },
+
+    // GLN
+    .{ "GLN :CG  ", atom_types.C_ALI },
+    .{ "GLN :CD  ", atom_types.C_CAR },
+    .{ "GLN :OE1 ", atom_types.O },
+    .{ "GLN :NE2 ", atom_types.N },
+
+    // GLU
+    .{ "GLU :CG  ", atom_types.C_ALI },
+    .{ "GLU :CD  ", atom_types.C_CAR },
+    .{ "GLU :OE1 ", atom_types.O },
+    .{ "GLU :OE2 ", atom_types.O },
+
+    // HIS
+    .{ "HIS :CG  ", atom_types.C_ARO },
+    .{ "HIS :ND1 ", atom_types.N },
+    .{ "HIS :CD2 ", atom_types.C_ARO },
+    .{ "HIS :NE2 ", atom_types.N },
+    .{ "HIS :CE1 ", atom_types.C_ARO },
+
+    // ILE
+    .{ "ILE :CG1 ", atom_types.C_ALI },
+    .{ "ILE :CG2 ", atom_types.C_ALI },
+    .{ "ILE :CD1 ", atom_types.C_ALI },
+
+    // LEU
+    .{ "LEU :CG  ", atom_types.C_ALI },
+    .{ "LEU :CD1 ", atom_types.C_ALI },
+    .{ "LEU :CD2 ", atom_types.C_ALI },
+
+    // LYS
+    .{ "LYS :CG  ", atom_types.C_ALI },
+    .{ "LYS :CD  ", atom_types.C_ALI },
+    .{ "LYS :CE  ", atom_types.C_ALI },
+    .{ "LYS :NZ  ", atom_types.N },
+
+    // MET
+    .{ "MET :CG  ", atom_types.C_ALI },
+    .{ "MET :SD  ", atom_types.S },
+    .{ "MET :CE  ", atom_types.C_ALI },
+
+    // PHE
+    .{ "PHE :CG  ", atom_types.C_ARO },
+    .{ "PHE :CD1 ", atom_types.C_ARO },
+    .{ "PHE :CD2 ", atom_types.C_ARO },
+    .{ "PHE :CE1 ", atom_types.C_ARO },
+    .{ "PHE :CE2 ", atom_types.C_ARO },
+    .{ "PHE :CZ  ", atom_types.C_ARO },
+
+    // PRO (ring carbons are aromatic-like)
+    .{ "PRO :CB  ", atom_types.C_ARO },
+    .{ "PRO :CG  ", atom_types.C_ARO },
+    .{ "PRO :CD  ", atom_types.C_ARO },
+
+    // SER
+    .{ "SER :OG  ", atom_types.O },
+
+    // THR
+    .{ "THR :OG1 ", atom_types.O },
+    .{ "THR :CG2 ", atom_types.C_ALI },
+
+    // TRP
+    .{ "TRP :CG  ", atom_types.C_ARO },
+    .{ "TRP :CD1 ", atom_types.C_ARO },
+    .{ "TRP :CD2 ", atom_types.C_ARO },
+    .{ "TRP :NE1 ", atom_types.N },
+    .{ "TRP :CE2 ", atom_types.C_ARO },
+    .{ "TRP :CE3 ", atom_types.C_ARO },
+    .{ "TRP :CZ2 ", atom_types.C_ARO },
+    .{ "TRP :CZ3 ", atom_types.C_ARO },
+    .{ "TRP :CH2 ", atom_types.C_ARO },
+
+    // TYR
+    .{ "TYR :CG  ", atom_types.C_ARO },
+    .{ "TYR :CD1 ", atom_types.C_ARO },
+    .{ "TYR :CD2 ", atom_types.C_ARO },
+    .{ "TYR :CE1 ", atom_types.C_ARO },
+    .{ "TYR :CE2 ", atom_types.C_ARO },
+    .{ "TYR :CZ  ", atom_types.C_ARO },
+    .{ "TYR :OH  ", atom_types.O },
+
+    // VAL
+    .{ "VAL :CG1 ", atom_types.C_ALI },
+    .{ "VAL :CG2 ", atom_types.C_ALI },
+
+    // === Non-standard Amino Acids ===
+
+    // ASX (ambiguous ASN/ASP)
+    .{ "ASX :CG  ", atom_types.C_CAR },
+    .{ "ASX :XD1 ", atom_types.U_POL },
+    .{ "ASX :XD2 ", atom_types.U_POL },
+    .{ "ASX :AD1 ", atom_types.U_POL },
+    .{ "ASX :AD2 ", atom_types.U_POL },
+
+    // GLX (ambiguous GLN/GLU)
+    .{ "GLX :CG  ", atom_types.C_ALI },
+    .{ "GLX :CD  ", atom_types.C_CAR },
+    .{ "GLX :XE1 ", atom_types.U_POL },
+    .{ "GLX :XE2 ", atom_types.U_POL },
+    .{ "GLX :AE1 ", atom_types.U_POL },
+    .{ "GLX :AE2 ", atom_types.U_POL },
+
+    // SEC (selenocysteine)
+    .{ "SEC :SE  ", atom_types.SE },
+    .{ "CSE :SE  ", atom_types.SE }, // alternate name
+
+    // MSE (selenomethionine)
+    .{ "MSE :SE  ", atom_types.SE },
+    .{ "MSE :CG  ", atom_types.C_ALI },
+    .{ "MSE :CE  ", atom_types.C_ALI },
+
+    // PYL (pyrrolysine)
+    .{ "PYL :CG  ", atom_types.C_ALI },
+    .{ "PYL :CD  ", atom_types.C_ALI },
+    .{ "PYL :CE  ", atom_types.C_ALI },
+    .{ "PYL :NZ  ", atom_types.N },
+    .{ "PYL :O2  ", atom_types.O },
+    .{ "PYL :C2  ", atom_types.C_CAR },
+    .{ "PYL :CA2 ", atom_types.C_ARO },
+    .{ "PYL :CB2 ", atom_types.C_ALI },
+    .{ "PYL :CG2 ", atom_types.C_ARO },
+    .{ "PYL :CD2 ", atom_types.C_ARO },
+    .{ "PYL :CE2 ", atom_types.C_ARO },
+    .{ "PYL :N2  ", atom_types.N },
+
+    // === Capping Groups ===
+
+    // ACE (acetyl)
+    .{ "ACE :CH3 ", atom_types.C_ALI },
+
+    // NH2 (amide)
+    .{ "NH2 :NH2 ", atom_types.N },
+
+    // === Water ===
+    .{ "HOH :O   ", atom_types.WATER },
+});
+
+/// Create lookup key at runtime
+fn makeKeyRuntime(residue: []const u8, atom: []const u8) [9]u8 {
+    var key: [9]u8 = .{ ' ', ' ', ' ', ' ', ':', ' ', ' ', ' ', ' ' };
+
+    // Copy residue (up to 4 chars, left-justified)
+    const res_len = @min(residue.len, 4);
+    for (residue[0..res_len], 0..) |c, i| {
+        key[i] = c;
+    }
+
+    // Copy atom name (up to 4 chars)
+    const atom_len = @min(atom.len, 4);
+    for (atom[0..atom_len], 0..) |c, i| {
+        key[5 + i] = c;
+    }
+
+    return key;
+}
+
+/// Get radius for a (residue, atom) pair
+/// Lookup order: residue-specific → ANY fallback → element guess
+pub fn getRadius(residue: []const u8, atom: []const u8) ?f64 {
+    // Try residue-specific first
+    const key = makeKeyRuntime(residue, atom);
+    if (residue_atoms.get(&key)) |t| {
+        return t.radius;
+    }
+
+    // Try ANY fallback
+    const any_key = makeKeyRuntime("ANY", atom);
+    if (any_atoms.get(&any_key)) |t| {
+        return t.radius;
+    }
+
+    // Fall back to element guess
+    return classifier.guessRadiusFromAtomName(atom);
+}
+
+/// Get polarity class for a (residue, atom) pair
+pub fn getClass(residue: []const u8, atom: []const u8) AtomClass {
+    // Try residue-specific first
+    const key = makeKeyRuntime(residue, atom);
+    if (residue_atoms.get(&key)) |t| {
+        return t.class;
+    }
+
+    // Try ANY fallback
+    const any_key = makeKeyRuntime("ANY", atom);
+    if (any_atoms.get(&any_key)) |t| {
+        return t.class;
+    }
+
+    return .unknown;
+}
+
+/// Get both radius and class
+pub fn getProperties(residue: []const u8, atom: []const u8) ?AtomProperties {
+    // Try residue-specific first
+    const key = makeKeyRuntime(residue, atom);
+    if (residue_atoms.get(&key)) |t| {
+        return AtomProperties{ .radius = t.radius, .class = t.class };
+    }
+
+    // Try ANY fallback
+    const any_key = makeKeyRuntime("ANY", atom);
+    if (any_atoms.get(&any_key)) |t| {
+        return AtomProperties{ .radius = t.radius, .class = t.class };
+    }
+
+    // Try element guess for radius only
+    if (classifier.guessRadiusFromAtomName(atom)) |r| {
+        return AtomProperties{ .radius = r, .class = .unknown };
+    }
+
+    return null;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "OONS backbone atoms via ANY" {
+    // All residues should get backbone atoms from ANY
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("ALA", "CA").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.55), getRadius("ALA", "C").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.55), getRadius("ALA", "N").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.40), getRadius("ALA", "O").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("ALA", "CB").?, 0.001);
+
+    // ANY works for any residue
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("GLY", "CA").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("VAL", "CA").?, 0.001);
+}
+
+test "OONS side chain atoms" {
+    // PHE aromatic ring
+    try std.testing.expectApproxEqAbs(@as(f64, 1.75), getRadius("PHE", "CG").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.75), getRadius("PHE", "CD1").?, 0.001);
+
+    // LEU aliphatic
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("LEU", "CG").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("LEU", "CD1").?, 0.001);
+
+    // CYS sulfur
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("CYS", "SG").?, 0.001);
+}
+
+test "OONS polarity classes" {
+    try std.testing.expectEqual(AtomClass.polar, getClass("ALA", "N"));
+    try std.testing.expectEqual(AtomClass.polar, getClass("ALA", "O"));
+    try std.testing.expectEqual(AtomClass.apolar, getClass("ALA", "CA"));
+    try std.testing.expectEqual(AtomClass.polar, getClass("ALA", "C")); // C_CAR is polar in OONS
+    try std.testing.expectEqual(AtomClass.polar, getClass("CYS", "SG")); // S is polar in OONS
+}
+
+test "OONS vs NACCESS radii differences" {
+    // OONS has larger aliphatic carbon radius
+    // NACCESS C_ALI = 1.87, OONS C_ALI = 2.00
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("ALA", "CA").?, 0.001);
+
+    // OONS aromatic carbon is smaller
+    // NACCESS C_CAR = 1.76, OONS C_ARO = 1.75
+    try std.testing.expectApproxEqAbs(@as(f64, 1.75), getRadius("PHE", "CG").?, 0.001);
+}
+
+test "OONS selenocysteine and selenomethionine" {
+    // SEC
+    try std.testing.expectApproxEqAbs(@as(f64, 1.90), getRadius("SEC", "SE").?, 0.001);
+    // CB comes from ANY
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("SEC", "CB").?, 0.001);
+
+    // MSE
+    try std.testing.expectApproxEqAbs(@as(f64, 1.90), getRadius("MSE", "SE").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("MSE", "CG").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.00), getRadius("MSE", "CE").?, 0.001);
+}
+
+test "OONS nucleotides via ANY" {
+    // Phosphate
+    try std.testing.expectApproxEqAbs(@as(f64, 1.80), getRadius("A", "P").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.40), getRadius("A", "OP1").?, 0.001);
+
+    // Sugar
+    try std.testing.expectApproxEqAbs(@as(f64, 1.75), getRadius("A", "C1'").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.40), getRadius("A", "O4'").?, 0.001);
+
+    // Base
+    try std.testing.expectApproxEqAbs(@as(f64, 1.55), getRadius("A", "N9").?, 0.001);
+}
+
+test "OONS water" {
+    try std.testing.expectApproxEqAbs(@as(f64, 1.40), getRadius("HOH", "O").?, 0.001);
+    try std.testing.expectEqual(AtomClass.polar, getClass("HOH", "O"));
+}
+
+test "OONS element-based fallback" {
+    // Unknown residue - should use element guess
+    const r = getRadius("UNK", "FE");
+    try std.testing.expect(r != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.26), r.?, 0.001); // Fe element
+}
+
+test "OONS getProperties" {
+    const props = getProperties("PHE", "CG");
+    try std.testing.expect(props != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.75), props.?.radius, 0.001);
+    try std.testing.expectEqual(AtomClass.apolar, props.?.class);
+}

--- a/src/classifier_protor.zig
+++ b/src/classifier_protor.zig
@@ -1,0 +1,793 @@
+//! ProtOr classifier - Hybridization-based radii from Tsai et al. 1999
+//!
+//! Reference:
+//! Tsai, J., Taylor, R., Chothia, C., & Gerstein, M. (1999).
+//! The packing density in proteins: standard radii and volumes.
+//! Journal of molecular biology, 290(1), 253-266.
+//!
+//! Unlike NACCESS, ProtOr does not have ANY fallback - all atoms are
+//! specified per residue with hybridization-based types (C3H0, C4H1, etc.).
+
+const std = @import("std");
+const classifier = @import("classifier.zig");
+const AtomClass = classifier.AtomClass;
+const AtomProperties = classifier.AtomProperties;
+
+/// Atom type with radius and polarity class
+const AtomType = struct {
+    radius: f64,
+    class: AtomClass,
+};
+
+/// ProtOr atom types based on hybridization state
+const atom_types = struct {
+    // Carbon types
+    const C3H0 = AtomType{ .radius = 1.61, .class = .apolar }; // sp2, no H
+    const C3H1 = AtomType{ .radius = 1.76, .class = .apolar }; // sp2, 1 H
+    const C4H1 = AtomType{ .radius = 1.88, .class = .apolar }; // sp3, 1 H
+    const C4H2 = AtomType{ .radius = 1.88, .class = .apolar }; // sp3, 2 H
+    const C4H3 = AtomType{ .radius = 1.88, .class = .apolar }; // sp3, 3 H (methyl)
+
+    // Nitrogen types
+    const N2H0 = AtomType{ .radius = 1.64, .class = .polar }; // sp, no H
+    const N2H2 = AtomType{ .radius = 1.64, .class = .polar }; // (really N3H2)
+    const N3H0 = AtomType{ .radius = 1.64, .class = .polar }; // sp2, no H
+    const N3H1 = AtomType{ .radius = 1.64, .class = .polar }; // sp2, 1 H
+    const N3H2 = AtomType{ .radius = 1.64, .class = .polar }; // sp2, 2 H (amide)
+    const N4H3 = AtomType{ .radius = 1.64, .class = .polar }; // sp3, 3 H (amino)
+
+    // Oxygen types
+    const O1H0 = AtomType{ .radius = 1.42, .class = .polar }; // carbonyl
+    const O2H0 = AtomType{ .radius = 1.46, .class = .polar }; // ether/ester
+    const O2H1 = AtomType{ .radius = 1.46, .class = .polar }; // hydroxyl
+    const O2H2 = AtomType{ .radius = 1.46, .class = .polar }; // water
+
+    // Sulfur types
+    const S2H0 = AtomType{ .radius = 1.77, .class = .polar }; // thioether
+    const S2H1 = AtomType{ .radius = 1.77, .class = .polar }; // thiol
+
+    // Selenium types
+    const SE2H0 = AtomType{ .radius = 1.90, .class = .polar }; // selenoether (MSE)
+    const SE2H1 = AtomType{ .radius = 1.90, .class = .polar }; // selenol (SEC)
+
+    // Phosphorus
+    const P4H0 = AtomType{ .radius = 1.80, .class = .polar };
+
+    // Unknown polar (ASX, GLX)
+    const X1H0 = AtomType{ .radius = 1.50, .class = .polar };
+};
+
+/// Residue-specific atom lookup (no ANY fallback in ProtOr)
+/// Key format: "RES :ATOM" (9 chars, space-padded)
+const residue_atoms = std.StaticStringMap(AtomType).initComptime(.{
+    // === Standard Amino Acids ===
+
+    // ALA
+    .{ "ALA :N   ", atom_types.N3H2 },
+    .{ "ALA :CA  ", atom_types.C4H1 },
+    .{ "ALA :C   ", atom_types.C3H0 },
+    .{ "ALA :O   ", atom_types.O1H0 },
+    .{ "ALA :CB  ", atom_types.C4H3 },
+    .{ "ALA :OXT ", atom_types.O2H1 },
+
+    // ARG
+    .{ "ARG :N   ", atom_types.N3H2 },
+    .{ "ARG :CA  ", atom_types.C4H1 },
+    .{ "ARG :C   ", atom_types.C3H0 },
+    .{ "ARG :O   ", atom_types.O1H0 },
+    .{ "ARG :CB  ", atom_types.C4H2 },
+    .{ "ARG :CG  ", atom_types.C4H2 },
+    .{ "ARG :CD  ", atom_types.C4H2 },
+    .{ "ARG :NE  ", atom_types.N3H1 },
+    .{ "ARG :CZ  ", atom_types.C3H0 },
+    .{ "ARG :NH1 ", atom_types.N3H2 },
+    .{ "ARG :NH2 ", atom_types.N3H2 },
+    .{ "ARG :OXT ", atom_types.O2H1 },
+
+    // ASN
+    .{ "ASN :N   ", atom_types.N3H2 },
+    .{ "ASN :CA  ", atom_types.C4H1 },
+    .{ "ASN :C   ", atom_types.C3H0 },
+    .{ "ASN :O   ", atom_types.O1H0 },
+    .{ "ASN :CB  ", atom_types.C4H2 },
+    .{ "ASN :CG  ", atom_types.C3H0 },
+    .{ "ASN :OD1 ", atom_types.O1H0 },
+    .{ "ASN :ND2 ", atom_types.N3H2 },
+    .{ "ASN :OXT ", atom_types.O2H1 },
+
+    // ASP
+    .{ "ASP :N   ", atom_types.N3H2 },
+    .{ "ASP :CA  ", atom_types.C4H1 },
+    .{ "ASP :C   ", atom_types.C3H0 },
+    .{ "ASP :O   ", atom_types.O1H0 },
+    .{ "ASP :CB  ", atom_types.C4H2 },
+    .{ "ASP :CG  ", atom_types.C3H0 },
+    .{ "ASP :OD1 ", atom_types.O1H0 },
+    .{ "ASP :OD2 ", atom_types.O2H1 },
+    .{ "ASP :OXT ", atom_types.O2H1 },
+
+    // CYS
+    .{ "CYS :N   ", atom_types.N3H2 },
+    .{ "CYS :CA  ", atom_types.C4H1 },
+    .{ "CYS :C   ", atom_types.C3H0 },
+    .{ "CYS :O   ", atom_types.O1H0 },
+    .{ "CYS :CB  ", atom_types.C4H2 },
+    .{ "CYS :SG  ", atom_types.S2H1 },
+    .{ "CYS :OXT ", atom_types.O2H1 },
+
+    // GLN
+    .{ "GLN :N   ", atom_types.N3H2 },
+    .{ "GLN :CA  ", atom_types.C4H1 },
+    .{ "GLN :C   ", atom_types.C3H0 },
+    .{ "GLN :O   ", atom_types.O1H0 },
+    .{ "GLN :CB  ", atom_types.C4H2 },
+    .{ "GLN :CG  ", atom_types.C4H2 },
+    .{ "GLN :CD  ", atom_types.C3H0 },
+    .{ "GLN :OE1 ", atom_types.O1H0 },
+    .{ "GLN :NE2 ", atom_types.N3H2 },
+    .{ "GLN :OXT ", atom_types.O2H1 },
+
+    // GLU
+    .{ "GLU :N   ", atom_types.N3H2 },
+    .{ "GLU :CA  ", atom_types.C4H1 },
+    .{ "GLU :C   ", atom_types.C3H0 },
+    .{ "GLU :O   ", atom_types.O1H0 },
+    .{ "GLU :CB  ", atom_types.C4H2 },
+    .{ "GLU :CG  ", atom_types.C4H2 },
+    .{ "GLU :CD  ", atom_types.C3H0 },
+    .{ "GLU :OE1 ", atom_types.O1H0 },
+    .{ "GLU :OE2 ", atom_types.O2H1 },
+    .{ "GLU :OXT ", atom_types.O2H1 },
+
+    // GLY
+    .{ "GLY :N   ", atom_types.N3H2 },
+    .{ "GLY :CA  ", atom_types.C4H2 },
+    .{ "GLY :C   ", atom_types.C3H0 },
+    .{ "GLY :O   ", atom_types.O1H0 },
+    .{ "GLY :OXT ", atom_types.O2H1 },
+
+    // HIS
+    .{ "HIS :N   ", atom_types.N3H2 },
+    .{ "HIS :CA  ", atom_types.C4H1 },
+    .{ "HIS :C   ", atom_types.C3H0 },
+    .{ "HIS :O   ", atom_types.O1H0 },
+    .{ "HIS :CB  ", atom_types.C4H2 },
+    .{ "HIS :CG  ", atom_types.C3H0 },
+    .{ "HIS :ND1 ", atom_types.N3H1 },
+    .{ "HIS :CD2 ", atom_types.C3H1 },
+    .{ "HIS :CE1 ", atom_types.C3H1 },
+    .{ "HIS :NE2 ", atom_types.N3H1 },
+    .{ "HIS :OXT ", atom_types.O2H1 },
+
+    // ILE
+    .{ "ILE :N   ", atom_types.N3H2 },
+    .{ "ILE :CA  ", atom_types.C4H1 },
+    .{ "ILE :C   ", atom_types.C3H0 },
+    .{ "ILE :O   ", atom_types.O1H0 },
+    .{ "ILE :CB  ", atom_types.C4H1 },
+    .{ "ILE :CG1 ", atom_types.C4H2 },
+    .{ "ILE :CG2 ", atom_types.C4H3 },
+    .{ "ILE :CD1 ", atom_types.C4H3 },
+    .{ "ILE :OXT ", atom_types.O2H1 },
+
+    // LEU
+    .{ "LEU :N   ", atom_types.N3H2 },
+    .{ "LEU :CA  ", atom_types.C4H1 },
+    .{ "LEU :C   ", atom_types.C3H0 },
+    .{ "LEU :O   ", atom_types.O1H0 },
+    .{ "LEU :CB  ", atom_types.C4H2 },
+    .{ "LEU :CG  ", atom_types.C4H1 },
+    .{ "LEU :CD1 ", atom_types.C4H3 },
+    .{ "LEU :CD2 ", atom_types.C4H3 },
+    .{ "LEU :OXT ", atom_types.O2H1 },
+
+    // LYS
+    .{ "LYS :N   ", atom_types.N3H2 },
+    .{ "LYS :CA  ", atom_types.C4H1 },
+    .{ "LYS :C   ", atom_types.C3H0 },
+    .{ "LYS :O   ", atom_types.O1H0 },
+    .{ "LYS :CB  ", atom_types.C4H2 },
+    .{ "LYS :CG  ", atom_types.C4H2 },
+    .{ "LYS :CD  ", atom_types.C4H2 },
+    .{ "LYS :CE  ", atom_types.C4H2 },
+    .{ "LYS :NZ  ", atom_types.N4H3 },
+    .{ "LYS :OXT ", atom_types.O2H1 },
+
+    // MET
+    .{ "MET :N   ", atom_types.N3H2 },
+    .{ "MET :CA  ", atom_types.C4H1 },
+    .{ "MET :C   ", atom_types.C3H0 },
+    .{ "MET :O   ", atom_types.O1H0 },
+    .{ "MET :CB  ", atom_types.C4H2 },
+    .{ "MET :CG  ", atom_types.C4H2 },
+    .{ "MET :SD  ", atom_types.S2H0 },
+    .{ "MET :CE  ", atom_types.C4H3 },
+    .{ "MET :OXT ", atom_types.O2H1 },
+
+    // PHE
+    .{ "PHE :N   ", atom_types.N3H2 },
+    .{ "PHE :CA  ", atom_types.C4H1 },
+    .{ "PHE :C   ", atom_types.C3H0 },
+    .{ "PHE :O   ", atom_types.O1H0 },
+    .{ "PHE :CB  ", atom_types.C4H2 },
+    .{ "PHE :CG  ", atom_types.C3H0 },
+    .{ "PHE :CD1 ", atom_types.C3H1 },
+    .{ "PHE :CD2 ", atom_types.C3H1 },
+    .{ "PHE :CE1 ", atom_types.C3H1 },
+    .{ "PHE :CE2 ", atom_types.C3H1 },
+    .{ "PHE :CZ  ", atom_types.C3H1 },
+    .{ "PHE :OXT ", atom_types.O2H1 },
+
+    // PRO
+    .{ "PRO :N   ", atom_types.N3H1 },
+    .{ "PRO :CA  ", atom_types.C4H1 },
+    .{ "PRO :C   ", atom_types.C3H0 },
+    .{ "PRO :O   ", atom_types.O1H0 },
+    .{ "PRO :CB  ", atom_types.C4H2 },
+    .{ "PRO :CG  ", atom_types.C4H2 },
+    .{ "PRO :CD  ", atom_types.C4H2 },
+    .{ "PRO :OXT ", atom_types.O2H1 },
+
+    // SER
+    .{ "SER :N   ", atom_types.N3H2 },
+    .{ "SER :CA  ", atom_types.C4H1 },
+    .{ "SER :C   ", atom_types.C3H0 },
+    .{ "SER :O   ", atom_types.O1H0 },
+    .{ "SER :CB  ", atom_types.C4H2 },
+    .{ "SER :OG  ", atom_types.O2H1 },
+    .{ "SER :OXT ", atom_types.O2H1 },
+
+    // THR
+    .{ "THR :N   ", atom_types.N3H2 },
+    .{ "THR :CA  ", atom_types.C4H1 },
+    .{ "THR :C   ", atom_types.C3H0 },
+    .{ "THR :O   ", atom_types.O1H0 },
+    .{ "THR :CB  ", atom_types.C4H1 },
+    .{ "THR :OG1 ", atom_types.O2H1 },
+    .{ "THR :CG2 ", atom_types.C4H3 },
+    .{ "THR :OXT ", atom_types.O2H1 },
+
+    // TRP
+    .{ "TRP :N   ", atom_types.N3H2 },
+    .{ "TRP :CA  ", atom_types.C4H1 },
+    .{ "TRP :C   ", atom_types.C3H0 },
+    .{ "TRP :O   ", atom_types.O1H0 },
+    .{ "TRP :CB  ", atom_types.C4H2 },
+    .{ "TRP :CG  ", atom_types.C3H0 },
+    .{ "TRP :CD1 ", atom_types.C3H1 },
+    .{ "TRP :CD2 ", atom_types.C3H0 },
+    .{ "TRP :NE1 ", atom_types.N3H1 },
+    .{ "TRP :CE2 ", atom_types.C3H0 },
+    .{ "TRP :CE3 ", atom_types.C3H1 },
+    .{ "TRP :CZ2 ", atom_types.C3H1 },
+    .{ "TRP :CZ3 ", atom_types.C3H1 },
+    .{ "TRP :CH2 ", atom_types.C3H1 },
+    .{ "TRP :OXT ", atom_types.O2H1 },
+
+    // TYR
+    .{ "TYR :N   ", atom_types.N3H2 },
+    .{ "TYR :CA  ", atom_types.C4H1 },
+    .{ "TYR :C   ", atom_types.C3H0 },
+    .{ "TYR :O   ", atom_types.O1H0 },
+    .{ "TYR :CB  ", atom_types.C4H2 },
+    .{ "TYR :CG  ", atom_types.C3H0 },
+    .{ "TYR :CD1 ", atom_types.C3H1 },
+    .{ "TYR :CD2 ", atom_types.C3H1 },
+    .{ "TYR :CE1 ", atom_types.C3H1 },
+    .{ "TYR :CE2 ", atom_types.C3H1 },
+    .{ "TYR :CZ  ", atom_types.C3H0 },
+    .{ "TYR :OH  ", atom_types.O2H1 },
+    .{ "TYR :OXT ", atom_types.O2H1 },
+
+    // VAL
+    .{ "VAL :N   ", atom_types.N3H2 },
+    .{ "VAL :CA  ", atom_types.C4H1 },
+    .{ "VAL :C   ", atom_types.C3H0 },
+    .{ "VAL :O   ", atom_types.O1H0 },
+    .{ "VAL :CB  ", atom_types.C4H1 },
+    .{ "VAL :CG1 ", atom_types.C4H3 },
+    .{ "VAL :CG2 ", atom_types.C4H3 },
+    .{ "VAL :OXT ", atom_types.O2H1 },
+
+    // === Non-standard Amino Acids ===
+
+    // ASX (ambiguous ASN/ASP)
+    .{ "ASX :N   ", atom_types.N3H2 },
+    .{ "ASX :CA  ", atom_types.C4H1 },
+    .{ "ASX :C   ", atom_types.C3H0 },
+    .{ "ASX :O   ", atom_types.O1H0 },
+    .{ "ASX :CB  ", atom_types.C4H2 },
+    .{ "ASX :CG  ", atom_types.C3H0 },
+    .{ "ASX :XD1 ", atom_types.X1H0 },
+    .{ "ASX :XD2 ", atom_types.X1H0 },
+    .{ "ASX :OXT ", atom_types.O2H1 },
+
+    // GLX (ambiguous GLN/GLU)
+    .{ "GLX :N   ", atom_types.N3H2 },
+    .{ "GLX :CA  ", atom_types.C4H1 },
+    .{ "GLX :C   ", atom_types.C3H0 },
+    .{ "GLX :O   ", atom_types.O1H0 },
+    .{ "GLX :CB  ", atom_types.C4H2 },
+    .{ "GLX :CG  ", atom_types.C4H2 },
+    .{ "GLX :CD  ", atom_types.C3H0 },
+    .{ "GLX :XE1 ", atom_types.X1H0 },
+    .{ "GLX :XE2 ", atom_types.X1H0 },
+    .{ "GLX :OXT ", atom_types.O2H1 },
+
+    // SEC (selenocysteine)
+    .{ "SEC :N   ", atom_types.N3H2 },
+    .{ "SEC :CA  ", atom_types.C4H1 },
+    .{ "SEC :CB  ", atom_types.C4H2 },
+    .{ "SEC :SE  ", atom_types.SE2H1 },
+    .{ "SEC :C   ", atom_types.C3H0 },
+    .{ "SEC :O   ", atom_types.O1H0 },
+    .{ "SEC :OXT ", atom_types.O2H1 },
+
+    // MSE (selenomethionine)
+    .{ "MSE :N   ", atom_types.N3H2 },
+    .{ "MSE :CA  ", atom_types.C4H1 },
+    .{ "MSE :C   ", atom_types.C3H0 },
+    .{ "MSE :O   ", atom_types.O1H0 },
+    .{ "MSE :OXT ", atom_types.O2H1 },
+    .{ "MSE :CB  ", atom_types.C4H2 },
+    .{ "MSE :CG  ", atom_types.C4H2 },
+    .{ "MSE :SE  ", atom_types.SE2H0 },
+    .{ "MSE :CE  ", atom_types.C4H3 },
+
+    // PYL (pyrrolysine)
+    .{ "PYL :N   ", atom_types.N3H2 },
+    .{ "PYL :CA  ", atom_types.C4H1 },
+    .{ "PYL :C   ", atom_types.C3H0 },
+    .{ "PYL :O   ", atom_types.O1H0 },
+    .{ "PYL :OXT ", atom_types.O2H1 },
+    .{ "PYL :CB  ", atom_types.C4H2 },
+    .{ "PYL :CG  ", atom_types.C4H2 },
+    .{ "PYL :CD  ", atom_types.C4H2 },
+    .{ "PYL :CE  ", atom_types.C4H2 },
+    .{ "PYL :NZ  ", atom_types.N3H1 },
+    .{ "PYL :C2  ", atom_types.C3H0 },
+    .{ "PYL :O2  ", atom_types.O1H0 },
+    .{ "PYL :CA2 ", atom_types.C4H1 },
+    .{ "PYL :N2  ", atom_types.N2H0 },
+    .{ "PYL :CB2 ", atom_types.C4H3 },
+    .{ "PYL :CG2 ", atom_types.C4H1 },
+    .{ "PYL :CD2 ", atom_types.C4H2 },
+    .{ "PYL :CE2 ", atom_types.C3H1 },
+
+    // === Capping Groups ===
+
+    // ACE (acetyl)
+    .{ "ACE :C   ", atom_types.C3H1 },
+    .{ "ACE :O   ", atom_types.O1H0 },
+    .{ "ACE :CH3 ", atom_types.C4H3 },
+
+    // NH2 (amide)
+    .{ "NH2 :N   ", atom_types.N2H2 },
+
+    // HOH (water)
+    .{ "HOH :O   ", atom_types.O2H2 },
+
+    // === RNA Nucleotides ===
+
+    // A (adenine)
+    .{ "A   :OP3 ", atom_types.O2H1 },
+    .{ "A   :P   ", atom_types.P4H0 },
+    .{ "A   :OP1 ", atom_types.O1H0 },
+    .{ "A   :OP2 ", atom_types.O2H1 },
+    .{ "A   :O5' ", atom_types.O2H0 },
+    .{ "A   :C5' ", atom_types.C4H2 },
+    .{ "A   :C4' ", atom_types.C4H1 },
+    .{ "A   :O4' ", atom_types.O2H0 },
+    .{ "A   :C3' ", atom_types.C4H1 },
+    .{ "A   :O3' ", atom_types.O2H1 },
+    .{ "A   :C2' ", atom_types.C4H1 },
+    .{ "A   :O2' ", atom_types.O2H1 },
+    .{ "A   :C1' ", atom_types.C4H1 },
+    .{ "A   :N9  ", atom_types.N3H0 },
+    .{ "A   :C8  ", atom_types.C3H1 },
+    .{ "A   :N7  ", atom_types.N2H0 },
+    .{ "A   :C5  ", atom_types.C3H0 },
+    .{ "A   :C6  ", atom_types.C3H0 },
+    .{ "A   :N6  ", atom_types.N3H2 },
+    .{ "A   :N1  ", atom_types.N2H0 },
+    .{ "A   :C2  ", atom_types.C3H1 },
+    .{ "A   :N3  ", atom_types.N2H0 },
+    .{ "A   :C4  ", atom_types.C3H0 },
+
+    // C (cytosine)
+    .{ "C   :OP3 ", atom_types.O2H1 },
+    .{ "C   :P   ", atom_types.P4H0 },
+    .{ "C   :OP1 ", atom_types.O1H0 },
+    .{ "C   :OP2 ", atom_types.O2H1 },
+    .{ "C   :O5' ", atom_types.O2H0 },
+    .{ "C   :C5' ", atom_types.C4H2 },
+    .{ "C   :C4' ", atom_types.C4H1 },
+    .{ "C   :O4' ", atom_types.O2H0 },
+    .{ "C   :C3' ", atom_types.C4H1 },
+    .{ "C   :O3' ", atom_types.O2H1 },
+    .{ "C   :C2' ", atom_types.C4H1 },
+    .{ "C   :O2' ", atom_types.O2H1 },
+    .{ "C   :C1' ", atom_types.C4H1 },
+    .{ "C   :N1  ", atom_types.N3H0 },
+    .{ "C   :C2  ", atom_types.C3H0 },
+    .{ "C   :O2  ", atom_types.O1H0 },
+    .{ "C   :N3  ", atom_types.N2H0 },
+    .{ "C   :C4  ", atom_types.C3H0 },
+    .{ "C   :N4  ", atom_types.N3H2 },
+    .{ "C   :C5  ", atom_types.C3H1 },
+    .{ "C   :C6  ", atom_types.C3H1 },
+
+    // G (guanine)
+    .{ "G   :OP3 ", atom_types.O2H1 },
+    .{ "G   :P   ", atom_types.P4H0 },
+    .{ "G   :OP1 ", atom_types.O1H0 },
+    .{ "G   :OP2 ", atom_types.O2H1 },
+    .{ "G   :O5' ", atom_types.O2H0 },
+    .{ "G   :C5' ", atom_types.C4H2 },
+    .{ "G   :C4' ", atom_types.C4H1 },
+    .{ "G   :O4' ", atom_types.O2H0 },
+    .{ "G   :C3' ", atom_types.C4H1 },
+    .{ "G   :O3' ", atom_types.O2H1 },
+    .{ "G   :C2' ", atom_types.C4H1 },
+    .{ "G   :O2' ", atom_types.O2H1 },
+    .{ "G   :C1' ", atom_types.C4H1 },
+    .{ "G   :N9  ", atom_types.N3H0 },
+    .{ "G   :C8  ", atom_types.C3H1 },
+    .{ "G   :N7  ", atom_types.N2H0 },
+    .{ "G   :C5  ", atom_types.C3H0 },
+    .{ "G   :C6  ", atom_types.C3H0 },
+    .{ "G   :O6  ", atom_types.O1H0 },
+    .{ "G   :N1  ", atom_types.N3H1 },
+    .{ "G   :C2  ", atom_types.C3H0 },
+    .{ "G   :N2  ", atom_types.N3H2 },
+    .{ "G   :N3  ", atom_types.N2H0 },
+    .{ "G   :C4  ", atom_types.C3H0 },
+
+    // I (inosine)
+    .{ "I   :OP3 ", atom_types.O2H1 },
+    .{ "I   :P   ", atom_types.P4H0 },
+    .{ "I   :OP1 ", atom_types.O1H0 },
+    .{ "I   :OP2 ", atom_types.O2H1 },
+    .{ "I   :O5' ", atom_types.O2H0 },
+    .{ "I   :C5' ", atom_types.C4H2 },
+    .{ "I   :C4' ", atom_types.C4H1 },
+    .{ "I   :O4' ", atom_types.O2H0 },
+    .{ "I   :C3' ", atom_types.C4H1 },
+    .{ "I   :O3' ", atom_types.O2H1 },
+    .{ "I   :C2' ", atom_types.C4H1 },
+    .{ "I   :O2' ", atom_types.O2H1 },
+    .{ "I   :C1' ", atom_types.C4H1 },
+    .{ "I   :N9  ", atom_types.N3H0 },
+    .{ "I   :C8  ", atom_types.C3H1 },
+    .{ "I   :N7  ", atom_types.N2H0 },
+    .{ "I   :C5  ", atom_types.C3H0 },
+    .{ "I   :C6  ", atom_types.C3H0 },
+    .{ "I   :O6  ", atom_types.O1H0 },
+    .{ "I   :N1  ", atom_types.N3H1 },
+    .{ "I   :C2  ", atom_types.C3H1 },
+    .{ "I   :N3  ", atom_types.N2H0 },
+    .{ "I   :C4  ", atom_types.C3H0 },
+
+    // T (thymine - for RNA)
+    .{ "T   :OP3 ", atom_types.O2H1 },
+    .{ "T   :P   ", atom_types.P4H0 },
+    .{ "T   :OP1 ", atom_types.O1H0 },
+    .{ "T   :OP2 ", atom_types.O2H1 },
+    .{ "T   :O5' ", atom_types.O2H0 },
+    .{ "T   :C5' ", atom_types.C4H2 },
+    .{ "T   :C4' ", atom_types.C4H1 },
+    .{ "T   :O4' ", atom_types.O2H0 },
+    .{ "T   :C3' ", atom_types.C4H1 },
+    .{ "T   :O3' ", atom_types.O2H1 },
+    .{ "T   :C2' ", atom_types.C4H2 },
+    .{ "T   :C1' ", atom_types.C4H1 },
+    .{ "T   :N1  ", atom_types.N3H0 },
+    .{ "T   :C2  ", atom_types.C3H0 },
+    .{ "T   :O2  ", atom_types.O1H0 },
+    .{ "T   :N3  ", atom_types.N3H1 },
+    .{ "T   :C4  ", atom_types.C3H0 },
+    .{ "T   :O4  ", atom_types.O1H0 },
+    .{ "T   :C5  ", atom_types.C3H0 },
+    .{ "T   :C7  ", atom_types.C4H3 },
+    .{ "T   :C6  ", atom_types.C3H1 },
+
+    // U (uracil)
+    .{ "U   :OP3 ", atom_types.O2H1 },
+    .{ "U   :P   ", atom_types.P4H0 },
+    .{ "U   :OP1 ", atom_types.O1H0 },
+    .{ "U   :OP2 ", atom_types.O2H1 },
+    .{ "U   :O5' ", atom_types.O2H0 },
+    .{ "U   :C5' ", atom_types.C4H2 },
+    .{ "U   :C4' ", atom_types.C4H1 },
+    .{ "U   :O4' ", atom_types.O2H0 },
+    .{ "U   :C3' ", atom_types.C4H1 },
+    .{ "U   :O3' ", atom_types.O2H1 },
+    .{ "U   :C2' ", atom_types.C4H1 },
+    .{ "U   :O2' ", atom_types.O2H1 },
+    .{ "U   :C1' ", atom_types.C4H1 },
+    .{ "U   :N1  ", atom_types.N3H0 },
+    .{ "U   :C2  ", atom_types.C3H0 },
+    .{ "U   :O2  ", atom_types.O1H0 },
+    .{ "U   :N3  ", atom_types.N3H1 },
+    .{ "U   :C4  ", atom_types.C3H0 },
+    .{ "U   :O4  ", atom_types.O1H0 },
+    .{ "U   :C5  ", atom_types.C3H1 },
+    .{ "U   :C6  ", atom_types.C3H1 },
+
+    // === DNA Nucleotides ===
+
+    // DA (deoxyadenosine)
+    .{ "DA  :OP3 ", atom_types.O2H1 },
+    .{ "DA  :P   ", atom_types.P4H0 },
+    .{ "DA  :OP1 ", atom_types.O1H0 },
+    .{ "DA  :OP2 ", atom_types.O2H1 },
+    .{ "DA  :O5' ", atom_types.O2H0 },
+    .{ "DA  :C5' ", atom_types.C4H2 },
+    .{ "DA  :C4' ", atom_types.C4H1 },
+    .{ "DA  :O4' ", atom_types.O2H0 },
+    .{ "DA  :C3' ", atom_types.C4H1 },
+    .{ "DA  :O3' ", atom_types.O2H1 },
+    .{ "DA  :C2' ", atom_types.C4H2 },
+    .{ "DA  :C1' ", atom_types.C4H1 },
+    .{ "DA  :N9  ", atom_types.N3H0 },
+    .{ "DA  :C8  ", atom_types.C3H1 },
+    .{ "DA  :N7  ", atom_types.N2H0 },
+    .{ "DA  :C5  ", atom_types.C3H0 },
+    .{ "DA  :C6  ", atom_types.C3H0 },
+    .{ "DA  :N6  ", atom_types.N3H2 },
+    .{ "DA  :N1  ", atom_types.N2H0 },
+    .{ "DA  :C2  ", atom_types.C3H1 },
+    .{ "DA  :N3  ", atom_types.N2H0 },
+    .{ "DA  :C4  ", atom_types.C3H0 },
+
+    // DC (deoxycytidine)
+    .{ "DC  :OP3 ", atom_types.O2H1 },
+    .{ "DC  :P   ", atom_types.P4H0 },
+    .{ "DC  :OP1 ", atom_types.O1H0 },
+    .{ "DC  :OP2 ", atom_types.O2H1 },
+    .{ "DC  :O5' ", atom_types.O2H0 },
+    .{ "DC  :C5' ", atom_types.C4H2 },
+    .{ "DC  :C4' ", atom_types.C4H1 },
+    .{ "DC  :O4' ", atom_types.O2H0 },
+    .{ "DC  :C3' ", atom_types.C4H1 },
+    .{ "DC  :O3' ", atom_types.O2H1 },
+    .{ "DC  :C2' ", atom_types.C4H2 },
+    .{ "DC  :C1' ", atom_types.C4H1 },
+    .{ "DC  :N1  ", atom_types.N3H0 },
+    .{ "DC  :C2  ", atom_types.C3H0 },
+    .{ "DC  :O2  ", atom_types.O1H0 },
+    .{ "DC  :N3  ", atom_types.N2H0 },
+    .{ "DC  :C4  ", atom_types.C3H0 },
+    .{ "DC  :N4  ", atom_types.N3H2 },
+    .{ "DC  :C5  ", atom_types.C3H1 },
+    .{ "DC  :C6  ", atom_types.C3H1 },
+
+    // DG (deoxyguanosine)
+    .{ "DG  :OP3 ", atom_types.O2H1 },
+    .{ "DG  :P   ", atom_types.P4H0 },
+    .{ "DG  :OP1 ", atom_types.O1H0 },
+    .{ "DG  :OP2 ", atom_types.O2H1 },
+    .{ "DG  :O5' ", atom_types.O2H0 },
+    .{ "DG  :C5' ", atom_types.C4H2 },
+    .{ "DG  :C4' ", atom_types.C4H1 },
+    .{ "DG  :O4' ", atom_types.O2H0 },
+    .{ "DG  :C3' ", atom_types.C4H1 },
+    .{ "DG  :O3' ", atom_types.O2H1 },
+    .{ "DG  :C2' ", atom_types.C4H2 },
+    .{ "DG  :C1' ", atom_types.C4H1 },
+    .{ "DG  :N9  ", atom_types.N3H0 },
+    .{ "DG  :C8  ", atom_types.C3H1 },
+    .{ "DG  :N7  ", atom_types.N2H0 },
+    .{ "DG  :C5  ", atom_types.C3H0 },
+    .{ "DG  :C6  ", atom_types.C3H0 },
+    .{ "DG  :O6  ", atom_types.O1H0 },
+    .{ "DG  :N1  ", atom_types.N3H1 },
+    .{ "DG  :C2  ", atom_types.C3H0 },
+    .{ "DG  :N2  ", atom_types.N3H2 },
+    .{ "DG  :N3  ", atom_types.N2H0 },
+    .{ "DG  :C4  ", atom_types.C3H0 },
+
+    // DI (deoxyinosine)
+    .{ "DI  :OP3 ", atom_types.O2H1 },
+    .{ "DI  :P   ", atom_types.P4H0 },
+    .{ "DI  :OP1 ", atom_types.O1H0 },
+    .{ "DI  :OP2 ", atom_types.O2H1 },
+    .{ "DI  :O5' ", atom_types.O2H0 },
+    .{ "DI  :C5' ", atom_types.C4H2 },
+    .{ "DI  :C4' ", atom_types.C4H1 },
+    .{ "DI  :O4' ", atom_types.O2H0 },
+    .{ "DI  :C3' ", atom_types.C4H1 },
+    .{ "DI  :O3' ", atom_types.O2H1 },
+    .{ "DI  :C2' ", atom_types.C4H2 },
+    .{ "DI  :C1' ", atom_types.C4H1 },
+    .{ "DI  :N9  ", atom_types.N3H0 },
+    .{ "DI  :C8  ", atom_types.C3H1 },
+    .{ "DI  :N7  ", atom_types.N2H0 },
+    .{ "DI  :C5  ", atom_types.C3H0 },
+    .{ "DI  :C6  ", atom_types.C3H0 },
+    .{ "DI  :O6  ", atom_types.O1H0 },
+    .{ "DI  :N1  ", atom_types.N3H1 },
+    .{ "DI  :C2  ", atom_types.C3H1 },
+    .{ "DI  :N3  ", atom_types.N2H0 },
+    .{ "DI  :C4  ", atom_types.C3H0 },
+
+    // DT (deoxythymidine)
+    .{ "DT  :OP3 ", atom_types.O2H1 },
+    .{ "DT  :P   ", atom_types.P4H0 },
+    .{ "DT  :OP1 ", atom_types.O1H0 },
+    .{ "DT  :OP2 ", atom_types.O2H1 },
+    .{ "DT  :O5' ", atom_types.O2H0 },
+    .{ "DT  :C5' ", atom_types.C4H2 },
+    .{ "DT  :C4' ", atom_types.C4H1 },
+    .{ "DT  :O4' ", atom_types.O2H0 },
+    .{ "DT  :C3' ", atom_types.C4H1 },
+    .{ "DT  :O3' ", atom_types.O2H1 },
+    .{ "DT  :C2' ", atom_types.C4H2 },
+    .{ "DT  :C1' ", atom_types.C4H1 },
+    .{ "DT  :N1  ", atom_types.N3H0 },
+    .{ "DT  :C2  ", atom_types.C3H0 },
+    .{ "DT  :O2  ", atom_types.O1H0 },
+    .{ "DT  :N3  ", atom_types.N3H1 },
+    .{ "DT  :C4  ", atom_types.C3H0 },
+    .{ "DT  :O4  ", atom_types.O1H0 },
+    .{ "DT  :C5  ", atom_types.C3H0 },
+    .{ "DT  :C7  ", atom_types.C4H3 },
+    .{ "DT  :C6  ", atom_types.C3H1 },
+
+    // DU (deoxyuridine)
+    .{ "DU  :OP3 ", atom_types.O2H1 },
+    .{ "DU  :P   ", atom_types.P4H0 },
+    .{ "DU  :OP1 ", atom_types.O1H0 },
+    .{ "DU  :OP2 ", atom_types.O2H1 },
+    .{ "DU  :O5' ", atom_types.O2H0 },
+    .{ "DU  :C5' ", atom_types.C4H2 },
+    .{ "DU  :C4' ", atom_types.C4H1 },
+    .{ "DU  :O4' ", atom_types.O2H0 },
+    .{ "DU  :C3' ", atom_types.C4H1 },
+    .{ "DU  :O3' ", atom_types.O2H1 },
+    .{ "DU  :C2' ", atom_types.C4H2 },
+    .{ "DU  :C1' ", atom_types.C4H1 },
+    .{ "DU  :N1  ", atom_types.N3H0 },
+    .{ "DU  :C2  ", atom_types.C3H0 },
+    .{ "DU  :O2  ", atom_types.O1H0 },
+    .{ "DU  :N3  ", atom_types.N3H1 },
+    .{ "DU  :C4  ", atom_types.C3H0 },
+    .{ "DU  :O4  ", atom_types.O1H0 },
+    .{ "DU  :C5  ", atom_types.C3H1 },
+    .{ "DU  :C6  ", atom_types.C3H1 },
+});
+
+/// Create lookup key at runtime
+fn makeKeyRuntime(residue: []const u8, atom: []const u8) [9]u8 {
+    var key: [9]u8 = .{ ' ', ' ', ' ', ' ', ':', ' ', ' ', ' ', ' ' };
+
+    // Copy residue (up to 4 chars, left-justified)
+    const res_len = @min(residue.len, 4);
+    for (residue[0..res_len], 0..) |c, i| {
+        key[i] = c;
+    }
+
+    // Copy atom name (up to 4 chars)
+    const atom_len = @min(atom.len, 4);
+    for (atom[0..atom_len], 0..) |c, i| {
+        key[5 + i] = c;
+    }
+
+    return key;
+}
+
+/// Get radius for a (residue, atom) pair
+/// ProtOr does not have ANY fallback, only element-based guessing
+pub fn getRadius(residue: []const u8, atom: []const u8) ?f64 {
+    const key = makeKeyRuntime(residue, atom);
+    if (residue_atoms.get(&key)) |t| {
+        return t.radius;
+    }
+    // No ANY fallback in ProtOr, go directly to element guess
+    return classifier.guessRadiusFromAtomName(atom);
+}
+
+/// Get polarity class for a (residue, atom) pair
+pub fn getClass(residue: []const u8, atom: []const u8) AtomClass {
+    const key = makeKeyRuntime(residue, atom);
+    if (residue_atoms.get(&key)) |t| {
+        return t.class;
+    }
+    return .unknown;
+}
+
+/// Get both radius and class
+pub fn getProperties(residue: []const u8, atom: []const u8) ?AtomProperties {
+    const key = makeKeyRuntime(residue, atom);
+    if (residue_atoms.get(&key)) |t| {
+        return AtomProperties{ .radius = t.radius, .class = t.class };
+    }
+    // Try element guess for radius only
+    if (classifier.guessRadiusFromAtomName(atom)) |r| {
+        return AtomProperties{ .radius = r, .class = .unknown };
+    }
+    return null;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "ProtOr backbone atoms" {
+    // ALA backbone
+    try std.testing.expectApproxEqAbs(@as(f64, 1.64), getRadius("ALA", "N").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("ALA", "CA").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.61), getRadius("ALA", "C").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.42), getRadius("ALA", "O").?, 0.001);
+
+    // GLY has different CA (C4H2 instead of C4H1)
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("GLY", "CA").?, 0.001);
+}
+
+test "ProtOr side chain atoms" {
+    // ALA CB (methyl)
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("ALA", "CB").?, 0.001);
+
+    // PHE aromatic ring
+    try std.testing.expectApproxEqAbs(@as(f64, 1.61), getRadius("PHE", "CG").?, 0.001); // C3H0
+    try std.testing.expectApproxEqAbs(@as(f64, 1.76), getRadius("PHE", "CD1").?, 0.001); // C3H1
+
+    // CYS thiol
+    try std.testing.expectApproxEqAbs(@as(f64, 1.77), getRadius("CYS", "SG").?, 0.001);
+
+    // MET thioether
+    try std.testing.expectApproxEqAbs(@as(f64, 1.77), getRadius("MET", "SD").?, 0.001);
+
+    // LYS amino
+    try std.testing.expectApproxEqAbs(@as(f64, 1.64), getRadius("LYS", "NZ").?, 0.001);
+}
+
+test "ProtOr polarity classes" {
+    try std.testing.expectEqual(AtomClass.polar, getClass("ALA", "N"));
+    try std.testing.expectEqual(AtomClass.polar, getClass("ALA", "O"));
+    try std.testing.expectEqual(AtomClass.apolar, getClass("ALA", "CA"));
+    try std.testing.expectEqual(AtomClass.apolar, getClass("ALA", "CB"));
+    try std.testing.expectEqual(AtomClass.polar, getClass("CYS", "SG")); // S is polar in ProtOr
+}
+
+test "ProtOr selenocysteine and selenomethionine" {
+    // SEC
+    try std.testing.expectApproxEqAbs(@as(f64, 1.90), getRadius("SEC", "SE").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("SEC", "CB").?, 0.001);
+
+    // MSE
+    try std.testing.expectApproxEqAbs(@as(f64, 1.90), getRadius("MSE", "SE").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("MSE", "CG").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("MSE", "CE").?, 0.001);
+}
+
+test "ProtOr nucleotides" {
+    // RNA adenine
+    try std.testing.expectApproxEqAbs(@as(f64, 1.80), getRadius("A", "P").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("A", "C1'").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.64), getRadius("A", "N9").?, 0.001);
+
+    // DNA thymine
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), getRadius("DT", "C7").?, 0.001); // methyl
+}
+
+test "ProtOr element-based fallback" {
+    // Unknown residue - should use element guess
+    // Note: " CA " (with leading space) -> Carbon (1.70)
+    // "CA" (without leading space) -> Calcium (2.31)
+    const r = getRadius("UNK", " CA ");
+    try std.testing.expect(r != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.70), r.?, 0.001); // C element
+
+    // Without leading space, "CA" is Calcium
+    const r2 = getRadius("UNK", "CA");
+    try std.testing.expect(r2 != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.31), r2.?, 0.001); // CA element (Calcium)
+}
+
+test "ProtOr getProperties" {
+    const props = getProperties("ALA", "CB");
+    try std.testing.expect(props != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), props.?.radius, 0.001);
+    try std.testing.expectEqual(AtomClass.apolar, props.?.class);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -4,6 +4,8 @@ const std = @import("std");
 // Re-export modules for library consumers
 pub const classifier = @import("classifier.zig");
 pub const classifier_naccess = @import("classifier_naccess.zig");
+pub const classifier_protor = @import("classifier_protor.zig");
+pub const classifier_oons = @import("classifier_oons.zig");
 
 pub fn bufferedPrint() !void {
     // Stdout is for the actual output of your application, for example if you
@@ -30,4 +32,6 @@ test {
     // Reference imported modules to include their tests
     _ = classifier;
     _ = classifier_naccess;
+    _ = classifier_protor;
+    _ = classifier_oons;
 }


### PR DESCRIPTION
## Summary

- Add ProtOr classifier with hybridization-based radii (Tsai et al. 1999)
- Add OONS classifier (older FreeSASA default)
- Add `ClassifierType` enum for classifier selection
- Export new modules from root.zig

## Changes

### New Files
- `src/classifier_protor.zig` - ProtOr classifier implementation
  - Types based on hybridization state (C3H0, C4H1, N3H2, etc.)
  - Support for 20 amino acids + SEC/MSE/PYL/ASX/GLX
  - RNA/DNA nucleotides
  - Capping groups (ACE, NH2)
  
- `src/classifier_oons.zig` - OONS classifier implementation
  - Simpler classification (C_ALI, C_ARO, C_CAR, N, O, S, P, SE)
  - ANY fallback section for backbone atoms
  - Support for amino acids and nucleotides

### Modified Files
- `src/classifier.zig` - Added `ClassifierType` enum and documentation
- `src/root.zig` - Export new classifier modules

## Classifier Comparison

| Feature | NACCESS | ProtOr | OONS |
|---------|---------|--------|------|
| C aliphatic | 1.87Å | 1.88Å | 2.00Å |
| C aromatic | 1.76Å | 1.76Å | 1.75Å |
| ANY fallback | Yes | No | Yes |
| Type system | Atom-based | Hybridization | Atom-based |

## Test plan

- [x] All existing tests pass
- [x] ProtOr classifier tests pass
- [x] OONS classifier tests pass
- [x] ClassifierType enum works correctly