### PR TITLE
refactor: make bitmask variants independent tools

### DIFF
--- a/benchmarks/scripts/bench.py
+++ b/benchmarks/scripts/bench.py
@@ -81,8 +81,15 @@ def _build_command(
     """Build shell command for a tool.
 
     Raises:
-        ValueError: If tool base is not recognized.
+        ValueError: If tool base is not recognized, or if use_bitmask is True
+            for a tool that does not support bitmask mode.
     """
+    if use_bitmask and base not in ("zig", "lahuta"):
+        raise ValueError(
+            f"Bitmask mode is not supported for tool base '{base}'. "
+            f"Only 'zig' and 'lahuta' support --use-bitmask."
+        )
+
     binary = quote_path(get_binary_path(base))
     quoted = quote_path(pdb_path)
     bitmask_flag = " --use-bitmask" if use_bitmask else ""
@@ -119,7 +126,8 @@ def main(
             "-t",
             help=(
                 "Tool: zig_f64, zig_f32, zig_f64_bitmask, zig_f32_bitmask, "
-                "freesasa, rust, lahuta, lahuta_bitmask (zig = zig_f64)"
+                "freesasa, rust, lahuta, lahuta_bitmask "
+                "(zig = zig_f64, zig_bitmask = zig_f64_bitmask)"
             ),
         ),
     ],

--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -75,7 +75,7 @@ class Tool(str, Enum):
     lahuta_bitmask = "lahuta_bitmask"
 
 
-ALL_TOOLS = list(Tool)
+ALL_TOOLS = [Tool.zig, Tool.freesasa, Tool.rustsasa, Tool.lahuta]
 
 
 def get_root_dir() -> Path:

--- a/benchmarks/scripts/bench_common.py
+++ b/benchmarks/scripts/bench_common.py
@@ -25,15 +25,22 @@ TOOL_ALIASES = {"zig": "zig_f64", "zig_bitmask": "zig_f64_bitmask"}
 
 LAHUTA_BITMASK_POINTS = {64, 128, 256}
 
+BITMASK_CAPABLE_BASES = {"zig", "lahuta"}
+
 
 def parse_tool(tool: str) -> tuple[str, str, str, bool]:
     """Parse tool name into (canonical, base, precision, use_bitmask).
+
+    Raises:
+        ValueError: If a _bitmask suffix is used with a tool that does not
+            support bitmask mode.
 
     Examples:
         "zig_f64"          -> ("zig_f64", "zig", "f64", False)
         "zig_f32"          -> ("zig_f32", "zig", "f32", False)
         "zig"              -> ("zig_f64", "zig", "f64", False)  # alias
         "zig_f64_bitmask"  -> ("zig_f64_bitmask", "zig", "f64", True)
+        "zig_f32_bitmask"  -> ("zig_f32_bitmask", "zig", "f32", True)
         "zig_bitmask"      -> ("zig_f64_bitmask", "zig", "f64", True)  # alias
         "freesasa"         -> ("freesasa", "freesasa", "f64", False)
         "rust"             -> ("rust", "rust", "f64", False)
@@ -47,8 +54,19 @@ def parse_tool(tool: str) -> tuple[str, str, str, bool]:
     base_tool = tool.removesuffix("_bitmask") if use_bitmask else tool
 
     if base_tool.startswith("zig_f"):
-        return tool, "zig", base_tool.split("_")[1], use_bitmask
-    return tool, base_tool, "f64", use_bitmask
+        effective_base = "zig"
+        precision = base_tool.split("_")[1]
+    else:
+        effective_base = base_tool
+        precision = "f64"
+
+    if use_bitmask and effective_base not in BITMASK_CAPABLE_BASES:
+        raise ValueError(
+            f"Tool '{tool}' does not support bitmask mode. "
+            f"Bitmask is only supported for: {sorted(BITMASK_CAPABLE_BASES)}"
+        )
+
+    return tool, effective_base, precision, use_bitmask
 
 
 def parse_threads(threads_str: str) -> list[int]:

--- a/benchmarks/scripts/bench_lr.py
+++ b/benchmarks/scripts/bench_lr.py
@@ -145,7 +145,12 @@ def main(
         console.print(f"Available: {', '.join(LR_TOOLS)} (zig = zig_f64)")
         raise typer.Exit(1)
 
-    tool_canonical, tool_base, precision, _ = parse_tool(tool)
+    tool_canonical, tool_base, precision, use_bitmask = parse_tool(tool)
+    if use_bitmask:
+        console.print(
+            "[red]Error:[/red] Bitmask mode is not supported for LR benchmarks"
+        )
+        raise typer.Exit(1)
     thread_counts = parse_threads(threads)
 
     # Check binary exists

--- a/benchmarks/scripts/bench_md.py
+++ b/benchmarks/scripts/bench_md.py
@@ -6,7 +6,7 @@
 """Batch MD trajectory SASA benchmark using hyperfine.
 
 Compares SASA calculation performance across implementations:
