### PR TITLE
fix: call shorten_chain_names as Structure method

### DIFF
--- a/benchmarks/scripts/generate_pdb.py
+++ b/benchmarks/scripts/generate_pdb.py
@@ -120,7 +120,7 @@ def clean_cif_to_pdb(cif_path: Path, output_path: Path) -> tuple[str, int]:
         return (cif_path.stem.replace(".cif", ""), 0)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    gemmi.shorten_chain_names(st)
+    st.shorten_chain_names()
     st.write_pdb(str(output_path))
 
     return (cif_path.stem.replace(".cif", ""), n_atoms)


### PR DESCRIPTION
## Summary
- Fix `AttributeError: module 'gemmi' has no attribute 'shorten_chain_names'`
- `shorten_chain_names` is bound on the Structure class, not as a module function
- Change `gemmi.shorten_chain_names(st)` → `st.shorten_chain_names()`

## Test plan
- [x] Verified: `hasattr(gemmi.Structure(), 'shorten_chain_names')` → True
- [x] Verified: `hasattr(gemmi, 'shorten_chain_names')` → False