### PR TITLE
ci: remove Windows from PR checks for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,11 @@ jobs:
           - os: macos-latest
             name: macOS
             binary: zsasa
-          - os: windows-latest
-            name: Windows
-            binary: zsasa.exe
 
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.name }})
     needs: [fmt]
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -157,15 +154,11 @@ jobs:
             name: macOS
             lib: libzsasa.dylib
             lib_dir: lib
-          - os: windows-latest
-            name: Windows
-            lib: zsasa.dll
-            lib_dir: bin
 
     runs-on: ${{ matrix.os }}
     name: Python (${{ matrix.name }})
     needs: [fmt]
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Remove Windows from build and Python test matrices in CI
- Windows builds (~2.5min) slow down PR feedback; Linux/macOS (~1min) are sufficient for development
- Windows is still fully covered by `publish.yml` on release tags
- Reduce job timeout from 15 to 10 minutes

## Test plan
- [x] CI on this PR itself confirms Linux + macOS pass without Windows