### PR TITLE
chore: Add E. coli proteome benchmark scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,17 @@ benchmarks/dataset/
 # Benchmark samples (large files)
 benchmarks/samples/
 
+# E. coli proteome dataset (AlphaFold structures)
+benchmarks/UP000000625_83333_ECOLI_v6/
+
+# E. coli benchmark temp files
+benchmarks/ecoli_bench/temp_out/
+benchmarks/ecoli_bench/results/
+benchmarks/ecoli_bench/sasa_batch
+
+# XTC reader cache files
+test_data/.*.xtc_offsets.*
+
 # Archived plans
 plans/archive/
 

--- a/benchmarks/ecoli_bench/README.md
+++ b/benchmarks/ecoli_bench/README.md
@@ -1,0 +1,57 @@
+# E. coli Proteome Benchmark
+
+RustSASA論文との比較用ベンチマーク。
+
+## Dataset
+
+- Source: AlphaFold E. coli proteome (UP000000625_83333_ECOLI_v6)
+- Structures: 4,370
+- Total atoms: 10,520,167
+- Atom range: 122 - 17,331
+
+## Quick Start
+
+```bash
+# 1. Run benchmark (single tool)
+./benchmarks/scripts/run.py \
+  --tool zig --algorithm sr \
+  --input-dir benchmarks/UP000000625_83333_ECOLI_v6/json \
+  --output-dir benchmarks/results/ecoli/zig_sr_f64 \
+  --threads 1,2,4,8,10 --runs 10
+
+# 2. Run all tools
+./benchmarks/ecoli_bench/run_all.sh
+
+# 3. Analyze results
+./benchmarks/scripts/analyze.py summary \
+  --config benchmarks/results/ecoli/config.yaml
+```
+
+## Methodology Improvements over RustSASA
+
+| Aspect | RustSASA | This Benchmark |
+|--------|----------|----------------|
+| Parallelization | GNU parallel (process overhead) | Native threading |
+| Warmup | 3 | 5 |
+| Runs | 3 | 10 |
+| Timing | Total proteome only | Per-structure SASA time |
+| Analysis | None | Size-stratified speedup |
+
+## Directory Structure
+
+```
+benchmarks/
+├── UP000000625_83333_ECOLI_v6/
+│   ├── pdb/         # Original PDB (4370)
+│   ├── cif/         # Original CIF (4370)
+│   └── json/        # Converted JSON.gz (4370)
+├── ecoli_bench/
+│   ├── README.md    # This file
+│   ├── run_all.sh   # Run all benchmarks
+│   └── config.yaml  # (in results/ecoli/)
+└── results/ecoli/
+    ├── config.yaml
+    ├── zig_sr_f64/
+    ├── freesasa_sr/
+    └── rust_sr/
+```

