### PR TITLE
fix: shorten chain names before writing PDB

### DIFF
--- a/benchmarks/scripts/generate_pdb.py
+++ b/benchmarks/scripts/generate_pdb.py
@@ -120,6 +120,7 @@ def clean_cif_to_pdb(cif_path: Path, output_path: Path) -> tuple[str, int]:
         return (cif_path.stem.replace(".cif", ""), 0)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    gemmi.shorten_chain_names(st)
     st.write_pdb(str(output_path))
 
     return (cif_path.stem.replace(".cif", ""), n_atoms)


### PR DESCRIPTION
## Summary

- Add `gemmi.shorten_chain_names(st)` before `write_pdb` in `clean_cif_to_pdb`
- Fixes `RuntimeError: chain name too long for the PDB format` for structures with long mmCIF chain names (e.g. AAA, LA0, A001)
- Chain names don't affect SASA calculation (only coordinates and radii matter)

## Test plan
- [ ] Re-run `generate_pdb.py` — previously failing structures (6y2j, 7qca, 7toq, 6r83, 8p60, 8ckb) should succeed