### PR TITLE
feat: multi-threaded FreeSASA batch support

### DIFF
--- a/benchmarks/external/freesasa-batch/README.md
+++ b/benchmarks/external/freesasa-batch/README.md
@@ -1,10 +1,37 @@
 # FreeSASA Batch Wrapper
 
-C++ wrapper for FreeSASA that processes all PDB files in a directory sequentially.
+C++ wrappers for FreeSASA batch SASA computation.
 
 Originally from [RustSASA benchmark](https://github.com/OWissett/rustsasa).
 
-## Build
+## Batch Binary (recommended)
+
+The multi-threaded batch binary lives in [freesasa-bench](https://github.com/N283T/freesasa-bench) at `src/freesasa_batch.cc`.
+
+### Build
+
+```bash
+cd ../freesasa-bench/src
+c++ -O3 -std=c++17 -I. \
+  -o freesasa_batch freesasa_batch.cc json_input.o \
+  libfreesasa.a -lz -lpthread
+```
+
+### Usage
+
+```bash
+./freesasa_batch <input_dir> <output_dir> --n-threads=N --n-points=N
+```
+
+- Processes `.json`, `.json.gz`, `.pdb`, and `.cif` files
+- `--n-threads`: Number of parallel file-processing threads (default: 1)
+- `--n-points`: Shrake-Rupley sphere points per atom (default: 100)
+
+## Legacy PDB-only Wrapper (deprecated)
+
+The original `sasa_batch.cpp` is a single-threaded PDB-only wrapper.
+
+### Build
 
 ```bash
 c++ -O3 -std=c++17 \
@@ -13,12 +40,8 @@ c++ -O3 -std=c++17 \
   ../freesasa-bench/src/libfreesasa.a
 ```
 
-## Usage
+### Usage
 
 ```bash
 ./sasa_batch <input_dir> <output_dir> [n_points]
 ```
-
-- Processes all `.pdb`/`.cif` files in `input_dir`
-- Writes total SASA per file to `output_dir`
-- `n_points`: Shrake-Rupley sphere points (default: 100)

--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -30,7 +30,7 @@ Output:
     ├── bench_zsasa_f64_8t.json
     ├── bench_zsasa_f32_8t.json
     ├── bench_zsasa_f64_bitmask_8t.json  # with --use-bitmask
-    ├── bench_freesasa_1t.json
+    ├── bench_freesasa_8t.json
     ├── bench_rustsasa_8t.json
     ├── bench_lahuta_8t.json
     └── bench_lahuta_bitmask_8t.json     # with --use-bitmask
@@ -78,7 +78,7 @@ def get_binary_paths() -> dict[str, Path]:
     return {
         "zsasa": root.joinpath("zig-out", "bin", "zsasa"),
         "freesasa_batch": root.joinpath(
-            "benchmarks", "external", "freesasa-batch", "sasa_batch"
+            "benchmarks", "external", "freesasa-bench", "src", "freesasa_batch"
         ),
         "rustsasa": root.joinpath(
             "benchmarks", "external", "rustsasa-bench", "target", "release", "rust-sasa"
@@ -224,16 +224,17 @@ def run_zig(
 def run_freesasa(
     input_dir: Path,
     results_dir: Path,
+    thread_counts: list[int],
     n_points: int,
     warmup: int,
     runs: int,
     dry_run: bool,
     binaries: dict[str, Path],
 ) -> list[dict]:
-    """Run FreeSASA benchmark (single-threaded only)."""
-    sasa_batch = binaries["freesasa_batch"]
-    if not sasa_batch.exists():
-        console.print("[yellow][SKIP] sasa_batch not found[/]")
+    """Run FreeSASA benchmarks with file-level parallelism."""
+    freesasa_batch = binaries["freesasa_batch"]
+    if not freesasa_batch.exists():
+        console.print("[yellow][SKIP] freesasa_batch not found[/]")
         return []
 
     results = []
@@ -241,16 +242,17 @@ def run_freesasa(
     with tempfile.TemporaryDirectory(prefix="freesasa_") as tmp:
         out_dir = Path(tmp)
 
-        result = run_benchmark(
-            "freesasa_1t",
-            f"{sasa_batch} {input_dir} {out_dir} {n_points}",
-            results_dir,
-            warmup,
-            runs,
-            dry_run,
-        )
-        if result:
-            results.append({"name": "freesasa_1t", **result})
+        for n_threads in thread_counts:
+            result = run_benchmark(
+                f"freesasa_{n_threads}t",
+                f"{freesasa_batch} {input_dir} {out_dir} --n-threads={n_threads} --n-points={n_points}",
+                results_dir,
+                warmup,
+                runs,
+                dry_run,
+            )
+            if result:
+                results.append({"name": f"freesasa_{n_threads}t", **result})
 
     return results
 
@@ -413,7 +415,7 @@ def main(
         typer.Option(
             "--threads",
             "-T",
-            help="Thread counts: '1,8,10' or '1-10' (freesasa always 1t)",
+            help="Thread counts: '1,8,10' or '1-10'",
         ),
     ] = "1,8",
     runs: Annotated[
@@ -550,7 +552,14 @@ def main(
 
     if Tool.freesasa in selected_tools:
         results = run_freesasa(
-            input_dir, results_dir, n_points, warmup, runs, dry_run, binaries
+            input_dir,
+            results_dir,
+            thread_counts,
+            n_points,
+            warmup,
+            runs,
+            dry_run,
+            binaries,
         )
         all_results.extend(results)
 

--- a/benchmarks/scripts/validation.py
+++ b/benchmarks/scripts/validation.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import json
 import os
 import platform
-import re
 import subprocess
 import tempfile
 from datetime import datetime
@@ -76,8 +75,8 @@ def get_binary_paths() -> dict[str, Path]:
     root = get_root_dir()
     return {
         "zsasa": root.joinpath("zig-out", "bin", "zsasa"),
-        "freesasa": root.joinpath(
-            "benchmarks", "external", "freesasa-bench", "src", "freesasa"
+        "freesasa_batch": root.joinpath(
+            "benchmarks", "external", "freesasa-bench", "src", "freesasa_batch"
         ),
     }
 
@@ -171,48 +170,35 @@ def run_freesasa(
     binaries: dict[str, Path],
     n_points: int = 100,
 ) -> dict[str, float]:
-    """Run FreeSASA per-file via CLI. Returns {stem: total_sasa}."""
-    binary = binaries["freesasa"]
+    """Run FreeSASA batch binary. Returns {stem: total_sasa}."""
+    binary = binaries["freesasa_batch"]
     if not binary.exists():
-        console.print(f"[red]freesasa not found: {binary}[/]")
-        return {}
-
-    pdb_files = sorted(input_dir.glob("*.pdb"))
-    if not pdb_files:
-        pdb_files = sorted(input_dir.glob("*.ent"))
-    if not pdb_files:
-        console.print("[red]No PDB files found in input directory[/]")
+        console.print(f"[red]freesasa_batch not found: {binary}[/]")
         return {}
 
     results: dict[str, float] = {}
 
-    from rich.progress import Progress
+    with tempfile.TemporaryDirectory(prefix="validation_freesasa_") as tmp:
+        out_dir = Path(tmp)
+        cmd = [
+            str(binary),
+            str(input_dir),
+            str(out_dir),
+            f"--n-threads=1",
+            f"--n-points={n_points}",
+        ]
+        console.print(f"  [dim]$ {' '.join(cmd)}[/]")
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+        if proc.returncode != 0:
+            console.print(f"[red]freesasa_batch failed: {proc.stderr[:500]}[/]")
+            return {}
 
-    with Progress(console=console) as progress:
-        task = progress.add_task("  FreeSASA", total=len(pdb_files))
-        for pdb_file in pdb_files:
-            cmd = [str(binary), str(pdb_file)]
-            if algorithm == "sr":
-                cmd.extend(["--shrake-rupley", f"--resolution={n_points}"])
-            else:
-                cmd.extend(["--lee-richards", "--resolution=20"])
-
+        for txt_file in sorted(out_dir.glob("*.txt")):
             try:
-                proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-                if proc.returncode != 0:
-                    progress.advance(task)
-                    continue
-
-                for line in proc.stdout.split("\n"):
-                    if line.startswith("Total"):
-                        match = re.search(r"[\d.]+", line)
-                        if match:
-                            results[pdb_file.stem] = float(match.group())
-                            break
-            except (subprocess.TimeoutExpired, ValueError):
-                pass
-
-            progress.advance(task)
+                total = float(txt_file.read_text().strip())
+                results[txt_file.stem] = total
+            except ValueError:
+                continue
 
     return results
 


### PR DESCRIPTION
## Summary
- Update `bench_batch.py`: use `freesasa_batch` binary from freesasa-bench fork, loop over thread counts
- Update `validation.py`: replace per-file FreeSASA CLI calls with `freesasa_batch` batch execution
- Update `freesasa-batch/README.md`: point to freesasa-bench for source

Depends on: https://github.com/N283T/freesasa-bench/pull/1

## Test plan
- [x] Compiled and tested with 5 E. coli PDB files (1t, 4t)
- [x] SASA values match legacy `sasa_batch` output
- [x] Python syntax check passed for both scripts