### PR TITLE
fix: merge tool list in config.json instead of overwriting

### DIFF
--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -499,6 +499,16 @@ def main(
     }
     if not dry_run:
         config_path = results_dir.joinpath("config.json")
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text())
+                existing_tools = existing.get("parameters", {}).get("tools", [])
+                merged_tools = list(
+                    dict.fromkeys(existing_tools + config["parameters"]["tools"])
+                )
+                config["parameters"]["tools"] = merged_tools
+            except (json.JSONDecodeError, KeyError):
+                pass
         config_path.write_text(json.dumps(config, indent=2))
 
     # Print header


### PR DESCRIPTION
## Summary
- When re-running benchmarks with `--tool lahuta` (or any subset), `config.json` was overwritten and lost the record of previously benchmarked tools
- Now merges the existing tools list with the new one (order-preserved, deduplicated)

## Test plan
- [ ] Run full benchmark, verify config.json has all tools
- [ ] Re-run with `--tool lahuta`, verify config.json still lists all tools