### PR TITLE
docs: add use_bitmask to Python API docs

### DIFF
--- a/website/docs/guide/algorithms.mdx
+++ b/website/docs/guide/algorithms.mdx
@@ -97,6 +97,47 @@ result = calculate_sasa(coords, radii, n_points=200)
 | 50 | High | 2.5x |
 | 100 | Very high | 5.0x |
 
+## Bitmask LUT Optimization
+
+The Shrake-Rupley algorithm supports an optional **bitmask lookup table (LUT)** optimization that can improve performance for repeated calculations.
+
+### How It Works
+
+Instead of computing neighbor occlusion for each test point individually, the bitmask approach precomputes occlusion patterns as bitmasks. This allows batch neighbor processing using bitwise operations.
+
+### Constraints
+
+- **SR algorithm only** — not available for Lee-Richards
+- **Supported n_points**: 64, 128, or 256 only
+- Results may differ slightly from standard SR (< 2% relative difference per atom)
+
+### Usage
+
+<Tabs>
+  <TabItem value="cli" label="CLI" default>
+
+```bash
+# Bitmask with 128 test points
+zsasa --use-bitmask --n-points=128 structure.cif output.json
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+from zsasa import calculate_sasa
+
+# Single frame
+result = calculate_sasa(coords, radii, n_points=128, use_bitmask=True)
+
+# Batch (trajectory)
+from zsasa import calculate_sasa_batch
+result = calculate_sasa_batch(coords, radii, n_points=128, use_bitmask=True)
+```
+
+  </TabItem>
+</Tabs>
+
 ## References
 
 - Shrake, A.; Rupley, J. A. Environment and Exposure to Solvent of Protein Atoms. *J. Mol. Biol.* 1973, 79(2), 351-371.

--- a/website/docs/integrations/mdanalysis.md
+++ b/website/docs/integrations/mdanalysis.md
@@ -66,6 +66,7 @@ def run(
     algorithm: Literal["sr", "lr"] = "sr",
     n_slices: int = 20,
     n_threads: int = 0,
+    use_bitmask: bool = False,
 ) -> SASAAnalysis
 ```
 
@@ -81,6 +82,7 @@ def run(
 | `algorithm` | `"sr"` or `"lr"` | `"sr"` | Algorithm to use |
 | `n_slices` | `int` | `20` | Slices per atom (LR) |
 | `n_threads` | `int` | `0` | Threads (0 = auto) |
+| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 64, 128, or 256) |
 
 **Returns:** `self` for method chaining.
 
@@ -135,6 +137,7 @@ def compute_sasa(
     n_slices: int = 20,
     n_threads: int = 0,
     mode: Literal["atom", "residue", "total"] = "atom",
+    use_bitmask: bool = False,
 ) -> NDArray[np.float32]
 ```
 

--- a/website/docs/integrations/mdtraj.md
+++ b/website/docs/integrations/mdtraj.md
@@ -34,6 +34,7 @@ def compute_sasa(
     n_slices: int = 20,
     n_threads: int = 0,
     mode: Literal["atom", "residue", "total"] = "atom",
+    use_bitmask: bool = False,
 ) -> NDArray[np.float32]
 ```
 
@@ -48,6 +49,7 @@ def compute_sasa(
 | `n_slices` | `int` | `20` | Slices per atom (LR) |
 | `n_threads` | `int` | `0` | Threads (0 = auto) |
 | `mode` | `"atom"`, `"residue"`, `"total"` | `"atom"` | Output mode |
+| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 64, 128, or 256) |
 
 **Returns:** SASA values in nm² (matching MDTraj's output units).
 

--- a/website/docs/python-api/core.md
+++ b/website/docs/python-api/core.md
@@ -14,6 +14,7 @@ def calculate_sasa(
     n_slices: int = 20,
     probe_radius: float = 1.4,
     n_threads: int = 0,
+    use_bitmask: bool = False,
 ) -> SasaResult
 ```
 
@@ -30,6 +31,7 @@ Calculate Solvent Accessible Surface Area.
 | `n_slices` | `int` | `20` | Slices per atom (LR only) |
 | `probe_radius` | `float` | `1.4` | Water probe radius in Å |
 | `n_threads` | `int` | `0` | Number of threads (0 = auto) |
+| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 64, 128, or 256) |
 
 **Returns:** `SasaResult`
 
@@ -63,6 +65,7 @@ def calculate_sasa_batch(
     probe_radius: float = 1.4,
     n_threads: int = 0,
     precision: Literal["f64", "f32"] = "f64",
+    use_bitmask: bool = False,
 ) -> BatchSasaResult
 ```
 
@@ -80,6 +83,7 @@ Calculate SASA for multiple frames in batch.
 | `probe_radius` | `float` | `1.4` | Water probe radius in Å |
 | `n_threads` | `int` | `0` | Number of threads (0 = auto) |
 | `precision` | `"f64"` or `"f32"` | `"f64"` | Floating-point precision |
+| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 64, 128, or 256) |
 
 **Returns:** `BatchSasaResult`
 

--- a/website/docs/python-api/xtc.md
+++ b/website/docs/python-api/xtc.md
@@ -129,6 +129,7 @@ def compute_sasa_trajectory(
     start: int = 0,
     stop: int | None = None,
     step: int = 1,
+    use_bitmask: bool = False,
 ) -> TrajectorySasaResult
 ```
 
@@ -146,6 +147,7 @@ def compute_sasa_trajectory(
 | `start` | `int` | `0` | First frame to process |
 | `stop` | `int \| None` | `None` | Stop before this frame (None = all) |
 | `step` | `int` | `1` | Process every Nth frame |
+| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 64, 128, or 256) |
 
 **Returns:** `TrajectorySasaResult`
 


### PR DESCRIPTION
## Summary
- Add `use_bitmask` parameter to all Python API reference pages (core, xtc, mdtraj, mdanalysis)
- Add Bitmask LUT Optimization section to algorithms guide

## Files Updated
- `website/docs/python-api/core.md` — `calculate_sasa()` and `calculate_sasa_batch()`
- `website/docs/python-api/xtc.md` — `compute_sasa_trajectory()`
- `website/docs/integrations/mdtraj.md` — `compute_sasa()`
- `website/docs/integrations/mdanalysis.md` — `SASAAnalysis.run()` and `compute_sasa()`
- `website/docs/guide/algorithms.mdx` — New bitmask section with CLI/Python examples

## Test plan
- [ ] Verify docs site builds without errors
- [ ] Check parameter tables render correctly
- [ ] Verify bitmask section appears on algorithms page