### PR TITLE
feat: Add element atomic number support for CA/Ca disambiguation

### DIFF
--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -86,6 +86,10 @@ const class: AtomClass = oons.getClass("ALA", "C");  // .polar
 ```zig
 const classifier = @import("classifier.zig");
 
+// 原子番号から半径推定（CA/Ca問題を解決）
+const radius = classifier.guessRadiusFromAtomicNumber(6);   // 1.70 (Carbon)
+const radius = classifier.guessRadiusFromAtomicNumber(20);  // 2.31 (Calcium)
+
 // 元素記号から半径推定
 const radius = classifier.guessRadius("C");   // 1.70
 const radius = classifier.guessRadius("FE");  // 1.26
@@ -98,6 +102,25 @@ const radius = classifier.guessRadiusFromAtomName("FE  "); // 1.26 (FE)
 const elem = classifier.extractElement(" CA "); // "C"（先頭スペース→1文字元素）
 const elem = classifier.extractElement("FE  "); // "FE"（先頭スペースなし→2文字チェック）
 ```
+
+### 原子番号による明確な元素識別
+
+入力JSONに`element`フィールド（原子番号配列）を含めることで、原子名の曖昧さを解消できる：
+
+```json
+{
+  "x": [1.0, 2.0],
+  "y": [3.0, 4.0],
+  "z": [5.0, 6.0],
+  "r": [1.7, 2.31],
+  "atom_name": ["CA", "CA"],
+  "element": [6, 20]
+}
+```
+
+上記の例では：
+- 1番目のCA: 原子番号6 = 炭素（Cα）
+- 2番目のCA: 原子番号20 = カルシウム（金属イオン）
 
 ### データ型
 

--- a/scripts/cif_to_input_json.py
+++ b/scripts/cif_to_input_json.py
@@ -34,6 +34,7 @@ class AtomCoordinates(BaseModel):
     r: list[float]
     residue: list[str] | None = None
     atom_name: list[str] | None = None
+    element: list[int] | None = None  # Atomic numbers (e.g., 6=C, 7=N, 8=O)
 
     @property
     def n_atoms(self) -> int:
@@ -49,7 +50,7 @@ def extract_atoms(path: str | Path) -> AtomCoordinates:
         path: Path to mmCIF or PDB file (gzipped OK)
 
     Returns:
