### PR TITLE
feat: bitmask fallback with warning for unsupported n_points

### DIFF
--- a/python/tests/test_sasa.py
+++ b/python/tests/test_sasa.py
@@ -1,5 +1,7 @@
 """Tests for zsasa Python bindings."""
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -585,22 +587,29 @@ class TestBitmask:
         with pytest.raises(ValueError, match="only supports algorithm='sr'"):
             calculate_sasa(coords, radii, algorithm="lr", use_bitmask=True)
 
-    def test_bitmask_invalid_n_points(self):
-        """use_bitmask=True with unsupported n_points should raise ValueError."""
+    def test_bitmask_unsupported_n_points_warns_and_falls_back(self):
+        """use_bitmask=True with unsupported n_points warns and falls back."""
         coords = np.array([[0.0, 0.0, 0.0]])
         radii = np.array([1.5])
 
-        with pytest.raises(ValueError, match="n_points"):
-            calculate_sasa(coords, radii, n_points=100, use_bitmask=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = calculate_sasa(coords, radii, n_points=100, use_bitmask=True)
+            assert len(w) == 1
+            assert "Falling back" in str(w[0].message)
+        assert result.total_area > 0
 
-    def test_bitmask_default_n_points_raises(self):
-        """use_bitmask=True with default n_points=100 should raise ValueError."""
+    def test_bitmask_default_n_points_warns_and_falls_back(self):
+        """use_bitmask=True with default n_points warns and falls back."""
         coords = np.array([[0.0, 0.0, 0.0]])
         radii = np.array([1.5])
 
-        # Default n_points is 100, which is not in (64, 128, 256)
-        with pytest.raises(ValueError, match="n_points"):
-            calculate_sasa(coords, radii, use_bitmask=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = calculate_sasa(coords, radii, use_bitmask=True)
+            assert len(w) == 1
+            assert "Falling back" in str(w[0].message)
+        assert result.total_area > 0
 
     def test_bitmask_batch(self):
         """Bitmask batch mode should produce correct results."""
@@ -633,15 +642,19 @@ class TestBitmask:
         with pytest.raises(ValueError, match="only supports algorithm='sr'"):
             calculate_sasa_batch(coords, radii, algorithm="lr", use_bitmask=True)
 
-    def test_bitmask_batch_invalid_n_points(self):
-        """Batch bitmask with unsupported n_points should raise ValueError."""
+    def test_bitmask_batch_unsupported_n_points_warns_and_falls_back(self):
+        """Batch bitmask with unsupported n_points warns and falls back."""
         from zsasa import calculate_sasa_batch
 
         coords = np.array([[[0.0, 0.0, 0.0]]], dtype=np.float32)
         radii = np.array([1.5], dtype=np.float32)
 
-        with pytest.raises(ValueError, match="n_points"):
-            calculate_sasa_batch(coords, radii, n_points=100, use_bitmask=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = calculate_sasa_batch(coords, radii, n_points=100, use_bitmask=True)
+            assert len(w) == 1
+            assert "Falling back" in str(w[0].message)
+        assert result.atom_areas.sum() > 0
 
     def test_bitmask_batch_f32_precision(self):
         """Bitmask batch with f32 precision should work."""

--- a/python/zsasa/core.py
+++ b/python/zsasa/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import os
 import sys
+import warnings
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
@@ -26,14 +27,24 @@ ZSASA_ERROR_UNSUPPORTED_N_POINTS = -5
 _BITMASK_SUPPORTED_N_POINTS = (64, 128, 256)
 
 
-def _validate_bitmask_params(algorithm: str, n_points: int) -> None:
-    """Validate parameters for bitmask mode."""
+def _validate_bitmask_params(algorithm: str, n_points: int) -> bool:
+    """Validate parameters for bitmask mode.
+
+    Returns True if bitmask should be used, False if falling back to standard SR.
+    Raises ValueError if algorithm is incompatible (not SR).
+    """
     if algorithm != "sr":
         msg = "use_bitmask=True only supports algorithm='sr' (Shrake-Rupley)"
         raise ValueError(msg)
     if n_points not in _BITMASK_SUPPORTED_N_POINTS:
-        msg = f"use_bitmask=True requires n_points in {_BITMASK_SUPPORTED_N_POINTS}, got {n_points}"
-        raise ValueError(msg)
+        warnings.warn(
+            f"use_bitmask=True requires n_points in "
+            f"{_BITMASK_SUPPORTED_N_POINTS}, got {n_points}. "
+            f"Falling back to standard Shrake-Rupley.",
+            stacklevel=3,
+        )
+        return False
+    return True
 
 
 # Algorithm constants
@@ -320,7 +331,7 @@ def calculate_sasa(
 
     # Validate bitmask constraints
     if use_bitmask:
-        _validate_bitmask_params(algorithm, n_points)
+        use_bitmask = _validate_bitmask_params(algorithm, n_points)
 
     # Validate and convert inputs
     coords = np.ascontiguousarray(coords, dtype=np.float64)
@@ -928,7 +939,7 @@ def calculate_sasa_batch(
 
     # Validate bitmask constraints
     if use_bitmask:
-        _validate_bitmask_params(algorithm, n_points)
+        use_bitmask = _validate_bitmask_params(algorithm, n_points)
 
     # Validate and convert inputs
     coordinates = np.ascontiguousarray(coordinates, dtype=np.float32)


### PR DESCRIPTION
## Summary
- `use_bitmask=True` with unsupported `n_points` (not 64/128/256) now emits a warning and falls back to standard Shrake-Rupley instead of raising `ValueError`
- `use_bitmask=True` with `algorithm="lr"` still raises `ValueError` (fundamentally incompatible)

## Changes
- `_validate_bitmask_params()` returns `bool` instead of `None`, with `warnings.warn()` for unsupported n_points
- Updated 3 tests from `pytest.raises(ValueError)` to `warnings.catch_warnings`

## Test plan
- [x] All 65 tests pass
- [x] Bitmask fallback tests verify warning message and valid result