### PR TITLE
fix: resolve input_dir to absolute path in lahuta batch benchmark

### DIFF
--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -286,6 +286,8 @@ def run_lahuta(
     single_tool: bool = False,
 ) -> list[dict]:
     """Run Lahuta benchmarks (AF2 PDB only, Shrake-Rupley)."""
+    # Resolve to absolute path since the command cd's to a temp directory
+    input_dir = input_dir.resolve()
     lahuta = binaries["lahuta"]
     if not lahuta.exists():
         console.print("[yellow][SKIP] lahuta not found[/]")


### PR DESCRIPTION
## Summary
- `run_lahuta` does `cd` to a temp directory before executing, so relative input paths passed via `-d` fail to resolve
- Added `input_dir = input_dir.resolve()` to convert to absolute path before use
- Other tools (zig, freesasa, rustsasa) are unaffected because they don't change the working directory

## Test plan
- [ ] Run `./benchmarks/scripts/bench_batch.py -i ./benchmarks/UP000000625_83333_ECOLI_v6/pdb -n ecoli -T 1 --tool lahuta` with relative path
- [ ] Verify lahuta benchmark completes without exit code 1