### PR TITLE
fix: Use correct DLL output path on Windows

### DIFF
--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -34,7 +34,11 @@ class ZigBuildHook(BuildHookInterface):
         else:
             lib_name = "libzsasa.so"
 
-        lib_src = root_dir / "zig-out" / "lib" / lib_name
+        # Zig outputs DLLs to zig-out/bin/ on Windows, .so/.dylib to zig-out/lib/
+        if sys.platform == "win32":
+            lib_src = root_dir / "zig-out" / "bin" / lib_name
+        else:
+            lib_src = root_dir / "zig-out" / "lib" / lib_name
         lib_dst = package_dir / lib_name
 
         # Check if library already exists and is newer than source


### PR DESCRIPTION
## Summary
- Fix `hatch_build.py` to look for DLL in `zig-out/bin/` on Windows

## Problem
Zig outputs DLLs to `zig-out/bin/` (Windows convention) but `hatch_build.py` was looking in `zig-out/lib/`:
```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

## Fix
Platform-conditional path: `zig-out/bin/zsasa.dll` on Windows, `zig-out/lib/libzsasa.{so,dylib}` on Linux/macOS.

## Test plan
- [ ] Re-run Windows CI after merge
- [ ] Verify Python bindings install and tests pass