### PR TITLE
feat: Add native XTC reader to Python bindings

### DIFF
--- a/docs/python-api/README.md
+++ b/docs/python-api/README.md
@@ -22,6 +22,7 @@ The Python bindings provide:
 | [Core API](core.md) | `calculate_sasa`, batch API, precision |
 | [Classifier](classifier.md) | Atom classification, RSA calculation |
 | [Analysis](analysis.md) | Per-residue aggregation, examples |
+| [Native XTC Reader](xtc.md) | Standalone XTC reading, no dependencies |
 | **Integrations** | |
 | [Common Interface](integrations/README.md) | Shared API for all integrations |
 | [Gemmi](integrations/gemmi.md) | Fast mmCIF/PDB parsing |
@@ -138,6 +139,23 @@ sasa = SASAAnalysis(u, select="protein")
 sasa.run()
 
 print(f"Mean SASA: {sasa.results.mean_total_area:.2f} Å²")
+```
+
+### Native XTC Reading (No Dependencies)
+
+```python
+import numpy as np
+from zsasa.xtc import XtcReader, compute_sasa_trajectory
+
+# Low-level reader
+with XtcReader("trajectory.xtc") as reader:
+    for frame in reader:
+        print(f"Step {frame.step}: {frame.natoms} atoms")
+
+# High-level SASA calculation
+radii = np.full(304, 1.7)  # Atomic radii in Angstroms
+result = compute_sasa_trajectory("trajectory.xtc", radii)
+print(f"Total SASA: {result.total_areas}")
 ```
 
 ---

--- a/docs/python-api/xtc.md
+++ b/docs/python-api/xtc.md
@@ -1,0 +1,256 @@
+# Native XTC Reader
+
+The `zsasa.xtc` module provides a standalone XTC trajectory reader using zsasa's high-performance Zig implementation. This module doesn't require MDTraj or MDAnalysis, potentially offering better performance for simple XTC reading workflows.
+
+## When to Use
+
+| Use Case | Recommended Module |
+|----------|-------------------|
+| Simple XTC reading, no dependencies | `zsasa.xtc` |
+| Need topology parsing, selections | `zsasa.mdanalysis` or `zsasa.mdtraj` |
+| Complex analysis, multiple formats | `zsasa.mdanalysis` or `zsasa.mdtraj` |
+
+## XtcReader
+
+Low-level XTC file reader with iterator support.
+
+### Constructor
+
+```python
+XtcReader(path: str | Path)
+```
+
+Opens an XTC file for reading.
+
+**Parameters:**
+- `path`: Path to XTC trajectory file
+
+**Raises:**
+- `FileNotFoundError`: If file doesn't exist
+- `RuntimeError`: If file is invalid or corrupted
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `natoms` | `int` | Number of atoms in trajectory |
+
+### Methods
+
+#### read_frame
+
+```python
+def read_frame(self) -> XtcFrame | None
+```
+
+Read the next frame from the trajectory.
+
+**Returns:**
+- `XtcFrame` object, or `None` if end of file reached
+
+**Raises:**
+- `RuntimeError`: If reader is closed or read error occurs
+
+#### close
+
+```python
+def close(self) -> None
+```
+
+Close the file and release resources. Safe to call multiple times.
+
+### Example: Basic Reading
+
+```python
+from zsasa.xtc import XtcReader
+
+# Using context manager (recommended)
+with XtcReader("trajectory.xtc") as reader:
+    print(f"Trajectory has {reader.natoms} atoms")
+
+    for frame in reader:
+        print(f"Step {frame.step}, time {frame.time} ps")
+        print(f"First atom: {frame.coords[0]}")
+```
+
+### Example: Manual Control
+
+```python
+from zsasa.xtc import XtcReader
+
+reader = XtcReader("trajectory.xtc")
+try:
+    frame = reader.read_frame()
+    while frame is not None:
+        # Process frame...
+        frame = reader.read_frame()
+finally:
+    reader.close()
+```
+
+---
+
+## XtcFrame
+
+Represents a single frame from an XTC trajectory.
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `step` | `int` | Simulation step number |
+| `time` | `float` | Simulation time in picoseconds |
+| `coords` | `NDArray[float32]` | Coordinates as (n_atoms, 3) array in **nanometers** |
+| `box` | `NDArray[float32]` | Box matrix as 3x3 array in **nanometers** |
+| `precision` | `float` | XTC compression precision |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `natoms` | `int` | Number of atoms |
+
+---
+
+## compute_sasa_trajectory
+
+High-level function for SASA calculation on XTC trajectories.
+
+```python
+def compute_sasa_trajectory(
+    xtc_path: str | Path,
+    radii: NDArray[np.floating] | list[float],
+    *,
+    probe_radius: float = 1.4,
+    n_points: int = 100,
+    algorithm: Literal["sr", "lr"] = "sr",
+    n_slices: int = 20,
+    n_threads: int = 0,
+    start: int = 0,
+    stop: int | None = None,
+    step: int = 1,
+) -> TrajectorySasaResult
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `xtc_path` | `str \| Path` | Required | Path to XTC file |
+| `radii` | `array-like` | Required | Atomic radii in Angstroms (n_atoms,) |
+| `probe_radius` | `float` | `1.4` | Water probe radius in Angstroms |
+| `n_points` | `int` | `100` | Test points per atom (SR algorithm) |
+| `algorithm` | `str` | `"sr"` | `"sr"` (Shrake-Rupley) or `"lr"` (Lee-Richards) |
+| `n_slices` | `int` | `20` | Slices per atom (LR algorithm) |
+| `n_threads` | `int` | `0` | Thread count (0 = auto-detect) |
+| `start` | `int` | `0` | First frame to process |
+| `stop` | `int \| None` | `None` | Stop before this frame (None = all) |
+| `step` | `int` | `1` | Process every Nth frame |
+
+**Returns:** `TrajectorySasaResult`
+
+**Raises:**
+- `FileNotFoundError`: If XTC file doesn't exist
+- `ValueError`: If radii length doesn't match trajectory atoms
+
+### Unit Conversion
+
+XTC coordinates are in **nanometers** (GROMACS convention). This function automatically converts to **Angstroms** for SASA calculation. Output SASA values are in **Angstroms²**.
+
+### Example: Basic Usage
+
+```python
+import numpy as np
+from zsasa.xtc import compute_sasa_trajectory
+
+# Define radii (must match trajectory atom count)
+# Typically you'd get these from a topology file
+radii = np.full(304, 1.7)  # 1.7 Å for all atoms (simplified)
+
+result = compute_sasa_trajectory("trajectory.xtc", radii)
+
+print(f"Frames: {result.n_frames}")
+print(f"Total SASA per frame: {result.total_areas}")
+```
+
+### Example: With Frame Selection
+
+```python
+# Process every 10th frame, starting from frame 100
+result = compute_sasa_trajectory(
+    "trajectory.xtc",
+    radii,
+    start=100,
+    stop=1000,
+    step=10,
+)
+```
+
+### Example: With Topology Radii
+
+```python
+import numpy as np
+from zsasa import classify_atoms
+from zsasa.xtc import compute_sasa_trajectory
+
+# Get radii from topology (e.g., from a PDB file)
+# This example assumes you have residue and atom names
+residues = ["ALA", "ALA", "ALA", ...]
+atoms = ["N", "CA", "C", ...]
+
+classification = classify_atoms(residues, atoms)
+radii = classification.radii
+
+# Handle unknown atoms
+radii = np.where(np.isnan(radii), 1.7, radii)  # Default to 1.7 Å
+
+result = compute_sasa_trajectory("trajectory.xtc", radii)
+```
+
+---
+
+## TrajectorySasaResult
+
+Result container for trajectory SASA calculation.
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `atom_areas` | `NDArray[float32]` | Per-atom SASA, shape (n_frames, n_atoms) in Å² |
+| `steps` | `NDArray[int32]` | Step numbers for each frame |
+| `times` | `NDArray[float32]` | Time values in picoseconds |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `n_frames` | `int` | Number of frames |
+| `n_atoms` | `int` | Number of atoms |
+| `total_areas` | `NDArray[float32]` | Total SASA per frame, shape (n_frames,) |
+
+---
+
+## Comparison with MDTraj/MDAnalysis Integration
+
+| Feature | zsasa.xtc | zsasa.mdtraj | zsasa.mdanalysis |
+|---------|-----------|--------------|------------------|
+| Dependencies | None (only NumPy) | mdtraj | MDAnalysis |
+| Trajectory formats | XTC only | Many (XTC, TRR, DCD, ...) | Many |
+| Topology support | Manual radii | From topology | From topology |
+| Atom selection | No | Yes | Yes |
+| Performance | Potentially faster | Good | Good |
+
+### When to Use zsasa.xtc
+
+- You only have XTC files
+- You want minimal dependencies
+- You have radii from another source
+- Performance is critical
+
+### When to Use MDTraj/MDAnalysis
+
+- You need topology parsing
+- You need atom selection
+- You work with multiple trajectory formats
+- You need additional analysis tools

