### PR TITLE
ci: Add experimental Windows CI workflow

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,108 @@
+name: Windows CI (Experimental)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Zig Build & Test
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build (Debug)
+        run: zig build
+
+      - name: Run tests
+        run: zig build test
+
+      - name: Build (ReleaseFast)
+        run: zig build -Doptimize=ReleaseFast
+
+      - name: Check binary exists
+        run: |
+          if (Test-Path "./zig-out/bin/zsasa.exe") {
+            Write-Output "Binary built successfully"
+            Get-Item ./zig-out/bin/zsasa.exe
+          } else {
+            Write-Error "Binary not found"
+            exit 1
+          }
+
+      - name: Test CLI
+        run: |
+          ./zig-out/bin/zsasa.exe --help
+          ./zig-out/bin/zsasa.exe --version
+
+      - name: Check shared library exists
+        run: |
+          if (Test-Path "./zig-out/lib/zsasa.dll") {
+            Write-Output "DLL built successfully"
+            Get-Item ./zig-out/lib/zsasa.dll
+          } else {
+            Write-Output "zsasa.dll not found, checking other outputs..."
+            Get-ChildItem ./zig-out/lib/ -ErrorAction SilentlyContinue
+            exit 1
+          }
+
+      - name: Test with example input
+        run: |
+          ./zig-out/bin/zsasa.exe examples/1ubq.pdb output.json
+          Get-Content output.json | Select-Object -First 10
+
+  python:
+    name: Python Bindings
+    runs-on: windows-latest
+    needs: [build]
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build shared library
+        run: zig build -Doptimize=ReleaseFast
+
+      - name: Check DLL
+        run: Get-Item ./zig-out/lib/zsasa.dll
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python package
+        working-directory: python
+        run: pip install -e ".[dev]"
+
+      - name: Run Python tests
+        working-directory: python
+        run: pytest tests/test_sasa.py -v
+
+      - name: Test import
+        run: |
+          python -c "
+          import numpy as np
+          from zsasa import calculate_sasa, get_version
+          print(f'Version: {get_version()}')
+          coords = np.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
+          radii = np.array([1.5, 1.5])
+          result = calculate_sasa(coords, radii)
+          print(f'Total SASA: {result.total_area:.2f}')
+          assert result.total_area > 0
+          print('Windows Python test passed!')
+          "


### PR DESCRIPTION
## Summary
- Add manual-only workflow (`ci-windows.yml`) to test Windows support

## What it tests
1. Zig build (Debug + ReleaseFast) on windows-latest
2. Zig tests
3. CLI (`zsasa.exe --help`, `--version`, example input)
4. Shared library (`zsasa.dll`) existence
5. Python bindings (pip install + pytest + import test)

## Notes
- `workflow_dispatch` only — does not run on push/PR
- Separate from main CI to avoid blocking existing pipelines
- Experimental: results will determine if Windows support is feasible for v0.2.0