### PR TITLE
perf: Use compact format for Zig batch benchmark

### DIFF
--- a/benchmarks/scripts/run_batch.py
+++ b/benchmarks/scripts/run_batch.py
@@ -155,6 +155,7 @@ def run_zig_batch(
         str(output_dir),
         f"--algorithm={algorithm}",
         f"--threads={n_threads}",
+        "--format=compact",
         "--timing",
         "--quiet",
     ]


### PR DESCRIPTION
Reduces I/O overhead by ~30% for more accurate SASA timing comparison.