--- a/python/tests/test_xtc.py
+++ b/python/tests/test_xtc.py
@@ -1,0 +1,226 @@
+"""Tests for native XTC reader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from zsasa.xtc import XtcReader, TrajectorySasaResult, compute_sasa_trajectory
+
+
+# Path to test data
+TEST_DATA_DIR = Path(__file__).parent.parent.parent / "test_data"
+XTC_FILE = TEST_DATA_DIR / "1l2y.xtc"
+
+
+class TestXtcReader:
+    """Test XtcReader class."""
+
+    @pytest.fixture
+    def reader(self) -> XtcReader:
+        """Create XtcReader for test file."""
+        return XtcReader(XTC_FILE)
+
+    def test_open_close(self) -> None:
+        """Test opening and closing XTC file."""
+        reader = XtcReader(XTC_FILE)
+        assert reader.natoms == 304
+        reader.close()
+
+    def test_context_manager(self) -> None:
+        """Test using XtcReader as context manager."""
+        with XtcReader(XTC_FILE) as reader:
+            assert reader.natoms == 304
+
+    def test_file_not_found(self) -> None:
+        """Test opening non-existent file raises error."""
+        with pytest.raises(FileNotFoundError):
+            XtcReader("nonexistent.xtc")
+
+    def test_natoms(self, reader: XtcReader) -> None:
+        """Test natoms property."""
+        assert reader.natoms == 304
+        reader.close()
+
+    def test_read_first_frame(self, reader: XtcReader) -> None:
+        """Test reading first frame."""
+        frame = reader.read_frame()
+        reader.close()
+
+        assert frame is not None
+        assert frame.step == 1
+        assert frame.coords.shape == (304, 3)
+        assert frame.box.shape == (3, 3)
+
+        # Check first atom coordinates (in nm, from C xdrfile reference)
+        np.testing.assert_allclose(frame.coords[0], [-0.8901, 0.4127, -0.0555], atol=0.001)
+
+    def test_read_all_frames(self, reader: XtcReader) -> None:
+        """Test reading all frames via iteration."""
+        frame_count = 0
+        for frame in reader:
+            frame_count += 1
+            assert frame.coords.shape == (304, 3)
+
+        # 1l2y.xtc has 38 frames
+        assert frame_count == 38
+
+    def test_read_frame_returns_none_at_eof(self, reader: XtcReader) -> None:
+        """Test that read_frame returns None at end of file."""
+        # Skip all frames
+        for _ in reader:
+            pass
+
+        # Next read should return None
+        frame = reader.read_frame()
+        reader.close()
+        assert frame is None
+
+    def test_frame_properties(self) -> None:
+        """Test XtcFrame properties."""
+        with XtcReader(XTC_FILE) as reader:
+            frame = reader.read_frame()
+            assert frame is not None
+
+            assert frame.natoms == 304
+            assert frame.step == 1
+            assert frame.time >= 0
+            assert frame.precision > 0
+
+
+class TestComputeSasaTrajectory:
+    """Test compute_sasa_trajectory function."""
+
+    @pytest.fixture
+    def radii(self) -> np.ndarray:
+        """Create radii array for 1l2y (304 atoms)."""
+        # Use uniform radii for simplicity (1.7 Å = typical carbon)
+        return np.full(304, 1.7, dtype=np.float32)
+
+    def test_basic(self, radii: np.ndarray) -> None:
+        """Test basic SASA calculation."""
+        result = compute_sasa_trajectory(XTC_FILE, radii)
+
+        assert isinstance(result, TrajectorySasaResult)
+        assert result.n_frames == 38
+        assert result.n_atoms == 304
+        assert result.atom_areas.shape == (38, 304)
+
+    def test_total_areas(self, radii: np.ndarray) -> None:
+        """Test total_areas property."""
+        result = compute_sasa_trajectory(XTC_FILE, radii)
+
+        assert result.total_areas.shape == (38,)
+        # Total SASA should be positive
+        assert np.all(result.total_areas > 0)
+
+    def test_steps_and_times(self, radii: np.ndarray) -> None:
+        """Test steps and times arrays."""
+        result = compute_sasa_trajectory(XTC_FILE, radii)
+
+        assert len(result.steps) == 38
+        assert len(result.times) == 38
+
+    def test_frame_range(self, radii: np.ndarray) -> None:
+        """Test processing subset of frames."""
+        # Process only frames 5-15
+        result = compute_sasa_trajectory(XTC_FILE, radii, start=5, stop=15)
+
+        assert result.n_frames == 10
+
+    def test_frame_step(self, radii: np.ndarray) -> None:
+        """Test processing every Nth frame."""
+        # Process every 5th frame
+        result = compute_sasa_trajectory(XTC_FILE, radii, step=5)
+
+        # 38 frames, every 5th = frames 0, 5, 10, 15, 20, 25, 30, 35 = 8 frames
+        assert result.n_frames == 8
+
+    def test_algorithms(self, radii: np.ndarray) -> None:
+        """Test different algorithms give similar results."""
+        result_sr = compute_sasa_trajectory(XTC_FILE, radii, algorithm="sr", n_points=500)
+        result_lr = compute_sasa_trajectory(XTC_FILE, radii, algorithm="lr", n_slices=50)
+
+        # Results should be similar (within 5%)
+        np.testing.assert_allclose(
+            result_sr.total_areas,
+            result_lr.total_areas,
+            rtol=0.05,
+        )
+
+    def test_radii_length_mismatch(self) -> None:
+        """Test that mismatched radii length raises error."""
+        wrong_radii = np.full(100, 1.7, dtype=np.float32)  # Wrong length
+
+        with pytest.raises(ValueError, match="radii length"):
+            compute_sasa_trajectory(XTC_FILE, wrong_radii)
+
+    def test_threading(self, radii: np.ndarray) -> None:
+        """Test that threading doesn't affect results."""
+        result_1 = compute_sasa_trajectory(XTC_FILE, radii, n_threads=1)
+        result_4 = compute_sasa_trajectory(XTC_FILE, radii, n_threads=4)
+
+        np.testing.assert_array_almost_equal(
+            result_1.atom_areas,
+            result_4.atom_areas,
+            decimal=4,
+        )
+
+
+class TestXtcReaderClosed:
+    """Test behavior with closed reader."""
+
+    def test_read_after_close_raises(self) -> None:
+        """Test that reading after close raises error."""
+        reader = XtcReader(XTC_FILE)
+        reader.close()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            reader.read_frame()
+
+    def test_double_close_safe(self) -> None:
+        """Test that closing twice is safe."""
+        reader = XtcReader(XTC_FILE)
+        reader.close()
+        reader.close()  # Should not raise
+
+
+class TestXtcCoordinateUnits:
+    """Test coordinate unit handling."""
+
+    def test_coords_in_nanometers(self) -> None:
+        """Test that coordinates are in nanometers."""
+        with XtcReader(XTC_FILE) as reader:
+            frame = reader.read_frame()
+            assert frame is not None
+
+            # 1l2y is a small protein, coordinates should be in nm range
+            # (roughly -1 to +1.5 nm for this protein)
+            assert np.all(frame.coords > -5)  # No coordinate > 5 nm away
+            assert np.all(frame.coords < 5)
+
+    def test_sasa_result_in_angstrom_squared(self) -> None:
+        """Test that SASA output is in Å²."""
+        radii = np.full(304, 1.7, dtype=np.float32)
+        result = compute_sasa_trajectory(XTC_FILE, radii)
+
+        # Total SASA for a small protein should be ~5000-10000 Å²
+        # If it were nm², it would be ~50-100
+        assert np.all(result.total_areas > 100)  # Must be in Å²
+        assert np.all(result.total_areas < 50000)  # Reasonable upper bound
+
+
+class TestRepr:
+    """Test string representations."""
+
+    def test_trajectory_sasa_result_repr(self) -> None:
+        """Test TrajectorySasaResult repr."""
+        radii = np.full(304, 1.7, dtype=np.float32)
+        result = compute_sasa_trajectory(XTC_FILE, radii, stop=5)
+
+        repr_str = repr(result)
+        assert "TrajectorySasaResult" in repr_str
+        assert "n_frames=5" in repr_str
+        assert "n_atoms=304" in repr_str

