### PR TITLE
ci: Add Python bindings test job

### DIFF
--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -186,13 +186,13 @@ jobs:
 
       - name: Run Python tests
         working-directory: python
-        run: uv run --with pytest pytest tests/ -v
+        run: pytest tests/ -v
 
       - name: Run linter
         working-directory: python
         run: |
-          uv run --with ruff ruff check freesasa_zig/
-          uv run --with ruff ruff format --check freesasa_zig/
+          ruff check freesasa_zig/
+          ruff format --check freesasa_zig/
 
       - name: Test import and basic usage
         run: |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -167,9 +167,9 @@ zig build -Doptimize=ReleaseFast
 # Pythonテスト
 cd python
 uv pip install -e ".[dev]"
-uv run --with pytest pytest tests/ -v
-uv run --with ruff ruff check freesasa_zig/
-uv run --with ruff ruff format --check freesasa_zig/
+pytest tests/ -v
+ruff check freesasa_zig/
+ruff format --check freesasa_zig/
 ```
 
 ## CI失敗時の対処
@@ -179,9 +179,11 @@ uv run --with ruff ruff format --check freesasa_zig/
 ```bash
 # ローカルでフォーマット実行
 zig fmt src/
-git add -u && git commit --amend
-git push -f
+git add -u && git commit -m "style: Format code"
+git push
 ```
+
+**注意:** `--amend` + `git push -f` はプッシュ済みコミットを書き換えるため、共有ブランチでは使用しないでください。
 
 ### Build failed
 
@@ -220,10 +222,10 @@ git push -f
 
 ```bash
 cd python
-uv run --with ruff ruff check freesasa_zig/ --fix
-uv run --with ruff ruff format freesasa_zig/
-git add -u && git commit --amend
-git push -f
+ruff check freesasa_zig/ --fix
+ruff format freesasa_zig/
+git add -u && git commit -m "style: Fix Python lint issues"
+git push
 ```
 
 ### Timeout


### PR DESCRIPTION
## Summary
Add Python bindings CI job to test the Python package on Linux and macOS.

## Changes

### New Python job in CI
- Build shared library (`libfreesasa_zig.so`/`.dylib`)
- Install Python package with dev dependencies
- Run pytest tests
- Run ruff linting checks
- Integration test (basic import and usage)

### Updated docs/ci.md
- Add Python job to job diagram
- Document Python job steps and failure handling
- Update timeout list and security section

## CI Job Flow
```
fmt ──────┬──────► build (Linux, macOS) ──────► validate
          │
          └──────► python (Linux, macOS)
```

## Test plan
- [ ] CI file syntax is valid (YAML lint)
- [ ] Python tests pass locally
- [ ] When enabled, CI runs successfully