--- a/benchmarks/ecoli_bench/benchmark.sh
+++ b/benchmarks/ecoli_bench/benchmark.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# E. coli Proteome Benchmark (RustSASA-style)
+#
+# All tools use PDB input for fair comparison.
+# Methodology matches RustSASA paper: hyperfine, warmup 3, runs 3
+#
+# Usage:
+#   ./benchmark.sh              # Run all
+#   ./benchmark.sh --tool zig   # Run specific tool
+#   ./benchmark.sh --dry-run    # Show commands only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Input: PDB files
+ECOLI_PDB="$ROOT_DIR/benchmarks/UP000000625_83333_ECOLI_v6/pdb"
+
+# Output
+RESULTS_DIR="$SCRIPT_DIR/results"
+TEMP_OUT="$SCRIPT_DIR/temp_out"
+
+# Binaries
+ZSASA="$ROOT_DIR/zig-out/bin/zsasa"
+FREESASA_BATCH="$SCRIPT_DIR/sasa_batch"
+RUSTSASA="$ROOT_DIR/benchmarks/external/rustsasa-bench/target/release/rust-sasa"
+
+# Parameters (RustSASA paper: warmup 3, runs 3)
+WARMUP=3
+RUNS=3
+THREADS=8
+
+# Parse args
+TOOL=""
+DRY_RUN=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tool|-t) TOOL="$2"; shift 2 ;;
+        --threads|-T) THREADS="$2"; shift 2 ;;
+        --warmup) WARMUP="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        *) echo "Unknown: $1"; exit 1 ;;
+    esac
+done
+
+echo "=== E. coli Proteome Benchmark ==="
+echo "Input: $ECOLI_PDB (PDB)"
+echo "Warmup: $WARMUP, Runs: $RUNS, Threads: $THREADS"
+echo ""
+
+mkdir -p "$RESULTS_DIR" "$TEMP_OUT"
+
+run_bench() {
+    local name="$1"
+    local cmd="$2"
+    local json_out="$RESULTS_DIR/bench_${name}.json"
+
+    echo ">>> $name"
+    if [[ -n "$DRY_RUN" ]]; then
+        echo "    $cmd"
+        return
+    fi
+
+    # Note: Each tool clears its own output directory before running
+    hyperfine --warmup "$WARMUP" --runs "$RUNS" --export-json "$json_out" "$cmd"
+    echo ""
+}
+
+# === zsasa ===
+run_zig() {
+    [[ -x "$ZSASA" ]] || { echo "[SKIP] zsasa not found"; return; }
+
+    local out_dir="$TEMP_OUT/zig"
+    rm -rf "$out_dir" && mkdir -p "$out_dir"
+
+    # f64 (default, double precision)
+    run_bench "zsasa_f64_${THREADS}t" \
+        "$ZSASA $ECOLI_PDB $out_dir --threads=$THREADS --parallelism=file --precision=f64"
+
+    run_bench "zsasa_f64_1t" \
+        "$ZSASA $ECOLI_PDB $out_dir --threads=1 --precision=f64"
+
+    # f32 (single precision)
+    run_bench "zsasa_f32_${THREADS}t" \
+        "$ZSASA $ECOLI_PDB $out_dir --threads=$THREADS --parallelism=file --precision=f32"
+
+    run_bench "zsasa_f32_1t" \
+        "$ZSASA $ECOLI_PDB $out_dir --threads=1 --precision=f32"
+}
+
+# === FreeSASA (sasa_batch, single-threaded) ===
+run_freesasa() {
+    [[ -x "$FREESASA_BATCH" ]] || { echo "[SKIP] sasa_batch not found"; return; }
+
+    local out_dir="$TEMP_OUT/freesasa"
+    rm -rf "$out_dir" && mkdir -p "$out_dir"
+
+    run_bench "freesasa_1t" \
+        "$FREESASA_BATCH $ECOLI_PDB $out_dir"
+}
+
+# === RustSASA ===
+run_rustsasa() {
+    [[ -x "$RUSTSASA" ]] || { echo "[SKIP] RustSASA not found"; return; }
+
+    local out_dir="$TEMP_OUT/rustsasa"
+    rm -rf "$out_dir" && mkdir -p "$out_dir"
+
+    run_bench "rustsasa_${THREADS}t" \
+        "$RUSTSASA $ECOLI_PDB $out_dir --format json -t $THREADS"
+
+    run_bench "rustsasa_1t" \
+        "$RUSTSASA $ECOLI_PDB $out_dir --format json -t 1"
+}
+
+# === Main ===
+case "${TOOL:-all}" in
+    zig|zsasa) run_zig ;;
+    freesasa) run_freesasa ;;
+    rust|rustsasa) run_rustsasa ;;
+    all) run_zig; run_freesasa; run_rustsasa ;;
+    *) echo "Unknown tool: $TOOL"; exit 1 ;;
+esac
+
+echo "=== Done! Results: $RESULTS_DIR ==="
+
+# Summary
+if [[ -z "$DRY_RUN" ]]; then
+    echo ""
+    for f in "$RESULTS_DIR"/bench_*.json; do
+        [[ -f "$f" ]] || continue
+        name=$(basename "$f" .json | sed 's/bench_//')
+        mean=$(jq -r '.results[0].mean' "$f" 2>/dev/null || echo "N/A")
+        stddev=$(jq -r '.results[0].stddev' "$f" 2>/dev/null || echo "N/A")
+        [[ "$mean" != "N/A" ]] && printf "  %-20s %8.3f s (± %.3f)\n" "$name" "$mean" "$stddev"
+    done
+fi

--- a/benchmarks/ecoli_bench/run_all.sh
+++ b/benchmarks/ecoli_bench/run_all.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# E. coli proteome benchmark runner
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+INPUT_DIR="$ROOT_DIR/benchmarks/UP000000625_83333_ECOLI_v6/json"
+OUTPUT_BASE="$ROOT_DIR/benchmarks/results/ecoli"
+RUN_SCRIPT="$ROOT_DIR/benchmarks/scripts/run.py"
+
+THREADS="1,2,4,8,10"
+RUNS=10
+
+# Parse arguments
+TOOLS="zig,freesasa,rust"
+ALGORITHM="sr"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tools)
+            TOOLS="$2"
+            shift 2
+            ;;
+        --algorithm)
+            ALGORITHM="$2"
+            shift 2
+            ;;
+        --threads)
+            THREADS="$2"
+            shift 2
+            ;;
+        --runs)
+            RUNS="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo "E. coli Proteome Benchmark"
+echo "=========================="
+echo "Input: $INPUT_DIR"
+echo "Output: $OUTPUT_BASE"
+echo "Tools: $TOOLS"
+echo "Algorithm: $ALGORITHM"
+echo "Threads: $THREADS"
+echo "Runs: $RUNS"
+echo ""
+
+mkdir -p "$OUTPUT_BASE"
+
+IFS=',' read -ra TOOL_ARRAY <<< "$TOOLS"
+for tool in "${TOOL_ARRAY[@]}"; do
+    # Skip rust for LR (not supported)
+    if [[ "$tool" == "rust" && "$ALGORITHM" == "lr" ]]; then
+        echo "Skipping rust (LR not supported)"
+        continue
+    fi
+
+    output_dir="$OUTPUT_BASE/${tool}_${ALGORITHM}"
+
+    # Add precision suffix for zig
+    if [[ "$tool" == "zig" ]]; then
+        output_dir="${output_dir}_f64"
+    fi
+
+    echo "Running: $tool $ALGORITHM -> $output_dir"
+
+    cmd="$RUN_SCRIPT \
+        --tool $tool \
+        --algorithm $ALGORITHM \
+        --input-dir $INPUT_DIR \
+        --output-dir $output_dir \
+        --threads $THREADS \
+        --runs $RUNS"
+
+    if [[ -n "${DRY_RUN:-}" ]]; then
+        echo "  [dry-run] $cmd"
+    else
+        $cmd
+    fi
+
+    echo ""
+done
+
+echo "Done! Results saved to: $OUTPUT_BASE"