--- a/python/zsasa/__init__.py
+++ b/python/zsasa/__init__.py
@@ -57,6 +57,19 @@ MDAnalysis Integration:
     >>> sasa = SASAAnalysis(u, select='protein')
     >>> sasa.run()
     >>> print(sasa.results.total_area)  # Returns per-frame SASA in Å²
+
+Native XTC Reader:
+    For standalone XTC reading without MDTraj/MDAnalysis dependencies:
+
+    >>> from zsasa.xtc import XtcReader, compute_sasa_trajectory
+    >>> # Low-level reader API
+    >>> with XtcReader("trajectory.xtc") as reader:
+    ...     for frame in reader:
+    ...         print(f"Step {frame.step}")
+    >>>
+    >>> # High-level SASA calculation (radii from topology)
+    >>> result = compute_sasa_trajectory("trajectory.xtc", radii)
+    >>> print(result.total_areas)  # Per-frame SASA in Å²
 """
 
 from zsasa.analysis import (

--- a/python/zsasa/core.py
+++ b/python/zsasa/core.py
@@ -94,6 +94,19 @@ _CDEF = """
         const double* sasas, const char** residue_names, size_t n_residues,
         double* rsa_out
     );
+
+    // XTC trajectory reader
+    void* zsasa_xtc_open(const char* path, int* natoms_out, int* error_code);
+    void zsasa_xtc_close(void* handle);
+    int zsasa_xtc_read_frame(
+        void* handle,
+        float* coords_out,
+        int* step_out,
+        float* time_out,
+        float* box_out,
+        float* precision_out
+    );
+    int zsasa_xtc_get_natoms(void* handle);
 """
 
 

--- a/python/zsasa/xtc.py
+++ b/python/zsasa/xtc.py
@@ -1,0 +1,376 @@
+"""Native XTC trajectory reader using zsasa's high-performance Zig implementation.
+
+This module provides a standalone XTC reader that doesn't require MDTraj or MDAnalysis,
+using zsasa's native Zig XTC implementation for potentially better performance.
+
+Example:
+    >>> from zsasa.xtc import XtcReader, compute_sasa_trajectory
+    >>>
+    >>> # Low-level reader API
+    >>> with XtcReader("trajectory.xtc") as reader:
+    ...     for frame in reader:
+    ...         print(f"Step {frame.step}, {frame.natoms} atoms")
+    >>>
+    >>> # High-level SASA calculation
+    >>> from zsasa.xtc import compute_sasa_trajectory
+    >>> result = compute_sasa_trajectory(
+    ...     "trajectory.xtc",
+    ...     "topology.pdb",  # for radii
+    ... )
+    >>> print(result.total_areas)  # Per-frame total SASA
+
+Note:
+    Coordinates are returned in nanometers (nm), matching GROMACS convention.
+    For SASA calculation, coordinates are automatically converted to Angstroms.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from zsasa.core import _get_lib, calculate_sasa_batch
+
+if TYPE_CHECKING:
+    from cffi import FFI
+
+
+# Error codes from C API
+_ZSASA_OK = 0
+_ZSASA_XTC_END_OF_FILE = 1
+_ZSASA_ERROR_INVALID_INPUT = -1
+_ZSASA_ERROR_OUT_OF_MEMORY = -2
+
+
+@dataclass
+class XtcFrame:
+    """A single frame from an XTC trajectory.
+
+    Attributes:
+        step: Simulation step number.
+        time: Simulation time in ps.
+        coords: Atom coordinates as (n_atoms, 3) array in nanometers.
+        box: Simulation box as 3x3 matrix in nanometers.
+        precision: Compression precision.
+    """
+
+    step: int
+    time: float
+    coords: NDArray[np.float32]
+    box: NDArray[np.float32]
+    precision: float
+
+    @property
+    def natoms(self) -> int:
+        """Number of atoms."""
+        return self.coords.shape[0]
+
+
+class XtcReader:
+    """Native XTC trajectory reader.
+
+    This reader uses zsasa's high-performance Zig XTC implementation,
+    providing a standalone alternative to MDTraj/MDAnalysis for reading
+    XTC files.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to XTC trajectory file.
+
+    Attributes
+    ----------
+    natoms : int
+        Number of atoms in the trajectory.
+
+    Example
+    -------
+    >>> with XtcReader("trajectory.xtc") as reader:
+    ...     print(f"Trajectory has {reader.natoms} atoms")
+    ...     for frame in reader:
+    ...         print(f"Step {frame.step}: {frame.coords.shape}")
+
+    >>> # Or without context manager (remember to close!)
+    >>> reader = XtcReader("trajectory.xtc")
+    >>> frame = reader.read_frame()
+    >>> reader.close()
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        """Open an XTC file for reading."""
+        self._ffi: FFI
+        self._lib: object
+        self._ffi, self._lib = _get_lib()
+
+        self._path = str(path)
+        self._handle = None
+        self._natoms = 0
+        self._closed = False
+
+        # Open the file
+        natoms_out = self._ffi.new("int*")
+        error_code = self._ffi.new("int*")
+
+        self._handle = self._lib.zsasa_xtc_open(
+            self._path.encode("utf-8"),
+            natoms_out,
+            error_code,
+        )
+
+        if self._handle == self._ffi.NULL:
+            if error_code[0] == _ZSASA_ERROR_INVALID_INPUT:
+                msg = f"Cannot open XTC file: {self._path}"
+                raise FileNotFoundError(msg)
+            elif error_code[0] == _ZSASA_ERROR_OUT_OF_MEMORY:
+                msg = "Out of memory opening XTC file"
+                raise MemoryError(msg)
+            else:
+                msg = f"Error opening XTC file: {error_code[0]}"
+                raise RuntimeError(msg)
+
+        self._natoms = natoms_out[0]
+
+        # Pre-allocate buffers for reading frames
+        self._coords_buffer = np.zeros(self._natoms * 3, dtype=np.float32)
+        self._box_buffer = np.zeros(9, dtype=np.float32)
+
+    @property
+    def natoms(self) -> int:
+        """Number of atoms in the trajectory."""
+        return self._natoms
+
+    def read_frame(self) -> XtcFrame | None:
+        """Read the next frame from the trajectory.
+
+        Returns
+        -------
+        XtcFrame or None
+            The next frame, or None if end of file is reached.
+
+        Raises
+        ------
+        RuntimeError
+            If an error occurs during reading.
+        """
+        if self._closed:
+            msg = "XtcReader is closed"
+            raise RuntimeError(msg)
+
+        step = self._ffi.new("int*")
+        time = self._ffi.new("float*")
+        precision = self._ffi.new("float*")
+
+        coords_ptr = self._ffi.cast("float*", self._coords_buffer.ctypes.data)
+        box_ptr = self._ffi.cast("float*", self._box_buffer.ctypes.data)
+
+        result = self._lib.zsasa_xtc_read_frame(
+            self._handle,
+            coords_ptr,
+            step,
+            time,
+            box_ptr,
+            precision,
+        )
+
+        if result == _ZSASA_XTC_END_OF_FILE:
+            return None
+        elif result != _ZSASA_OK:
+            msg = f"Error reading XTC frame: {result}"
+            raise RuntimeError(msg)
+
+        # Copy buffers to new arrays (so they're independent of the reader)
+        coords = self._coords_buffer.copy().reshape(self._natoms, 3)
+        box = self._box_buffer.copy().reshape(3, 3)
+
+        return XtcFrame(
+            step=step[0],
+            time=time[0],
+            coords=coords,
+            box=box,
+            precision=precision[0],
+        )
+
+    def __iter__(self) -> Iterator[XtcFrame]:
+        """Iterate over all frames in the trajectory."""
+        while True:
+            frame = self.read_frame()
+            if frame is None:
+                break
+            yield frame
+
+    def __enter__(self) -> XtcReader:
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        """Context manager exit."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the XTC file and release resources."""
+        if not self._closed and self._handle is not None:
+            self._lib.zsasa_xtc_close(self._handle)
+            self._handle = None
+            self._closed = True
+
+    def __del__(self) -> None:
+        """Destructor - ensure file is closed."""
+        self.close()
+
+
+@dataclass
+class TrajectorySasaResult:
+    """Result of trajectory SASA calculation.
+
+    Attributes:
+        atom_areas: Per-atom SASA for all frames, shape (n_frames, n_atoms) in Å².
+        steps: Step numbers for each frame.
+        times: Time values for each frame in ps.
+    """
+
+    atom_areas: NDArray[np.float32]
+    steps: NDArray[np.int32]
+    times: NDArray[np.float32]
+
+    @property
+    def n_frames(self) -> int:
+        """Number of frames."""
+        return self.atom_areas.shape[0]
+
+    @property
+    def n_atoms(self) -> int:
+        """Number of atoms."""
+        return self.atom_areas.shape[1]
+
+    @property
+    def total_areas(self) -> NDArray[np.float32]:
+        """Total SASA per frame, shape (n_frames,)."""
+        return self.atom_areas.sum(axis=1)
+
+    def __repr__(self) -> str:
+        return f"TrajectorySasaResult(n_frames={self.n_frames}, n_atoms={self.n_atoms})"
+
+
+def compute_sasa_trajectory(
+    xtc_path: str | Path,
+    radii: NDArray[np.floating] | list[float],
+    *,
+    probe_radius: float = 1.4,
+    n_points: int = 100,
+    algorithm: Literal["sr", "lr"] = "sr",
+    n_slices: int = 20,
+    n_threads: int = 0,
+    start: int = 0,
+    stop: int | None = None,
+    step: int = 1,
+) -> TrajectorySasaResult:
+    """Compute SASA for an XTC trajectory using native Zig reader.
+
+    This function reads an XTC file directly using zsasa's native Zig XTC reader,
+    without requiring MDTraj or MDAnalysis.
+
+    Parameters
+    ----------
+    xtc_path : str or Path
+        Path to XTC trajectory file.
+    radii : array-like
+        Atomic radii in Angstroms, shape (n_atoms,).
+        Must match the number of atoms in the trajectory.
+    probe_radius : float, optional
+        Water probe radius in Angstroms. Default: 1.4.
+    n_points : int, optional
+        Number of test points per atom (SR algorithm). Default: 100.
+    algorithm : {"sr", "lr"}, optional
+        Algorithm: "sr" (Shrake-Rupley) or "lr" (Lee-Richards). Default: "sr".
+    n_slices : int, optional
+        Number of slices per atom (LR algorithm). Default: 20.
+    n_threads : int, optional
+        Number of threads (0 = auto-detect). Default: 0.
+    start : int, optional
+        First frame to process (0-indexed). Default: 0.
+    stop : int, optional
+        Stop before this frame (exclusive). Default: None (all frames).
+    step : int, optional
+        Process every Nth frame. Default: 1.
+
+    Returns
+    -------
+    TrajectorySasaResult
+        Result containing per-atom SASA values for all frames.
+
+    Note
+    ----
+    XTC coordinates are in nanometers. This function automatically converts
+    them to Angstroms (x10) for SASA calculation. Output SASA values are in Å².
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> from zsasa.xtc import compute_sasa_trajectory
+    >>>
+    >>> # Define radii for each atom (e.g., from a topology file)
+    >>> radii = np.array([1.7, 1.55, 1.52, ...])  # Carbon, Nitrogen, Oxygen, etc.
+    >>>
+    >>> result = compute_sasa_trajectory("trajectory.xtc", radii)
+    >>> print(f"Processed {result.n_frames} frames")
+    >>> print(f"Total SASA: {result.total_areas}")
+    """
+    radii = np.asarray(radii, dtype=np.float32)
+
+    # Read all frames first (to know total count and validate radii)
+    frames: list[XtcFrame] = []
+    steps: list[int] = []
+    times: list[float] = []
+
+    with XtcReader(xtc_path) as reader:
+        # Validate radii length
+        if len(radii) != reader.natoms:
+            msg = f"radii length ({len(radii)}) doesn't match trajectory atoms ({reader.natoms})"
+            raise ValueError(msg)
+
+        frame_idx = 0
+        for frame in reader:
+            # Check if this frame should be processed
+            if frame_idx < start:
+                frame_idx += 1
+                continue
+            if stop is not None and frame_idx >= stop:
+                break
+            if (frame_idx - start) % step != 0:
+                frame_idx += 1
+                continue
+
+            frames.append(frame)
+            steps.append(frame.step)
+            times.append(frame.time)
+            frame_idx += 1
+
+    if not frames:
+        msg = "No frames to process"
+        raise ValueError(msg)
+
+    # Stack coordinates: (n_frames, n_atoms, 3) and convert nm -> Angstrom
+    coords = np.stack([f.coords for f in frames], axis=0)
+    coords_angstrom = coords * 10.0  # nm -> Angstrom
+
+    # Calculate SASA using batch API
+    result = calculate_sasa_batch(
+        coords_angstrom,
+        radii,
+        algorithm=algorithm,
+        n_points=n_points,
+        n_slices=n_slices,
+        probe_radius=probe_radius,
+        n_threads=n_threads,
+    )
+
+    return TrajectorySasaResult(
+        atom_areas=result.atom_areas,
+        steps=np.array(steps, dtype=np.int32),
+        times=np.array(times, dtype=np.float32),
+    )

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -12,6 +12,7 @@ const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_protor = @import("classifier_protor.zig");
 const classifier_oons = @import("classifier_oons.zig");
 const analysis = @import("analysis.zig");
