### PR TITLE
feat: default to including hydrogens in trajectory mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Trajectory mode**: `--include-hydrogens` is now the default (hydrogen atoms included). Use `--no-hydrogens` to exclude. MD trajectories typically include all atoms.
 - CI: removed Windows from PR checks (linux + macOS only); Windows builds remain in release workflow (#199)
 
 ### Performance

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -128,7 +128,7 @@ pub const TrajArgs = struct {
     stride: u32 = 1, // Process every Nth frame
     start_frame: u32 = 0, // Start frame
     end_frame: ?u32 = null, // End frame (null = all)
-    include_hydrogens: bool = false, // Include hydrogen atoms (default: exclude)
+    include_hydrogens: bool = true, // Include hydrogen atoms (default: include for MD trajectories)
     batch_size: u32 = 0, // Frames per batch for parallel processing (0 = auto)
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 64/128/256)
     quiet: bool = false,
@@ -216,6 +216,8 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
                 result.output_path = arg[prefix_len..];
             } else if (std.mem.eql(u8, arg, "--include-hydrogens")) {
                 result.include_hydrogens = true;
+            } else if (std.mem.eql(u8, arg, "--no-hydrogens") or std.mem.eql(u8, arg, "--exclude-hydrogens")) {
+                result.include_hydrogens = false;
             } else if (std.mem.eql(u8, arg, "--use-bitmask")) {
                 result.use_bitmask = true;
             } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
@@ -314,8 +316,9 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --n-points=N       Test points per atom (default: 100, for sr)
         \\    --n-slices=N       Slices per atom diameter (default: 20, for lr)
         \\    --precision=PREC    Floating-point precision: f32, f64 (default: f32)
+        \\    --no-hydrogens     Exclude hydrogen atoms (default: included)
         \\    --include-hydrogens
-        \\                       Include hydrogen atoms (default: excluded)
+        \\                       Include hydrogen atoms (default, for backward compat)
         \\    --use-bitmask      Use bitmask LUT optimization for SR algorithm
         \\                       (n-points must be 64, 128, or 256)
         \\    --stride=N         Process every Nth frame (default: 1)

--- a/website/docs/guide/trajectory.md
+++ b/website/docs/guide/trajectory.md
@@ -31,8 +31,8 @@ zsasa traj trajectory.xtc topology.pdb \
     --stride=10 \
     --start=100 --end=500
 
-# Include hydrogens
-zsasa traj trajectory.xtc topology.pdb --include-hydrogens
+# Exclude hydrogens (included by default)
+zsasa traj trajectory.xtc topology.pdb --no-hydrogens
 
 # Output to specific file
 zsasa traj trajectory.xtc topology.pdb -o sasa_results.csv
@@ -48,7 +48,7 @@ zsasa traj trajectory.xtc topology.pdb -o sasa_results.csv
 | `--classifier=TYPE` | `naccess`, `protor`, `oons` | none |
 | `--threads=N` | Thread count (0 = auto) | `0` |
 | `--precision=P` | `f32` (fast) or `f64` (precise) | `f32` |
-| `--include-hydrogens` | Include hydrogen atoms | excluded |
+| `--no-hydrogens` | Exclude hydrogen atoms | included |
 | `--batch-size=N` | Frames per batch (omit for auto) | auto |
 | `-o, --output=FILE` | Output CSV file | `traj_sasa.csv` |
 


### PR DESCRIPTION
## Summary
- Changed `--include-hydrogens` default from `false` to `true` in trajectory mode
- Added `--no-hydrogens` / `--exclude-hydrogens` flag to opt out
- `--include-hydrogens` kept for backward compatibility
- Updated website docs and CHANGELOG

## Rationale
MD trajectories typically include all atoms (including hydrogens). Excluding them by default was an inconsistency with typical MD workflows.

## Test plan
- [x] `zig build` passes
- [x] `zig build test` passes
- [x] Help text shows updated defaults