### PR TITLE
fix: handle missing stddev in bench summary when runs=1

### DIFF
--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -385,7 +385,7 @@ def print_summary(results_dir: Path) -> None:
                     table.add_row(
                         name,
                         f"{r['mean']:.3f}",
-                        f"±{r['stddev']:.3f}",
+                        f"±{r['stddev']:.3f}" if r.get("stddev") is not None else "N/A",
                         f"{r['min']:.3f}",
                         f"{r['max']:.3f}",
                     )


### PR DESCRIPTION
## Summary
- Fix crash in `bench_batch.py` summary table when `--runs=1` (stddev is None)

## Test plan
- [x] Run `bench_batch.py` with `-r 1` and verify summary prints without error