+const xtc = @import("xtc.zig");
 
 const AtomInput = types.AtomInput;
 const Config = types.Config;
@@ -935,6 +936,144 @@ export fn zsasa_calculate_rsa_batch(
     return ZSASA_OK;
 }
 
+// =============================================================================
+// XTC Trajectory Reader Functions
+// =============================================================================
+
+/// Error code: End of file reached
+pub const ZSASA_XTC_END_OF_FILE: c_int = 1;
+
+/// XTC reader handle (opaque pointer to internal struct)
+const XtcHandle = struct {
+    reader: xtc.XtcReader,
+};
+
+/// Open an XTC trajectory file.
+///
+/// Parameters:
+///   path: Path to XTC file (null-terminated string)
+///   natoms_out: Output pointer for number of atoms (set on success)
+///   error_code: Output pointer for error code (set on failure)
+///
+/// Returns:
+///   Opaque handle on success, null on failure.
+///   Caller must call zsasa_xtc_close() to free resources.
+export fn zsasa_xtc_open(
+    path: [*:0]const u8,
+    natoms_out: *i32,
+    error_code: *c_int,
+) callconv(.c) ?*anyopaque {
+    const path_slice = std.mem.span(path);
+
+    const handle = c_allocator.create(XtcHandle) catch {
+        error_code.* = ZSASA_ERROR_OUT_OF_MEMORY;
+        return null;
+    };
+
+    handle.reader = xtc.XtcReader.open(c_allocator, path_slice) catch |err| {
+        c_allocator.destroy(handle);
+        error_code.* = switch (err) {
+            xtc.XtcError.FileNotFound => ZSASA_ERROR_INVALID_INPUT,
+            xtc.XtcError.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
+            xtc.XtcError.OutOfMemory => ZSASA_ERROR_OUT_OF_MEMORY,
+            else => ZSASA_ERROR_CALCULATION,
+        };
+        return null;
+    };
+
+    natoms_out.* = handle.reader.getNumAtoms();
+    error_code.* = ZSASA_OK;
+    return handle;
+}
+
+/// Close an XTC trajectory file and free resources.
+///
+/// Parameters:
+///   handle: Handle returned by zsasa_xtc_open()
+export fn zsasa_xtc_close(
+    handle: ?*anyopaque,
+) callconv(.c) void {
+    if (handle) |h| {
+        const xtc_handle: *XtcHandle = @ptrCast(@alignCast(h));
+        xtc_handle.reader.close();
+        c_allocator.destroy(xtc_handle);
+    }
+}
+
+/// Read the next frame from an XTC trajectory.
+///
+/// Parameters:
+///   handle: Handle returned by zsasa_xtc_open()
+///   coords_out: Output buffer for coordinates (natoms * 3 floats, in nm)
+///   step_out: Output pointer for step number
+///   time_out: Output pointer for frame time
+///   box_out: Output buffer for box matrix (9 floats, row-major 3x3)
+///   precision_out: Output pointer for precision value
+///
+/// Returns:
+///   ZSASA_OK (0) on success
+///   ZSASA_XTC_END_OF_FILE (1) when no more frames
+///   Negative error code on failure
+export fn zsasa_xtc_read_frame(
+    handle: ?*anyopaque,
+    coords_out: [*]f32,
+    step_out: *i32,
+    time_out: *f32,
+    box_out: [*]f32,
+    precision_out: *f32,
+) callconv(.c) c_int {
+    if (handle == null) {
+        return ZSASA_ERROR_INVALID_INPUT;
+    }
+
+    const xtc_handle: *XtcHandle = @ptrCast(@alignCast(handle.?));
+
+    var frame = xtc_handle.reader.readFrame() catch |err| {
+        return switch (err) {
+            xtc.XtcError.EndOfFile => ZSASA_XTC_END_OF_FILE,
+            xtc.XtcError.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
+            xtc.XtcError.DecompressionError => ZSASA_ERROR_CALCULATION,
+            else => ZSASA_ERROR_CALCULATION,
+        };
+    };
+    defer frame.deinit(c_allocator);
+
+    // Copy step, time, precision
+    step_out.* = frame.step;
+    time_out.* = frame.time;
+    precision_out.* = frame.precision;
+
+    // Copy box (3x3 matrix, row-major)
+    for (0..3) |i| {
+        for (0..3) |j| {
+            box_out[i * 3 + j] = frame.box[i][j];
+        }
+    }
+
+    // Copy coordinates
+    const natoms: usize = @intCast(xtc_handle.reader.getNumAtoms());
+    @memcpy(coords_out[0 .. natoms * 3], frame.coords);
+
+    return ZSASA_OK;
+}
+
+/// Get the number of atoms in an opened XTC file.
+///
+/// Parameters:
+///   handle: Handle returned by zsasa_xtc_open()
+///
+/// Returns:
+///   Number of atoms, or -1 if handle is invalid
+export fn zsasa_xtc_get_natoms(
+    handle: ?*anyopaque,
+) callconv(.c) i32 {
+    if (handle == null) {
+        return -1;
+    }
+    const xtc_handle: *XtcHandle = @ptrCast(@alignCast(handle.?));
+    return xtc_handle.reader.getNumAtoms();
+}
+
 // Tests
 test "zsasa_version returns valid string" {
     const version = zsasa_version();
@@ -1240,4 +1379,104 @@ test "zsasa_calculate_rsa_batch with unknown" {
     try std.testing.expectEqual(ZSASA_OK, result);
     try std.testing.expectApproxEqAbs(0.5, rsa_out[0], 0.001); // ALA: known
     try std.testing.expect(std.math.isNan(rsa_out[1])); // HOH: unknown
+}
+
+// =============================================================================
+// XTC Reader Tests
+// =============================================================================
+
+test "zsasa_xtc_open and close" {
+    var natoms: i32 = 0;
+    var error_code: c_int = 0;
+
+    const handle = zsasa_xtc_open("test_data/1l2y.xtc", &natoms, &error_code);
+    try std.testing.expect(handle != null);
+    try std.testing.expectEqual(ZSASA_OK, error_code);
+    try std.testing.expectEqual(@as(i32, 304), natoms);
+
+    // Get natoms via function
+    try std.testing.expectEqual(@as(i32, 304), zsasa_xtc_get_natoms(handle));
+
+    zsasa_xtc_close(handle);
+}
+
+test "zsasa_xtc_open invalid file" {
+    var natoms: i32 = 0;
+    var error_code: c_int = 0;
+
+    const handle = zsasa_xtc_open("nonexistent.xtc", &natoms, &error_code);
+    try std.testing.expect(handle == null);
+    try std.testing.expectEqual(ZSASA_ERROR_INVALID_INPUT, error_code);
+}
+
+test "zsasa_xtc_read_frame" {
+    var natoms: i32 = 0;
+    var error_code: c_int = 0;
+
+    const handle = zsasa_xtc_open("test_data/1l2y.xtc", &natoms, &error_code);
+    try std.testing.expect(handle != null);
+    defer zsasa_xtc_close(handle);
+
+    // Allocate buffers
+    const natoms_u: usize = @intCast(natoms);
+    const coords = c_allocator.alloc(f32, natoms_u * 3) catch unreachable;
+    defer c_allocator.free(coords);
+    var box: [9]f32 = undefined;
+    var step: i32 = 0;
+    var time: f32 = 0;
+    var precision: f32 = 0;
+
+    // Read first frame
+    const result = zsasa_xtc_read_frame(handle, coords.ptr, &step, &time, &box, &precision);
+    try std.testing.expectEqual(ZSASA_OK, result);
+    try std.testing.expectEqual(@as(i32, 1), step);
+
+    // Check first atom coordinates (in nm)
+    const tolerance: f32 = 0.0001;
+    try std.testing.expectApproxEqAbs(@as(f32, -0.8901), coords[0], tolerance);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.4127), coords[1], tolerance);
+    try std.testing.expectApproxEqAbs(@as(f32, -0.0555), coords[2], tolerance);
+}
+
+test "zsasa_xtc_read_all_frames" {
+    var natoms: i32 = 0;
+    var error_code: c_int = 0;
+
+    const handle = zsasa_xtc_open("test_data/1l2y.xtc", &natoms, &error_code);
+    try std.testing.expect(handle != null);
+    defer zsasa_xtc_close(handle);
+
+    const natoms_u: usize = @intCast(natoms);
+    const coords = c_allocator.alloc(f32, natoms_u * 3) catch unreachable;
+    defer c_allocator.free(coords);
+    var box: [9]f32 = undefined;
+    var step: i32 = 0;
+    var time: f32 = 0;
+    var precision: f32 = 0;
+
+    var frame_count: usize = 0;
+    while (true) {
+        const result = zsasa_xtc_read_frame(handle, coords.ptr, &step, &time, &box, &precision);
+        if (result == ZSASA_XTC_END_OF_FILE) break;
+        try std.testing.expectEqual(ZSASA_OK, result);
+        frame_count += 1;
+    }
+
+    // 1l2y.xtc has 38 frames
+    try std.testing.expectEqual(@as(usize, 38), frame_count);
+}
+
+test "zsasa_xtc_get_natoms null handle" {
+    try std.testing.expectEqual(@as(i32, -1), zsasa_xtc_get_natoms(null));
+}
+
+test "zsasa_xtc_read_frame null handle" {
+    var coords: [3]f32 = undefined;
+    var box: [9]f32 = undefined;
+    var step: i32 = 0;
+    var time: f32 = 0;
+    var precision: f32 = 0;
+
+    const result = zsasa_xtc_read_frame(null, &coords, &step, &time, &box, &precision);
+    try std.testing.expectEqual(ZSASA_ERROR_INVALID_INPUT, result);
 }


