### PR TITLE
fix: Increase JSON parser max file size to 200MB

### DIFF
--- a/src/json_parser.zig
+++ b/src/json_parser.zig
@@ -240,7 +240,7 @@ pub fn readAtomInputFromFile(allocator: Allocator, path: []const u8) !AtomInput 
     const file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 
-    const max_size = 100 * 1024 * 1024; // 100 MB max
+    const max_size = 200 * 1024 * 1024; // 200 MB max
     const contents = try file.readToEndAlloc(allocator, max_size);
     defer allocator.free(contents);
 


### PR DESCRIPTION
## Summary

JSON パーサーの最大ファイルサイズを 100MB → 200MB に増加。

## Motivation

9fqr (4,506,416 atoms) などの超大規模構造の JSON ファイルが 100MB を超えるため。

## Changes

```zig
- const max_size = 100 * 1024 * 1024; // 100 MB max
+ const max_size = 200 * 1024 * 1024; // 200 MB max
```

## Test plan

- [x] 9fqr の JSON ファイルが読み込めることを確認済み