### PR TITLE
perf: replace readToEndAlloc with mmap for file reading

### DIFF
--- a/src/mmap_reader.zig
+++ b/src/mmap_reader.zig
@@ -1,11 +1,16 @@
 const std = @import("std");
 
+/// A read-only memory-mapped file region.
+///
+/// Ownership: single-owner, non-copyable by convention. Exactly one `deinit`
+/// call must occur per `mmapFile` call.
+/// Typical usage: `const mapped = try mmapFile(path); defer mapped.deinit();`
 pub const MappedFile = struct {
     data: []align(std.heap.page_size_min) const u8,
 
     pub fn deinit(self: MappedFile) void {
         if (self.data.len == 0) return;
-        std.posix.munmap(@constCast(self.data));
+        std.posix.munmap(self.data);
     }
 };
 
@@ -14,7 +19,7 @@ pub fn mmapFile(path: []const u8) !MappedFile {
     defer file.close();
 
     const stat = try file.stat();
-    const size = stat.size;
+    const size: usize = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
     if (size == 0) return .{ .data = &.{} };
 
     const mapped = try std.posix.mmap(

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -43,8 +43,6 @@ pub const ParseError = error{
     MissingCoordinateField,
     /// Invalid coordinate value (not a valid number)
     InvalidCoordinate,
-    /// File read error
-    FileReadError,
 };
 
 /// Column indices for atom_site fields
@@ -139,9 +137,7 @@ pub const MmcifParser = struct {
 
     /// Parse mmCIF from a file
     pub fn parseFile(self: *MmcifParser, path: []const u8) !AtomInput {
-        const mapped = mmap_reader.mmapFile(path) catch {
-            return ParseError.FileReadError;
-        };
+        const mapped = try mmap_reader.mmapFile(path);
         defer mapped.deinit();
         return self.parse(mapped.data);
     }

--- a/src/pdb_parser.zig
+++ b/src/pdb_parser.zig
@@ -42,8 +42,6 @@ const AtomInput = types.AtomInput;
 pub const ParseError = error{
     /// Invalid coordinate value
     InvalidCoordinate,
-    /// File read error
-    FileReadError,
     /// No atoms found in file
     NoAtomsFound,
     /// Line too short for required field
@@ -216,9 +214,7 @@ pub const PdbParser = struct {
 
     /// Parse PDB from a file
     pub fn parseFile(self: *PdbParser, path: []const u8) !AtomInput {
-        const mapped = mmap_reader.mmapFile(path) catch {
-            return ParseError.FileReadError;
-        };
+        const mapped = try mmap_reader.mmapFile(path);
         defer mapped.deinit();
         return self.parse(mapped.data);
     }


### PR DESCRIPTION
## Summary

- Replace `readToEndAlloc` (malloc + read + free) with `mmap` for PDB/mmCIF file reading
- Add shared `src/mmap_reader.zig` helper with `MappedFile` struct
- Eliminates 837MB of heap allocations during batch processing of 4370 files
- Reduces allocator contention across 10 worker threads

## Benchmark (4370 PDB files, 10 threads)

| Mode | Before | After | Delta |
|------|--------|-------|-------|
| SIMD | 3.6s | 3.40s | -5.6% |
| Bitmask | 1.5s | 1.18s | **-21.3%** |

## Test plan

- [x] `zig build test` — all tests pass
- [x] `zig build -Doptimize=ReleaseFast` — builds clean
- [x] Batch output matches pre-change results
- [ ] CI passes