### PR TITLE
fix: use --format=jsonl for zsasa batch benchmark

### DIFF
--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -182,14 +182,14 @@ def run_zig(
 
     for precision in ["f64", "f32"]:
         with tempfile.TemporaryDirectory(prefix=f"zsasa_{precision}_") as tmp:
-            out_dir = Path(tmp)
+            out_file = Path(tmp).joinpath("sasa.jsonl")
 
             for n_threads in thread_counts:
                 bitmask_flag = " --use-bitmask" if use_bitmask else ""
                 bench_name = f"zsasa_{precision}{bitmask_suffix}_{n_threads}t"
                 result = run_benchmark(
                     bench_name,
-                    f"{quote_path(zsasa)} batch {quote_path(input_dir)} {quote_path(out_dir)} --threads={n_threads} --precision={precision} --n-points={n_points}{bitmask_flag}",
+                    f"{quote_path(zsasa)} batch {quote_path(input_dir)} --format=jsonl -o {quote_path(out_file)} --threads={n_threads} --precision={precision} --n-points={n_points}{bitmask_flag}",
                     results_dir,
                     warmup,
                     runs,


### PR DESCRIPTION
## Summary
- Switch zsasa batch benchmark from per-file directory writes to `--format=jsonl` output
- Avoids parallel I/O contention during multi-threaded computation by deferring all output to a single sequential write after completion
- Other tools (freesasa, rustsasa, lahuta) remain unchanged as their output paths are mandatory arguments

## Test plan
- [x] Verified with `--dry-run` that correct command is generated for both normal and bitmask variants