### PR TITLE
fix: Pass n_threads to FreeSASA Python benchmark

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -165,6 +165,7 @@ def run_freesasa_python_benchmark(
     algorithm: str = "sr",
     n_points: int = 100,
     n_slices: int = 20,
+    n_threads: int = 0,
 ) -> tuple[float, float]:
     """Run FreeSASA Python benchmark. Returns (time_ms, total_area).
 
@@ -183,13 +184,14 @@ def run_freesasa_python_benchmark(
 
     # Set algorithm parameters
     if algorithm == "sr":
-        params = freesasa.Parameters(
-            {"algorithm": freesasa.ShrakeRupley, "n-points": n_points}
-        )
+        param_dict = {"algorithm": freesasa.ShrakeRupley, "n-points": n_points}
     else:
-        params = freesasa.Parameters(
-            {"algorithm": freesasa.LeeRichards, "n-slices": n_slices}
-        )
+        param_dict = {"algorithm": freesasa.LeeRichards, "n-slices": n_slices}
+
+    if n_threads > 0:
+        param_dict["n-threads"] = n_threads
+
+    params = freesasa.Parameters(param_dict)
 
     # Time only the SASA calculation
     start = time.perf_counter()
@@ -299,7 +301,9 @@ def run_benchmarks(
             fs_area = 0.0
             for _ in range(n_runs):
                 try:
-                    t, area = run_freesasa_python_benchmark(input_path, algo)
+                    t, area = run_freesasa_python_benchmark(
+                        input_path, algo, n_threads=n_threads
+                    )
                     fs_times.append(t)
                     fs_area = area
                 except Exception as e:


### PR DESCRIPTION
## Summary
- FreeSASA Python benchmark now receives `n_threads` parameter
- Previously only Zig implementations got thread configuration
- FreeSASA defaults to 2 threads, causing unfair comparisons

## Changes
- Added `n_threads` parameter to `run_freesasa_python_benchmark()`
- Pass `n-threads` to `freesasa.Parameters()` when `n_threads > 0`
- Updated call site in `run_benchmarks()` to pass `n_threads`

## Test plan
- [ ] Run benchmark with `--threads=1` to compare single-threaded performance
- [ ] Run benchmark with `--threads=4` to compare multi-threaded performance