### PR TITLE
feat: add directory batch processing C API

### DIFF
--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -1797,7 +1797,7 @@ export fn zsasa_batch_dir_process(
         setError(error_code, ZSASA_ERROR_INVALID_INPUT);
         return null;
     }
-    if (n_points == 0 or probe_radius <= 0.0) {
+    if (n_points == 0 or !(probe_radius > 0.0)) {
         setError(error_code, ZSASA_ERROR_INVALID_INPUT);
         return null;
     }
@@ -1838,8 +1838,12 @@ export fn zsasa_batch_dir_process(
     const output_dir_slice: ?[]const u8 = if (output_dir) |od| std.mem.span(od) else null;
 
     // Run batch processing
-    var batch_result = batch.runBatch(c_allocator, input_dir_slice, output_dir_slice, config) catch {
-        setError(error_code, ZSASA_ERROR_FILE_IO);
+    var batch_result = batch.runBatch(c_allocator, input_dir_slice, output_dir_slice, config) catch |err| {
+        const code = switch (err) {
+            error.OutOfMemory => ZSASA_ERROR_OUT_OF_MEMORY,
+            else => ZSASA_ERROR_FILE_IO,
+        };
+        setError(error_code, code);
         return null;
     };
 
@@ -1987,7 +1991,9 @@ export fn zsasa_batch_dir_get_total_sasa(
     if (handle == null) return std.math.nan(f64);
     const h: *BatchDirHandle = @ptrCast(@alignCast(handle.?));
     if (index >= h.result.file_results.len) return std.math.nan(f64);
-    return h.result.file_results[index].total_sasa;
+    const fr = h.result.file_results[index];
+    if (fr.status == .err) return std.math.nan(f64);
+    return fr.total_sasa;
 }
 
 /// Get the processing status of a file by index (0-based).


### PR DESCRIPTION
## Summary

- Add `zsasa_batch_dir_*` functions to `c_api.zig` wrapping `batch.runBatch()` with an opaque handle pattern (consistent with XTC/DCD readers)
- New constants: `ZSASA_ERROR_FILE_IO` (-4), `ZSASA_ALGORITHM_SR` (0), `ZSASA_ALGORITHM_LR` (1)
- 9 exported C functions: `process`, `get_total_files`, `get_successful`, `get_failed`, `get_filename`, `get_n_atoms`, `get_total_sasa`, `get_status`, `free`
- Enables Python/C/FFI users to process entire directories of PDB/CIF/JSON files with Zig's parallel processing without needing a Python wrapper

## Test plan

- [x] `zig build -Doptimize=ReleaseFast` succeeds
- [x] `zig build test` passes (exit 0)
- [x] `zig fmt --check src/c_api.zig` clean
- [x] 7 new test cases: null handle safety, invalid parameters, nonexistent directory, null error_code, SR integration with test_data, LR integration, classifier_type -1
- [ ] CI passes