### PR TITLE
feat: Add pre-built wheel distribution via cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,111 @@
+name: Build & Publish
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+          - none
+
+permissions:
+  contents: read
+
+jobs:
+  build_wheels:
+    name: Wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        with:
+          package-dir: python
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Source dist
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build sdist
+        working-directory: python
+        run: python -m build --sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: python/dist/*.tar.gz
+
+  publish:
+    name: Publish
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      || (github.event_name == 'workflow_dispatch' && inputs.target != 'none')
+    permissions:
+      id-token: write
+    environment:
+      name: ${{ github.event_name == 'push' && 'pypi' || inputs.target }}
+      url: ${{ (github.event_name == 'push' || inputs.target == 'pypi') && 'https://pypi.org/p/zsasa' || 'https://test.pypi.org/p/zsasa' }}
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List distributions
+        run: ls -la dist/
+
+      - name: Publish to PyPI
+        if: github.event_name == 'push' || inputs.target == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      - name: Publish to TestPyPI
+        if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pull request template
 - `speedup_by_threads.png` plot generation in `analyze.py large` (thread scaling for 50k+ atoms)
 - CI status, license, Zig, and Python badges to READMEs
+- Pre-built wheel distribution via cibuildwheel (Linux x86_64/aarch64, macOS x86_64/arm64)
+- PyPI publish workflow (`.github/workflows/publish.yml`) with OIDC trusted publishing
+- `python -m ziglang` fallback in `hatch_build.py` for Zig discovery
 
 ### Changed
 

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -18,6 +18,9 @@ class ZigBuildHook(BuildHookInterface):
 
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         """Build the Zig library and copy it to the package directory."""
+        # Mark as platform-specific wheel (required for .so/.dylib bundling)
+        build_data["infer_tag"] = True
+
         # Determine paths
         root_dir = Path(self.root).parent  # Go up from python/ to project root
         python_dir = Path(self.root)
@@ -52,21 +55,38 @@ class ZigBuildHook(BuildHookInterface):
         # Include the library in the wheel
         build_data["force_include"][str(lib_dst)] = f"zsasa/{lib_name}"
 
+    def _find_zig(self) -> list[str]:
+        """Find the Zig compiler command."""
+        # Check PATH first (system install or setup-zig action)
+        if shutil.which("zig"):
+            return ["zig"]
+        # Check python -m ziglang (PyPI ziglang package)
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "ziglang", "version"],
+                capture_output=True,
+                check=True,
+                timeout=10,
+            )
+            return [sys.executable, "-m", "ziglang"]
+        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+            return []
+
     def _build_zig(self, root_dir: Path) -> None:
         """Run zig build command."""
         self.app.display_info("Building Zig library...")
 
-        # Check if zig is available
-        if shutil.which("zig") is None:
+        zig_cmd = self._find_zig()
+        if not zig_cmd:
             msg = (
-                "Zig compiler not found. Please install Zig 0.15.2+ from https://ziglang.org/download/ "
-                "or set ZSASA_LIB to point to a pre-built library."
+                "Zig compiler not found. Install Zig 0.15.2+ from "
+                "https://ziglang.org/download/ or run: pip install ziglang"
             )
             raise RuntimeError(msg)
 
         try:
             subprocess.run(
-                ["zig", "build", "-Doptimize=ReleaseFast"],
+                [*zig_cmd, "build", "-Doptimize=ReleaseFast"],
                 cwd=root_dir,
                 check=True,
                 capture_output=True,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -61,5 +61,27 @@ select = ["E", "F", "W", "I", "UP", "B", "C4", "SIM"]
 [tool.ty.environment]
 python-version = "3.11"
 
+[tool.cibuildwheel]
+build = ["cp311-*", "cp312-*", "cp313-*"]
+skip = ["pp*", "*-win32", "*-win_arm64", "*-manylinux_i686", "*-musllinux_*", "*_s390x", "*_ppc64le"]
+test-requires = ["pytest", "numpy"]
+test-command = "pytest {project}/python/tests/test_sasa.py -x -q"
+
+[tool.cibuildwheel.linux]
+# Install Zig via PyPI and build shared library once per platform.
+# Uses python3/pip3 for manylinux container compatibility.
+before-all = "pip3 install ziglang && python3 -m ziglang build -Doptimize=ReleaseFast"
+# Skip auditwheel: cffi dlopen() pattern is invisible to auditwheel,
+# and Zig statically links everything except libc (manylinux-allowlisted).
+repair-wheel-command = ""
+
+[tool.cibuildwheel.macos]
+before-all = "pip3 install ziglang && python3 -m ziglang build -Doptimize=ReleaseFast"
+# Skip delocate: libzsasa.dylib has no external dylib dependencies.
+repair-wheel-command = ""
+
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "11.0"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Add cibuildwheel configuration for pre-built wheel distribution (12 wheels: 4 platforms × 3 Python versions)
- Create `publish.yml` workflow with OIDC trusted publishing (tag push `v*` + manual dispatch to TestPyPI/PyPI)
- Fix `hatch_build.py`: add `infer_tag=True` for correct platform-specific wheel tags
- Add `_find_zig()` to support both PATH `zig` and `python -m ziglang` (PyPI ziglang package)

### Target platforms

| Platform | Runner |
|----------|--------|
| Linux x86_64 | ubuntu-latest |
| Linux aarch64 | ubuntu-24.04-arm |
| macOS x86_64 | macos-13 |
| macOS arm64 | macos-14 |

### Key decisions

- **Skip auditwheel/delocate**: cffi `dlopen()` pattern is invisible to auditwheel; Zig statically links everything except libc
- **OIDC trusted publishing**: No API tokens needed
- **`before-all`**: Install `ziglang` from PyPI and compile once per platform (shared across Python versions)

### Pre-requisites (after merge)

1. Register trusted publisher on [PyPI](https://pypi.org/manage/account/publishing/) and [TestPyPI](https://test.pypi.org/manage/account/publishing/)
2. Create `pypi` and `testpypi` GitHub environments in repo Settings

## Test plan

- [ ] CI passes (no Zig/Python regressions)
- [ ] Run `workflow_dispatch` with `target: none` to verify wheel builds
- [ ] Run `workflow_dispatch` with `target: testpypi` to verify full publish pipeline
- [ ] `pip install -i https://test.pypi.org/simple/ zsasa` works on clean env