### PR TITLE
feat: auto-build zsasa ReleaseFast for benchmarks

### DIFF
--- a/benchmarks/external/setup.sh
+++ b/benchmarks/external/setup.sh
@@ -95,8 +95,7 @@ build_lahuta() {
 
 build_zsasa() {
     info "zsasa (ReleaseFast)"
-    cd "$PROJECT_ROOT"
-    zig build --release=fast
+    (cd "$PROJECT_ROOT" && zig build --release=fast)
     local zsasa="$PROJECT_ROOT/zig-out/bin/zsasa"
     if [ -f "$zsasa" ]; then
         symlink "$zsasa" zsasa

--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -480,9 +480,9 @@ def main(
     # Default to all tools if none specified
     selected_tools = tools if tools else ALL_TOOLS
 
-    # Build zsasa ReleaseFast when any zig variant is selected
+    # Rebuild zsasa in ReleaseFast mode to ensure benchmarks use optimized code
     zig_tools = {Tool.zig, Tool.zig_bitmask}
-    if zig_tools & set(selected_tools):
+    if not dry_run and zig_tools & set(selected_tools):
         ensure_zsasa_built()
 
     # Set up paths

--- a/benchmarks/scripts/bench_common.py
+++ b/benchmarks/scripts/bench_common.py
@@ -1,8 +1,8 @@
 """Shared benchmark utilities.
 
-Pure library module imported by bench.py, bench_lr.py, and bench_batch.py.
-Contains binary path resolution, parsing helpers, system info, hyperfine runner,
-and I/O utilities.
+Library module imported by bench.py, bench_lr.py, and bench_batch.py.
+Contains build helpers, binary path resolution, parsing helpers, system info,
+hyperfine runner, and I/O utilities.
 """
 
 from __future__ import annotations
@@ -25,14 +25,41 @@ TOOL_ALIASES = {"zig": "zig_f64", "zig_bitmask": "zig_f64_bitmask"}
 
 
 def ensure_zsasa_built() -> None:
-    """Build zsasa with ReleaseFast for accurate benchmarking."""
+    """Build zsasa with ReleaseFast and ensure the external/bin symlink exists."""
     root = Path(__file__).parent.parent.parent
     console.print("[bold]Building zsasa (ReleaseFast)...[/]")
-    subprocess.run(
-        ["zig", "build", "--release=fast"],
-        cwd=root,
-        check=True,
-    )
+    try:
+        subprocess.run(
+            ["zig", "build", "--release=fast"],
+            cwd=root,
+            check=True,
+        )
+    except FileNotFoundError:
+        console.print(
+            "[red]Error: 'zig' not found on PATH. "
+            "Install Zig (https://ziglang.org/download/) and ensure it is on your PATH.[/red]"
+        )
+        raise SystemExit(1) from None
+    except subprocess.CalledProcessError as e:
+        console.print(
+            f"[red]Error: 'zig build --release=fast' failed (exit code {e.returncode}). "
+            f"Check compiler output above.[/red]"
+        )
+        raise SystemExit(1) from e
+
+    binary = root.joinpath("zig-out", "bin", "zsasa")
+    if not binary.exists():
+        console.print(
+            f"[red]Error: Build succeeded but binary not found at {binary}[/red]"
+        )
+        raise SystemExit(1)
+
+    # Ensure symlink in external/bin/ points to the freshly built binary
+    bin_dir = root.joinpath("benchmarks", "external", "bin")
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    symlink = bin_dir.joinpath("zsasa")
+    symlink.unlink(missing_ok=True)
+    symlink.symlink_to(binary)
 
 
 LAHUTA_BITMASK_POINTS = {64, 128, 256}


### PR DESCRIPTION
## Summary
- Add `ensure_zsasa_built()` to `bench_common.py` that runs `zig build --release=fast`
- Call it in `bench_batch.py` before benchmarking when any zig tool is selected
- Change `link_zsasa()` to `build_zsasa()` in `setup.sh` to build with ReleaseFast instead of just symlinking

Prevents accidentally benchmarking a Debug binary (7x slower) when `zig build` has overwritten `zig-out/bin/zsasa`. Matches how other tools build with optimizations (RustSASA uses `--release`, Lahuta uses `CMAKE_BUILD_TYPE=Release`).

## Test plan
- [ ] Run `zig build` (Debug), then `bench_batch.py --tool zig --dry-run` — verify ReleaseFast build runs first
- [ ] Run `benchmarks/external/setup.sh zsasa` — verify it builds ReleaseFast and symlinks
- [ ] Run `bench_batch.py --tool freesasa --dry-run` — verify no zig build triggered
- [ ] Verify `time zig-out/bin/zsasa batch ... --quiet` shows ~4-5s (not ~32s Debug)