--- a/benchmarks/ecoli_bench/sasa_batch.cpp
+++ b/benchmarks/ecoli_bench/sasa_batch.cpp
@@ -1,0 +1,93 @@
+// sasa_batch.cpp
+// Batch process CIF/PDB files with FreeSASA C API
+//
+// Usage: sasa_batch <input_folder> <output_folder>
+// Compile: g++ -std=c++17 -O2 -o sasa_batch sasa_batch.cpp -lfreesasa -ljson-c -lxml2
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include <freesasa.h>
+}
+
+namespace fs = std::filesystem;
+
+bool has_structure_extension(const fs::path& path) {
+    std::string ext = path.extension().string();
+    for (char& c : ext) c = std::tolower(c);
+    return ext == ".pdb" || ext == ".cif";
+}
+
+std::vector<fs::path> find_structure_files(const fs::path& dir) {
+    std::vector<fs::path> files;
+    for (const auto& entry : fs::directory_iterator(dir)) {
+        if (entry.is_regular_file() && has_structure_extension(entry.path())) {
+            files.push_back(entry.path());
+        }
+    }
+    return files;
+}
+
+bool process_file(const fs::path& input, const fs::path& output) {
+    FILE* in = fopen(input.c_str(), "r");
+    if (!in) return false;
+
+    freesasa_structure* structure = freesasa_structure_from_pdb(
+        in, &freesasa_default_classifier, 0);
+    fclose(in);
+    if (!structure) return false;
+
+    freesasa_parameters params = freesasa_default_parameters;
+    params.n_threads = 1;
+    params.alg = FREESASA_SHRAKE_RUPLEY;
+    params.shrake_rupley_n_points = 100;
+
+    freesasa_node* tree = freesasa_calc_tree(structure, &params, input.stem().c_str());
+    freesasa_structure_free(structure);
+    if (!tree) return false;
+
+    FILE* out = fopen(output.c_str(), "w");
+    if (!out) { freesasa_node_free(tree); return false; }
+
+    int result = freesasa_tree_export(out, tree, FREESASA_JSON | FREESASA_OUTPUT_RESIDUE);
+    fclose(out);
+    freesasa_node_free(tree);
+
+    return result == FREESASA_SUCCESS;
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " <input_folder> <output_folder>\n";
+        return 1;
+    }
+
+    fs::path input_dir(argv[1]), output_dir(argv[2]);
+
+    if (!fs::exists(input_dir) || !fs::is_directory(input_dir)) {
+        std::cerr << "Error: Invalid input folder: " << input_dir << "\n";
+        return 1;
+    }
+
+    fs::create_directories(output_dir);
+    auto files = find_structure_files(input_dir);
+
+    if (files.empty()) {
+        std::cerr << "No PDB or CIF files found in " << input_dir << "\n";
+        return 1;
+    }
+
+    freesasa_set_verbosity(FREESASA_V_NOWARNINGS);
+
+    int success = 0, failed = 0;
+    for (const auto& file : files) {
+        fs::path out = output_dir / (file.stem().string() + ".json");
+        if (process_file(file, out)) ++success; else ++failed;
+    }
+
+    std::cout << "Done: " << success << " succeeded, " << failed << " failed.\n";
+    return failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
Add benchmark infrastructure for E. coli proteome comparison.

## Added
- `benchmarks/ecoli_bench/benchmark.sh` - Main benchmark script (hyperfine-based)
- `benchmarks/ecoli_bench/sasa_batch.cpp` - FreeSASA batch wrapper
- `benchmarks/ecoli_bench/README.md` - Documentation
- `benchmarks/ecoli_bench/run_all.sh` - Helper script

## Changes
- Output directories now separated by tool (`temp_out/zig/`, `temp_out/freesasa/`, `temp_out/rustsasa/`)
- Updated `.gitignore` for benchmark data and temp files

## Usage
```bash
cd benchmarks/ecoli_bench
./benchmark.sh              # Run all tools
./benchmark.sh --tool zig   # Run specific tool
```