### PR TITLE
ci: Auto-create GitHub Release from CHANGELOG

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ on:
           - none
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build_wheels:
@@ -109,3 +109,37 @@ jobs:
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/
+
+  github_release:
+    name: GitHub Release
+    needs: [publish]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Extract the section for this version from CHANGELOG.md
+          # Matches from "## [X.Y.Z]" to the next "## [" or end of file
+          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          # Write to file to preserve multiline
+          echo "$NOTES" > /tmp/release_notes.md
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/release_notes.md \
+            dist/*


### PR DESCRIPTION
## Summary
- Add `github_release` job to `publish.yml`
- On tag push (`v*`), extracts release notes from CHANGELOG.md and creates GitHub Release
- Attaches all wheels + sdist as release assets
- Uses `awk` to extract the matching version section from CHANGELOG

## Flow
```
tag push → build_wheels + build_sdist → publish (PyPI) → github_release
```

## Test plan
- [ ] CI passes (docs-only paths-ignore may skip)
- [ ] Test with `v0.1.1` tag push after merge