### PR TITLE
fix: Replace deprecated macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -70,7 +70,9 @@ test-command = "pytest {project}/python/tests/test_sasa.py -x -q"
 [tool.cibuildwheel.linux]
 # Install Zig via PyPI and build shared library once per platform.
 # Uses python3/pip3 for manylinux container compatibility.
-before-all = "pip3 install ziglang && python3 -m ziglang build -Doptimize=ReleaseFast"
+# Pin glibc 2.28 via Zig target to ensure manylinux_2_28 compatibility.
+# $(uname -m) resolves to x86_64 or aarch64 depending on the runner.
+before-all = "pip3 install ziglang && python3 -m ziglang build -Doptimize=ReleaseFast -Dtarget=$(uname -m)-linux-gnu.2.28"
 # Skip auditwheel: cffi dlopen() pattern is invisible to auditwheel,
 # and Zig statically links everything except libc (manylinux-allowlisted).
 repair-wheel-command = ""


### PR DESCRIPTION
## Summary

- Replace `macos-13` with `macos-15-intel` in publish.yml wheel build matrix
- `macos-13` was [fully deprecated in December 2025](https://github.com/actions/runner-images/issues/13046)

## Test plan

- [ ] Re-run `workflow_dispatch` with `target: none` to verify all 4 platforms build