### PR TITLE
fix: use absolute paths for benchmark images

### DIFF
--- a/website/docs/benchmarks/batch.md
+++ b/website/docs/benchmarks/batch.md
@@ -47,11 +47,11 @@ Benchmark parameters: warmup=3, runs=5, threads=1,8,10
 
 | 1 thread | 8 threads | 10 threads |
 |:--------:|:---------:|:----------:|
-| ![1t](pathname://../../benchmarks/results/plots/batch/ecoli_time_1t.png) | ![8t](pathname://../../benchmarks/results/plots/batch/ecoli_time_8t.png) | ![10t](pathname://../../benchmarks/results/plots/batch/ecoli_time_10t.png) |
+| ![1t](pathname:///zsasa/benchmarks/results/plots/batch/ecoli_time_1t.png) | ![8t](pathname:///zsasa/benchmarks/results/plots/batch/ecoli_time_8t.png) | ![10t](pathname:///zsasa/benchmarks/results/plots/batch/ecoli_time_10t.png) |
 
 | Memory (1t) | Memory (8t) | Memory (10t) |
 |:-----------:|:-----------:|:------------:|
-| ![1t](pathname://../../benchmarks/results/plots/batch/ecoli_memory_1t.png) | ![8t](pathname://../../benchmarks/results/plots/batch/ecoli_memory_8t.png) | ![10t](pathname://../../benchmarks/results/plots/batch/ecoli_memory_10t.png) |
+| ![1t](pathname:///zsasa/benchmarks/results/plots/batch/ecoli_memory_1t.png) | ![8t](pathname:///zsasa/benchmarks/results/plots/batch/ecoli_memory_8t.png) | ![10t](pathname:///zsasa/benchmarks/results/plots/batch/ecoli_memory_10t.png) |
 
 ### Human Proteome (23,586 structures)
 
@@ -83,11 +83,11 @@ Benchmark parameters: warmup=3, runs=3, threads=1,8,10
 
 | 1 thread | 8 threads | 10 threads |
 |:--------:|:---------:|:----------:|
-| ![1t](pathname://../../benchmarks/results/plots/batch/human_time_1t.png) | ![8t](pathname://../../benchmarks/results/plots/batch/human_time_8t.png) | ![10t](pathname://../../benchmarks/results/plots/batch/human_time_10t.png) |
+| ![1t](pathname:///zsasa/benchmarks/results/plots/batch/human_time_1t.png) | ![8t](pathname:///zsasa/benchmarks/results/plots/batch/human_time_8t.png) | ![10t](pathname:///zsasa/benchmarks/results/plots/batch/human_time_10t.png) |
 
 | Memory (1t) | Memory (8t) | Memory (10t) |
 |:-----------:|:-----------:|:------------:|
-| ![1t](pathname://../../benchmarks/results/plots/batch/human_memory_1t.png) | ![8t](pathname://../../benchmarks/results/plots/batch/human_memory_8t.png) | ![10t](pathname://../../benchmarks/results/plots/batch/human_memory_10t.png) |
+| ![1t](pathname:///zsasa/benchmarks/results/plots/batch/human_memory_1t.png) | ![8t](pathname:///zsasa/benchmarks/results/plots/batch/human_memory_8t.png) | ![10t](pathname:///zsasa/benchmarks/results/plots/batch/human_memory_10t.png) |
 
 ### SwissProt (550,122 structures)
 
@@ -114,11 +114,11 @@ Benchmark parameters: warmup=3, runs=3, threads=8,10
 
 | 8 threads | 10 threads |
 |:---------:|:----------:|
-| ![8t](pathname://../../benchmarks/results/plots/batch/swissprot_time_8t.png) | ![10t](pathname://../../benchmarks/results/plots/batch/swissprot_time_10t.png) |
+| ![8t](pathname:///zsasa/benchmarks/results/plots/batch/swissprot_time_8t.png) | ![10t](pathname:///zsasa/benchmarks/results/plots/batch/swissprot_time_10t.png) |
 
 | Memory (8t) | Memory (10t) |
 |:-----------:|:------------:|
-| ![8t](pathname://../../benchmarks/results/plots/batch/swissprot_memory_8t.png) | ![10t](pathname://../../benchmarks/results/plots/batch/swissprot_memory_10t.png) |
+| ![8t](pathname:///zsasa/benchmarks/results/plots/batch/swissprot_memory_8t.png) | ![10t](pathname:///zsasa/benchmarks/results/plots/batch/swissprot_memory_10t.png) |
 
 ## Summary
 

--- a/website/docs/benchmarks/md.md
+++ b/website/docs/benchmarks/md.md
@@ -44,7 +44,7 @@ Results at 10 threads (MDTraj: 1t, mdsasa-bolt: all cores):
 - All zsasa variants within 12% of each other (SASA engine is the same)
 - mdsasa-bolt uses **10.9 GB** RAM vs zsasa CLI's **394 MB** (28x difference)
 
-![6sup_A_analysis tool comparison](pathname://../../benchmarks/results/md/6sup_A_analysis/plots/bar.png)
+![6sup_A_analysis tool comparison](pathname:///zsasa/benchmarks/results/md/6sup_A_analysis/plots/bar.png)
 
 ### 6sup_R1 (Large: 33,377 atoms, 10,001 frames)
 
@@ -67,7 +67,7 @@ Results at 10 threads (MDTraj: 1t, mdsasa-bolt: all cores):
 - zsasa CLI is **147x faster** than mdsasa-bolt
 - zsasa CLI uses **395 MB** vs mdsasa-bolt's **22.1 GB** (56x difference)
 
-![6sup_R1 tool comparison](pathname://../../benchmarks/results/md/6sup_R1/plots/bar.png)
+![6sup_R1 tool comparison](pathname:///zsasa/benchmarks/results/md/6sup_R1/plots/bar.png)
 
 ## Key Findings
 
@@ -115,7 +115,7 @@ Results at 10 threads (MDTraj: 1t, mdsasa-bolt: all cores):
 - **Python tools** scale linearly with frame count (entire trajectory loaded into memory)
 - **mdsasa-bolt** has the highest memory usage: 22 GB for 10k frames of a 33k-atom system
 
-![6sup_R1 memory usage](pathname://../../benchmarks/results/md/6sup_R1/plots/memory.png)
+![6sup_R1 memory usage](pathname:///zsasa/benchmarks/results/md/6sup_R1/plots/memory.png)
 
 ## mdsasa-bolt Performance Degradation
 

--- a/website/docs/benchmarks/single-file.md
+++ b/website/docs/benchmarks/single-file.md
@@ -17,7 +17,7 @@ Zig's key advantage: **Large structures + Multi-threading**
 
 | Speedup at threads=10 | Thread Scaling (100k+ atoms) |
 |:---------------:|:----------------------------:|
-| ![Speedup](pathname://../../benchmarks/results/plots/large/speedup_bar.png) | ![Thread Scaling](pathname://../../benchmarks/results/plots/large/speedup_by_threads.png) |
+| ![Speedup](pathname:///zsasa/benchmarks/results/plots/large/speedup_bar.png) | ![Thread Scaling](pathname:///zsasa/benchmarks/results/plots/large/speedup_by_threads.png) |
 
 **Key Results (100k+ atoms, n=1,171):**
 - **Up to 3.05x faster** than FreeSASA (8to0: 673,884 atoms, threads=8)
@@ -105,7 +105,7 @@ diff a.json b.json  # No differences
 
 ## Dataset
 
-![Dataset Distribution](pathname://../../benchmarks/results/plots/dataset/stratified_100k.png)
+![Dataset Distribution](pathname:///zsasa/benchmarks/results/plots/dataset/stratified_100k.png)
 
 | Sampling Bin | Size Bin | Atoms | Count | Percentage |
 | :---: | --- | ---: | ---: | ---: |
@@ -162,7 +162,7 @@ Single-threaded comparison (excluding parallelization effects):
 
 ### Speedup by Structure Size
 
-![Speedup by Size and Threads](pathname://../../benchmarks/results/plots/speedup_by_bin/grid.png)
+![Speedup by Size and Threads](pathname:///zsasa/benchmarks/results/plots/speedup_by_bin/grid.png)
 
 | Size Bin | Count | vs FreeSASA | vs RustSASA |
 | --- | ---: | ---: | ---: |
@@ -192,7 +192,7 @@ Single-threaded comparison (excluding parallelization effects):
 
 ### Median Execution Time by Thread Count
 
-![Thread Scaling](pathname://../../benchmarks/results/plots/large/speedup_by_threads.png)
+![Thread Scaling](pathname:///zsasa/benchmarks/results/plots/large/speedup_by_threads.png)
 
 | Threads | Zig (ms) | FreeSASA (ms) | Rust (ms) |
 | ---: | ---: | ---: | ---: |
@@ -223,7 +223,7 @@ Parallel Efficiency = T1 / (TN x N)
 
 ### Efficiency by Thread Count
 
-![Parallel Efficiency](pathname://../../benchmarks/results/plots/efficiency/summary.png)
+![Parallel Efficiency](pathname:///zsasa/benchmarks/results/plots/efficiency/summary.png)
 
 | Threads | Zig | FreeSASA | Rust | Zig vs FS | Zig vs Rust |
 | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -261,7 +261,7 @@ Parallel Efficiency = T1 / (TN x N)
 
 | Speedup at threads=10 | Thread Scaling |
 |:---------------:|:--------------:|
-| ![Speedup](pathname://../../benchmarks/results/plots/large/speedup_bar.png) | ![Thread Scaling](pathname://../../benchmarks/results/plots/large/speedup_by_threads.png) |
+| ![Speedup](pathname:///zsasa/benchmarks/results/plots/large/speedup_bar.png) | ![Thread Scaling](pathname:///zsasa/benchmarks/results/plots/large/speedup_by_threads.png) |
 
 | Comparison | Median Speedup |
 | --- | ---: |
@@ -274,7 +274,7 @@ Parallel Efficiency = T1 / (TN x N)
 
 ### Maximum Structure: 9fqr (4,506,416 atoms)
 
-![Max Structure Scaling](pathname://../../benchmarks/results/plots/samples/max_structure.png)
+![Max Structure Scaling](pathname:///zsasa/benchmarks/results/plots/samples/max_structure.png)
 
 Thread scaling on the largest PDB structure (9fqr, mean of 3 runs):
 
@@ -293,7 +293,7 @@ Thread scaling on the largest PDB structure (9fqr, mean of 3 runs):
 
 ### Best Speedup Structures (50k+ atoms)
 
-![Speedup Comparison](pathname://../../benchmarks/results/plots/speedup/comparison.png)
+![Speedup Comparison](pathname:///zsasa/benchmarks/results/plots/speedup/comparison.png)
 
 Top 5 structures with highest speedup at any thread count:
 
@@ -321,7 +321,7 @@ Top 5 structures with highest speedup at any thread count:
 
 ## Execution Time Distribution
 
-![SR Scatter Plot](pathname://../../benchmarks/results/plots/scatter/sr/grid.png)
+![SR Scatter Plot](pathname:///zsasa/benchmarks/results/plots/scatter/sr/grid.png)
 
 **Observations:**
 - Nearly linear on log scale -> O(N) neighbor list is effective (all tools use cell list)
@@ -337,16 +337,16 @@ Thread scaling details on representative structures selected from each size bin.
 
 | Bin | Atoms Range | Sample Plot |
 |-----|-------------|-------------|
-| 0-500 | 0-500 | [View](pathname://../../benchmarks/results/plots/samples/0-500.png) |
-| 500-1k | 500-1,000 | [View](pathname://../../benchmarks/results/plots/samples/500-1k.png) |
-| 1k-2k | 1,000-2,000 | [View](pathname://../../benchmarks/results/plots/samples/1k-2k.png) |
-| 2k-5k | 2,000-5,000 | [View](pathname://../../benchmarks/results/plots/samples/2k-5k.png) |
-| 5k-10k | 5,000-10,000 | [View](pathname://../../benchmarks/results/plots/samples/5k-10k.png) |
-| 10k-20k | 10,000-20,000 | [View](pathname://../../benchmarks/results/plots/samples/10k-20k.png) |
-| 20k-50k | 20,000-50,000 | [View](pathname://../../benchmarks/results/plots/samples/20k-50k.png) |
-| 50k-100k | 50,000-100,000 | [View](pathname://../../benchmarks/results/plots/samples/50k-100k.png) |
-| 100k-200k | 100,000-200,000 | [View](pathname://../../benchmarks/results/plots/samples/100k-200k.png) |
-| 200k+ | 200,000+ | [View](pathname://../../benchmarks/results/plots/samples/200kplus.png) |
+| 0-500 | 0-500 | [View](pathname:///zsasa/benchmarks/results/plots/samples/0-500.png) |
+| 500-1k | 500-1,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/500-1k.png) |
+| 1k-2k | 1,000-2,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/1k-2k.png) |
+| 2k-5k | 2,000-5,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/2k-5k.png) |
+| 5k-10k | 5,000-10,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/5k-10k.png) |
+| 10k-20k | 10,000-20,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/10k-20k.png) |
+| 20k-50k | 20,000-50,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/20k-50k.png) |
+| 50k-100k | 50,000-100,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/50k-100k.png) |
+| 100k-200k | 100,000-200,000 | [View](pathname:///zsasa/benchmarks/results/plots/samples/100k-200k.png) |
+| 200k+ | 200,000+ | [View](pathname:///zsasa/benchmarks/results/plots/samples/200kplus.png) |
 
 ---
 
@@ -474,7 +474,7 @@ Lee-Richards results using ~30k structures. RustSASA does not support LR.
 
 ### Dataset
 
-![LR Dataset](pathname://../../benchmarks/results/plots/dataset/stratified_30k.png)
+![LR Dataset](pathname:///zsasa/benchmarks/results/plots/dataset/stratified_30k.png)
 
 ### Overall Statistics (threads=10)
 
@@ -516,7 +516,7 @@ Lee-Richards results using ~30k structures. RustSASA does not support LR.
 
 ### Execution Time Distribution
 
-![LR Scatter Plot](pathname://../../benchmarks/results/plots/scatter/lr/grid.png)
+![LR Scatter Plot](pathname:///zsasa/benchmarks/results/plots/scatter/lr/grid.png)
 
 **Observations:**
 - Overall 3-4x slower than SR (slice integration cost)

--- a/website/docs/benchmarks/validation.md
+++ b/website/docs/benchmarks/validation.md
@@ -27,7 +27,7 @@ Dataset: AlphaFold E. coli K-12 proteome, n_points=100.
 - **f64**: Bit-identical to FreeSASA (both use the same algorithm parameters)
 - **f32**: Max 0.015% error from floating-point rounding — negligible for practical use
 
-![SR validation scatter](pathname://../../benchmarks/results/validation/ecoli/sr/validation_sr.png)
+![SR validation scatter](pathname:///zsasa/benchmarks/results/validation/ecoli/sr/validation_sr.png)
 
 ### Lee-Richards (E. coli Proteome, 4,370 structures)
 
@@ -42,7 +42,7 @@ Dataset: AlphaFold E. coli K-12 proteome, n_slices=20.
 - Mean error ~0.22% is higher than SR (<0.001%) due to different slicing implementations between zsasa and FreeSASA
 - R² = 1.000000 confirms strong linear agreement
 
-![LR validation scatter](pathname://../../benchmarks/results/validation/ecoli/lr/validation_lr.png)
+![LR validation scatter](pathname:///zsasa/benchmarks/results/validation/ecoli/lr/validation_lr.png)
 
 ## MD Trajectory
 
@@ -93,9 +93,9 @@ Reference: mdtraj at n_points=960.
 - Max error <0.014% comes from floating-point coordinate precision differences between MDTraj's C reader and zsasa's Zig XTC reader
 - Error decreases with higher n_points (more points smooth out coordinate-level noise)
 
-![MD validation n_points=100](pathname://../../benchmarks/results/validation_md/5wvo_C_R1/validation_md_100.png)
-![MD validation n_points=500](pathname://../../benchmarks/results/validation_md/5wvo_C_R1/validation_md_500.png)
-![MD validation n_points=960](pathname://../../benchmarks/results/validation_md/5wvo_C_R1/validation_md_960.png)
+![MD validation n_points=100](pathname:///zsasa/benchmarks/results/validation_md/5wvo_C_R1/validation_md_100.png)
+![MD validation n_points=500](pathname:///zsasa/benchmarks/results/validation_md/5wvo_C_R1/validation_md_500.png)
+![MD validation n_points=960](pathname:///zsasa/benchmarks/results/validation_md/5wvo_C_R1/validation_md_960.png)
 
 ## Running Validation
 

--- a/website/docs/zig-api/autodoc.md
+++ b/website/docs/zig-api/autodoc.md
@@ -5,7 +5,7 @@ Auto-generated interactive API documentation from Zig source code.
 The autodoc provides searchable, browsable documentation for all public types,
 functions, and modules in zsasa.
 
-**[Open Zig Autodoc](pathname://../zig-autodoc/)**
+**[Open Zig Autodoc](pathname:///zsasa/zig-autodoc/)**
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Replace relative `pathname://../../` paths with absolute `pathname:///zsasa/` paths for all benchmark images and zig-autodoc link
- Fixes images failing to load during Docusaurus client-side (SPA) navigation, only appearing after hard refresh

## Root Cause

`pathname://../../benchmarks/results/...` resolves to a relative path from the current page URL. During SPA navigation, the browser URL changes but no real page load occurs, so the relative path base shifts and images 404. Absolute paths (`/zsasa/benchmarks/results/...`) resolve correctly regardless of navigation method.

## Test plan

- [x] `npm run build` passes
- [x] Generated HTML contains absolute `/zsasa/` image paths
- [ ] Verify images load on first SPA navigation (no refresh needed)