### PR TITLE
perf: align traj parallel workers with batch allocator pattern

### DIFF
--- a/src/traj.zig
+++ b/src/traj.zig
@@ -438,7 +438,7 @@ fn setWorkerError(args: BatchWorkerArgs, comptime fmt: []const u8, fmt_args: any
 
 /// Worker function for batch frame processing.
 /// Each thread processes frames at indices: thread_id, thread_id + n_threads, ...
-/// Allocates per-thread coordinate buffers and reuses them across frames.
+/// Allocates coordinate buffers per frame; arena reset retains backing memory.
 fn batchWorkerFn(args: BatchWorkerArgs) void {
     // Use smp_allocator as arena backing to avoid mmap/munmap syscall contention
     // that page_allocator causes under multi-threaded workloads.


### PR DESCRIPTION
## Summary
- Replace `page_allocator` with `smp_allocator` as arena backing in traj `batchWorkerFn` to avoid mmap/munmap syscall contention under multi-threaded workloads
- Add `arena.reset(.retain_capacity)` between frames to prevent memory accumulation (coordinate buffers re-allocated inside the loop, ~free with retain_capacity)
- Aligns traj mode's parallel worker pattern with batch mode (PR #229/#230)

## Benchmark (6sup_A 33K atoms, 3tvj_I 531 atoms, 10 threads)
- Output: bit-identical
- Wall clock: within noise (~1.01x)
- System time: ~10% reduction on small proteins (fewer syscalls)
- Primary value: code pattern consistency with batch.zig

## Test plan
- [x] `zig build test` passes
- [x] Output identical between main and feature branch
- [x] Benchmarked with SR and bitmask modes on small/large proteins