### PR DESCRIPTION
## Summary

- Expose zsasa's high-performance Zig XTC reader to Python via C API
- Create `zsasa.xtc` module with standalone XTC reading capability
- No MDTraj/MDAnalysis dependencies required

## Changes

### Zig C API (`src/c_api.zig`)
- Add `zsasa_xtc_open()`, `zsasa_xtc_close()`, `zsasa_xtc_read_frame()`
- Add `ZSASA_XTC_END_OF_FILE` error code

### Python (`python/zsasa/xtc.py`)
- `XtcReader` class with context manager and iterator support
- `XtcFrame` dataclass for frame data
- `compute_sasa_trajectory()` for high-level SASA calculation
- `TrajectorySasaResult` for trajectory results
- Auto-converts nm → Å for SASA calculation

### Documentation
- Add `docs/python-api/xtc.md` with full API reference
- Update `docs/python-api/README.md` with examples

## Usage

```python
from zsasa.xtc import XtcReader, compute_sasa_trajectory

# Low-level reader API
with XtcReader("trajectory.xtc") as reader:
    for frame in reader:
        print(f"Step {frame.step}: {frame.natoms} atoms")

# High-level SASA calculation
import numpy as np
radii = np.full(304, 1.7)  # Atomic radii in Angstroms
result = compute_sasa_trajectory("trajectory.xtc", radii)
print(f"Total SASA: {result.total_areas}")
```

## Test plan

- [x] All 21 new XTC tests pass
- [x] All 237 Python tests pass
- [x] Lint checks pass (`ruff check zsasa/`)