### PR TITLE
fix: Use manylinux_2_28 images for Linux wheel builds

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -68,6 +68,10 @@ test-requires = ["pytest", "numpy"]
 test-command = "pytest {project}/python/tests/test_sasa.py -x -q"
 
 [tool.cibuildwheel.linux]
+# Use manylinux_2_28 (glibc 2.28) containers to match Zig glibc target.
+# Default manylinux2014 (glibc 2.17) is too old for our glibc 2.28 target.
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 # Install Zig via PyPI and build shared library once per platform.
 # Uses python3/pip3 for manylinux container compatibility.
 # Pin glibc 2.28 via Zig target to ensure manylinux_2_28 compatibility.


### PR DESCRIPTION
## Summary
- Use `manylinux_2_28` container images for Linux cibuildwheel builds

## Problem
Default manylinux2014 containers have glibc 2.17, but our Zig build targets glibc 2.28 (`-Dtarget=$(uname -m)-linux-gnu.2.28`). Tests inside the container fail with:
```
GLIBC_2.27 not found (required by libzsasa.so)
```

## Fix
Set `manylinux-x86_64-image` and `manylinux-aarch64-image` to `manylinux_2_28`, aligning the container glibc (2.28) with our Zig target.

manylinux_2_28 covers: Ubuntu 20.04+, Debian 10+, RHEL 8+, Fedora 28+.

## Test plan
- [ ] Re-run `workflow_dispatch` with `target: none` after merge
- [ ] Verify all 4 platform wheels build and pass tests