-        AtomCoordinates with x, y, z coordinates, r radii, and residue/atom names
+        AtomCoordinates with x, y, z coordinates, r radii, residue/atom names, and elements
     """
     st = gemmi.read_structure(str(path))
     st.remove_hydrogens()
@@ -63,6 +64,7 @@ def extract_atoms(path: str | Path) -> AtomCoordinates:
     rs: list[float] = []
     residues: list[str] = []
     atom_names: list[str] = []
+    elements: list[int] = []
 
     # Use first model only (common for X-ray structures)
     model = st[0]
@@ -74,9 +76,10 @@ def extract_atoms(path: str | Path) -> AtomCoordinates:
         rs.append(cra.atom.element.vdw_r)
         residues.append(cra.residue.name)
         atom_names.append(cra.atom.name)
+        elements.append(cra.atom.element.atomic_number)
 
     return AtomCoordinates(
-        x=xs, y=ys, z=zs, r=rs, residue=residues, atom_name=atom_names
+        x=xs, y=ys, z=zs, r=rs, residue=residues, atom_name=atom_names, element=elements
     )
 
 

--- a/src/classifier.zig
+++ b/src/classifier.zig
@@ -254,6 +254,55 @@ pub const Classifier = struct {
 // Element-Based Radius Guessing
 // =============================================================================
 
+/// van der Waals radii by atomic number (O(1) array lookup)
+/// Sources: Mantina et al. 2009 for common elements, gemmi for others
+/// Index = atomic number, Value = radius in Angstroms (0 = unknown)
+const atomic_number_radii = blk: {
+    var radii: [119]f64 = .{0} ** 119;
+    // Common biological elements
+    radii[1] = 1.10; // H
+    radii[6] = 1.70; // C
+    radii[7] = 1.55; // N
+    radii[8] = 1.52; // O
+    radii[15] = 1.80; // P
+    radii[16] = 1.80; // S
+    radii[34] = 1.90; // Se
+    // Halogens
+    radii[9] = 1.47; // F
+    radii[17] = 1.75; // Cl
+    radii[35] = 1.83; // Br
+    radii[53] = 1.98; // I
+    // Alkali and Alkali Earth metals
+    radii[3] = 1.81; // Li
+    radii[4] = 1.53; // Be
+    radii[11] = 2.27; // Na
+    radii[12] = 1.73; // Mg
+    radii[19] = 2.75; // K
+    radii[20] = 2.31; // Ca
+    // Transition metals (common in proteins)
+    radii[25] = 1.19; // Mn
+    radii[26] = 1.26; // Fe
+    radii[27] = 1.13; // Co
+    radii[28] = 1.63; // Ni
+    radii[29] = 1.40; // Cu
+    radii[30] = 1.39; // Zn
+    // Other metals
+    radii[33] = 1.85; // As
+    radii[48] = 1.58; // Cd
+    radii[80] = 1.55; // Hg
+    radii[82] = 2.02; // Pb
+    break :blk radii;
+};
+
+/// Get van der Waals radius from atomic number
+/// Returns null if atomic number is not recognized or out of range
+pub fn guessRadiusFromAtomicNumber(atomic_number: u8) ?f64 {
+    if (atomic_number == 0 or atomic_number >= atomic_number_radii.len) return null;
+    const radius = atomic_number_radii[atomic_number];
+    if (radius == 0) return null;
+    return radius;
+}
+
 /// van der Waals radii map (O(1) lookup)
 /// Sources: Mantina et al. 2009 for common elements, gemmi for others
 /// Keys are uppercase element symbols
@@ -603,4 +652,36 @@ test "guessRadiusFromAtomName" {
     try std.testing.expectEqual(@as(?f64, 1.26), guessRadiusFromAtomName("FE  "));
     try std.testing.expectEqual(@as(?f64, 1.39), guessRadiusFromAtomName("ZN  "));
     try std.testing.expectEqual(@as(?f64, 1.90), guessRadiusFromAtomName("SE  "));
+}
+
+test "guessRadiusFromAtomicNumber common elements" {
+    // Common biological elements
+    try std.testing.expectEqual(@as(?f64, 1.10), guessRadiusFromAtomicNumber(1)); // H
+    try std.testing.expectEqual(@as(?f64, 1.70), guessRadiusFromAtomicNumber(6)); // C
+    try std.testing.expectEqual(@as(?f64, 1.55), guessRadiusFromAtomicNumber(7)); // N
+    try std.testing.expectEqual(@as(?f64, 1.52), guessRadiusFromAtomicNumber(8)); // O
+    try std.testing.expectEqual(@as(?f64, 1.80), guessRadiusFromAtomicNumber(15)); // P
+    try std.testing.expectEqual(@as(?f64, 1.80), guessRadiusFromAtomicNumber(16)); // S
+    try std.testing.expectEqual(@as(?f64, 1.90), guessRadiusFromAtomicNumber(34)); // Se
+}
+
+test "guessRadiusFromAtomicNumber metals" {
+    try std.testing.expectEqual(@as(?f64, 1.26), guessRadiusFromAtomicNumber(26)); // Fe
+    try std.testing.expectEqual(@as(?f64, 1.39), guessRadiusFromAtomicNumber(30)); // Zn
+    try std.testing.expectEqual(@as(?f64, 1.40), guessRadiusFromAtomicNumber(29)); // Cu
+    try std.testing.expectEqual(@as(?f64, 1.73), guessRadiusFromAtomicNumber(12)); // Mg
+    try std.testing.expectEqual(@as(?f64, 2.31), guessRadiusFromAtomicNumber(20)); // Ca
+}
+
+test "guessRadiusFromAtomicNumber distinguishes CA (Carbon) from Ca (Calcium)" {
+    // This is the key test: atomic numbers unambiguously identify elements
+    // Carbon (atomic number 6) vs Calcium (atomic number 20)
+    try std.testing.expectEqual(@as(?f64, 1.70), guessRadiusFromAtomicNumber(6)); // Carbon
+    try std.testing.expectEqual(@as(?f64, 2.31), guessRadiusFromAtomicNumber(20)); // Calcium
+}
+
+test "guessRadiusFromAtomicNumber unknown" {
+    try std.testing.expectEqual(@as(?f64, null), guessRadiusFromAtomicNumber(0)); // Invalid
+    try std.testing.expectEqual(@as(?f64, null), guessRadiusFromAtomicNumber(2)); // He (not in our map)
+    try std.testing.expectEqual(@as(?f64, null), guessRadiusFromAtomicNumber(118)); // Oganesson
 }

--- a/src/json_parser.zig
+++ b/src/json_parser.zig
@@ -11,6 +11,8 @@ const JsonInput = struct {
     r: []f64,
     residue: ?[][]const u8 = null,
     atom_name: ?[][]const u8 = null,
+    /// Element atomic numbers (e.g., 6=C, 7=N, 8=O, 20=Ca)
+    element: ?[]u8 = null,
 };
 
 /// Validation error details
@@ -156,6 +158,9 @@ pub fn parseAtomInput(allocator: Allocator, json_str: []const u8) !AtomInput {
     if (data.atom_name) |names| {
         if (names.len != n) return error.ArrayLengthMismatch;
     }
+    if (data.element) |elem| {
+        if (elem.len != n) return error.ArrayLengthMismatch;
+    }
 
     // Allocate and copy data
     const x = try allocator.alloc(f64, n);
@@ -211,6 +216,13 @@ pub fn parseAtomInput(allocator: Allocator, json_str: []const u8) !AtomInput {
         atom_name = names_copy;
     }
 
+    // Copy optional element atomic numbers
+    var element: ?[]u8 = null;
+    if (data.element) |elem| {
+        element = try allocator.dupe(u8, elem);
+    }
+    errdefer if (element) |elem| allocator.free(elem);
+
     return AtomInput{
         .x = x,
         .y = y,
@@ -218,6 +230,7 @@ pub fn parseAtomInput(allocator: Allocator, json_str: []const u8) !AtomInput {
         .r = r,
         .residue = residue,
         .atom_name = atom_name,
+        .element = element,
         .allocator = allocator,
     };
 }
@@ -275,6 +288,47 @@ test "parseAtomInput with residue and atom_name" {
     try std.testing.expectEqualStrings("GLY", residue[1]);
     try std.testing.expectEqualStrings("CA", atom_name[0]);
     try std.testing.expectEqualStrings("N", atom_name[1]);
+}
+
+test "parseAtomInput with element atomic numbers" {
+    const allocator = std.testing.allocator;
+
+    // 6=Carbon, 7=Nitrogen, 8=Oxygen
+    const json =
+        \\{"x": [1.0, 2.0, 3.0], "y": [4.0, 5.0, 6.0], "z": [7.0, 8.0, 9.0], "r": [1.5, 1.6, 1.7], "residue": ["ALA", "ALA", "ALA"], "atom_name": ["CA", "N", "O"], "element": [6, 7, 8]}
+    ;
+
+    var input = try parseAtomInput(allocator, json);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), input.atomCount());
+    try std.testing.expect(input.hasClassificationInfo());
+    try std.testing.expect(input.hasElementInfo());
+
+    const element = input.element.?;
+    try std.testing.expectEqual(@as(u8, 6), element[0]); // Carbon
+    try std.testing.expectEqual(@as(u8, 7), element[1]); // Nitrogen
+    try std.testing.expectEqual(@as(u8, 8), element[2]); // Oxygen
+}
+
+test "parseAtomInput with element distinguishes CA (Carbon) from Ca (Calcium)" {
+    const allocator = std.testing.allocator;
+
+    // First atom: CA = Carbon alpha (atomic number 6)
+    // Second atom: CA = Calcium ion (atomic number 20)
+    const json =
+        \\{"x": [1.0, 2.0], "y": [3.0, 4.0], "z": [5.0, 6.0], "r": [1.7, 2.31], "residue": ["ALA", "CA"], "atom_name": ["CA", "CA"], "element": [6, 20]}
+    ;
+
+    var input = try parseAtomInput(allocator, json);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expect(input.hasElementInfo());
+
+    const element = input.element.?;
+    try std.testing.expectEqual(@as(u8, 6), element[0]); // Carbon (CA in amino acid)
+    try std.testing.expectEqual(@as(u8, 20), element[1]); // Calcium (CA ion)
 }
 
 test "parseAtomInput empty arrays" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -54,6 +54,9 @@ pub const AtomInput = struct {
     residue: ?[]const []const u8 = null,
     /// Atom names (e.g., "CA", "CB") - optional, for classifier
     atom_name: ?[]const []const u8 = null,
+    /// Element atomic numbers (e.g., 6=C, 7=N, 8=O, 20=Ca) - optional
+    /// Used to disambiguate atom names like "CA" (Carbon alpha vs Calcium)
+    element: ?[]const u8 = null,
     allocator: std.mem.Allocator,
 
     /// Get number of atoms
@@ -64,6 +67,11 @@ pub const AtomInput = struct {
     /// Check if residue/atom names are available for classification
     pub fn hasClassificationInfo(self: AtomInput) bool {
         return self.residue != null and self.atom_name != null;
+    }
+
+    /// Check if element info is available
+    pub fn hasElementInfo(self: AtomInput) bool {
+        return self.element != null;
     }
 
     /// Free allocated memory
@@ -83,6 +91,9 @@ pub const AtomInput = struct {
                 self.allocator.free(s);
             }
             self.allocator.free(names);
+        }
+        if (self.element) |elem| {
+            self.allocator.free(elem);
         }
     }
 };


### PR DESCRIPTION
## Summary

- Add `element` field to `AtomInput` (optional `u8` array for atomic numbers)
- Add element parsing in `json_parser.zig` with validation
- Add `guessRadiusFromAtomicNumber()` for O(1) radius lookup by atomic number
- Update `cif_to_input_json.py` to output element atomic numbers using gemmi
- Update documentation in `docs/classifier.md`

## Problem Solved

In PDB format, atom name "CA" can mean either:
- Carbon alpha (Cα) in amino acid backbone (atomic number 6)
- Calcium metal ion (atomic number 20)

The PDB convention uses leading spaces to disambiguate (` CA ` = Carbon, `CA  ` = Calcium), but this is error-prone. By including atomic numbers directly in the input JSON, we can unambiguously identify elements.

## Example

```json
{
  "x": [1.0, 2.0],
  "y": [3.0, 4.0],
  "z": [5.0, 6.0],
  "r": [1.7, 2.31],
  "atom_name": ["CA", "CA"],
  "element": [6, 20]
}
```

- First "CA": atomic number 6 = Carbon (radius 1.70 Å)
- Second "CA": atomic number 20 = Calcium (radius 2.31 Å)

## Test plan

- [x] All tests pass (`zig build test`)
- [x] New tests for `guessRadiusFromAtomicNumber()`
- [x] New tests for element parsing in json_parser
- [x] Documentation updated