-- zsasa CLI (Zig, traj mode, f32/f64)
+- zsasa CLI (Zig, traj mode, f32/f64, with optional bitmask neighbor list)
 - zsasa.mdtraj (Python wrapper)
 - zsasa.mdanalysis (Python wrapper)
 - MDTraj shrake_rupley (native, single-threaded)
@@ -26,6 +26,11 @@ Usage:
         --name 5vz0_R1 \\
         --tool zig --tool mdtraj \\
         --threads 1,4,8
+
+    # Bitmask variant
+    ./benchmarks/scripts/bench_md.py \\
+        --xtc traj.xtc --pdb top.pdb \\
+        --name test --tool zig_bitmask
 
     # Quick test with stride
     ./benchmarks/scripts/bench_md.py \\
@@ -75,7 +80,13 @@ class Tool(str, Enum):
     mdsasa_bolt = "mdsasa_bolt"
 
 
-ALL_TOOLS = list(Tool)
+ALL_TOOLS = [
+    Tool.zig,
+    Tool.zsasa_mdtraj,
+    Tool.zsasa_mdanalysis,
+    Tool.mdtraj,
+    Tool.mdsasa_bolt,
+]
 
 
 def get_root_dir() -> Path:


### PR DESCRIPTION
## Summary
- Replace `--use-bitmask` boolean flag with independent tool variants (`zig_bitmask`, `lahuta_bitmask`) selectable via `--tool`
- `bench_common.py`: `parse_tool()` returns 4-tuple `(canonical, base, precision, use_bitmask)`, add `LAHUTA_BITMASK_POINTS`, expand `TOOL_ALIASES`
- `bench_batch.py`: add `zig_bitmask`/`lahuta_bitmask` to `Tool` enum, remove `--use-bitmask` CLI flag
- `bench_md.py`: add `zig_bitmask` to `Tool` enum, remove `--use-bitmask` CLI flag
- `bench.py`: add bitmask variants to `SR_TOOLS`, pass `use_bitmask` to `_build_command()`
- `bench_lr.py`: update `parse_tool()` destructuring for 4-tuple

## Motivation
Previously, running bitmask benchmarks required a separate invocation with `--use-bitmask`. Now bitmask variants are first-class tools: default (no `--tool`) runs all variants including bitmask, and specific variants can be selected individually.

## Test plan
- [x] `parse_tool()` unit tests: 10 input cases all correct
- [x] `_build_command()` verified: `--use-bitmask` flag appears for zig/lahuta, ignored for freesasa/rust
- [x] All 5 files pass `py_compile` syntax check
- [x] Tool enums contain expected bitmask variants
- [x] `--use-bitmask` removed from `bench_batch.main()` and `bench_md.main()` signatures
- [x] `ruff format --check` passes
- [ ] `bench_batch.py --dry-run -i <dir> -n test --tool zig_bitmask` shows `--use-bitmask` in command
- [ ] `bench_batch.py --dry-run -i <dir> -n test` runs all 6 tools
- [ ] `bench.py --tool zig_f64_bitmask --warmup 0 --runs 1 --input <pdb>` runs with bitmask flag