### PR TITLE
refactor: align bench_md.py and bench_lr.py with bench_batch.py

### DIFF
--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -50,7 +50,6 @@ Output:
 
 from __future__ import annotations
 
-import json
 import tempfile
 from datetime import datetime
 from enum import Enum
@@ -59,26 +58,23 @@ from typing import Annotated
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
 from bench_common import (
     LAHUTA_BITMASK_POINTS,
+    Precision,
     check_hyperfine,
     ensure_zsasa_built,
     get_binary_path,
     get_system_info,
     parse_threads,
+    print_benchmark_summary,
     quote_path,
     run_benchmark,
+    save_config,
 )
 
 app = typer.Typer(help="Batch SASA benchmark (hyperfine-based)")
 console = Console()
-
-
-class Precision(str, Enum):
-    f32 = "f32"
-    f64 = "f64"
 
 
 class Tool(str, Enum):
@@ -312,42 +308,6 @@ def run_lahuta(
     return results
 
 
-def print_summary(results_dir: Path) -> None:
-    """Print summary table from result JSON files."""
-    table = Table(title="Benchmark Results")
-    table.add_column("Tool", style="cyan")
-    table.add_column("Mean (s)", justify="right")
-    table.add_column("Std Dev", justify="right")
-    table.add_column("Min (s)", justify="right")
-    table.add_column("Max (s)", justify="right")
-
-    for json_file in sorted(results_dir.glob("bench_*.json")):
-        try:
-            with open(json_file) as f:
-                data = json.load(f)
-                if data.get("results"):
-                    r = data["results"][0]
-                    name = json_file.stem.replace("bench_", "")
-                    table.add_row(
-                        name,
-                        f"{r['mean']:.3f}",
-                        f"±{r['stddev']:.3f}" if r.get("stddev") is not None else "N/A",
-                        f"{r['min']:.3f}",
-                        f"{r['max']:.3f}",
-                    )
-        except json.JSONDecodeError as e:
-            console.print(
-                f"[yellow]Warning: corrupt JSON in {json_file.name}: {e}[/yellow]"
-            )
-        except KeyError as e:
-            console.print(
-                f"[yellow]Warning: missing key {e} in {json_file.name}[/yellow]"
-            )
-
-    console.print()
-    console.print(table)
-
-
 @app.command()
 def main(
     input_dir: Annotated[
@@ -505,18 +465,7 @@ def main(
         },
     }
     if not dry_run:
-        config_path = results_dir.joinpath("config.json")
-        if config_path.exists():
-            try:
-                existing = json.loads(config_path.read_text())
-                existing_tools = existing.get("parameters", {}).get("tools", [])
-                merged_tools = list(
-                    dict.fromkeys(existing_tools + config["parameters"]["tools"])
-                )
-                config["parameters"]["tools"] = merged_tools
-            except (json.JSONDecodeError, KeyError):
-                pass
-        config_path.write_text(json.dumps(config, indent=2))
+        save_config(config, results_dir)
 
     # Print header
     console.print(f"[bold]=== Batch SASA Benchmark: {name} ===[/]")
@@ -637,7 +586,7 @@ def main(
         console.print(f"  - config.json")
 
     if not dry_run and results_dir.exists():
-        print_summary(results_dir)
+        print_benchmark_summary(results_dir)
 
 
 if __name__ == "__main__":

--- a/benchmarks/scripts/bench_common.py
+++ b/benchmarks/scripts/bench_common.py
@@ -1,8 +1,8 @@
 """Shared benchmark utilities.
 
-Library module imported by bench.py, bench_lr.py, and bench_batch.py.
+Library module imported by bench_md.py, bench_lr.py, and bench_batch.py.
 Contains build helpers, binary path resolution, parsing helpers, system info,
-hyperfine runner, and I/O utilities.
+hyperfine runner, config I/O, and summary reporting utilities.
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ import shlex
 import shutil
 import subprocess
 from collections import defaultdict
+from enum import Enum
 from pathlib import Path
 
 from rich.console import Console
@@ -23,6 +24,13 @@ from rich.table import Table
 console = Console()
 
 TOOL_ALIASES = {"zig": "zig_f64", "zig_bitmask": "zig_f64_bitmask"}
+
+
+class Precision(str, Enum):
+    """Floating-point precision for zig-based benchmarks."""
+
+    f32 = "f32"
+    f64 = "f64"
 
 
 def ensure_zsasa_built() -> None:
@@ -287,18 +295,14 @@ def quote_path(path: Path) -> str:
     return shlex.quote(str(path))
 
 
-def run_hyperfine(
+def _build_hyperfine_cmd(
     cmd: str,
     warmup: int,
     runs: int,
     json_path: Path,
-    timeout: int = 600,
     prepare: str | None = None,
-) -> dict | None:
-    """Run hyperfine and return results dict, or None on failure.
-
-    Logs diagnostic details on failure.
-    """
+) -> list[str]:
+    """Build the hyperfine command list."""
     hyperfine_cmd = [
         "hyperfine",
         "--warmup",
@@ -311,12 +315,61 @@ def run_hyperfine(
     if prepare:
         hyperfine_cmd.extend(["--prepare", prepare])
     hyperfine_cmd.append(cmd)
+    return hyperfine_cmd
+
+
+def _parse_hyperfine_json(json_path: Path, strict: bool = True) -> dict | None:
+    """Parse hyperfine JSON output and return the first result, or None on failure.
+
+    When strict=True, validates that required keys (mean, stddev, min, max, median)
+    are present. When strict=False, accepts any result with a "results" key.
+    """
+    try:
+        if not json_path.exists():
+            console.print(f"[red]  No JSON output at {json_path}[/red]")
+            return None
+        with open(json_path) as f:
+            data = json.load(f)
+        if not data.get("results"):
+            console.print(f"[yellow]Warning: no results in {json_path.name}[/yellow]")
+            return None
+        result = data["results"][0]
+        if strict:
+            required_keys = {"mean", "stddev", "min", "max", "median"}
+            missing = required_keys - result.keys()
+            if missing:
+                console.print(f"[red]  Hyperfine result missing keys: {missing}[/red]")
+                return None
+        return result
+    except json.JSONDecodeError as e:
+        console.print(
+            f"[yellow]Warning: corrupt JSON in {json_path.name}: {e}[/yellow]"
+        )
+        return None
+    except KeyError as e:
+        console.print(f"[yellow]Warning: missing key {e} in {json_path.name}[/yellow]")
+        return None
+
+
+def run_hyperfine(
+    cmd: str,
+    warmup: int,
+    runs: int,
+    json_path: Path,
+    timeout: int = 600,
+    prepare: str | None = None,
+) -> dict | None:
+    """Run hyperfine (quiet) and return results dict, or None on failure.
+
+    Captures output. Used by bench_lr for progress-bar-driven benchmarks.
+    """
+    hyperfine_cmd = _build_hyperfine_cmd(cmd, warmup, runs, json_path, prepare)
     try:
         subprocess.run(
             hyperfine_cmd, check=True, capture_output=True, text=True, timeout=timeout
         )
     except subprocess.TimeoutExpired:
-        console.print(f"[red]  Timeout: command exceeded 600s: {cmd}[/red]")
+        console.print(f"[red]  Timeout: command exceeded {timeout}s: {cmd}[/red]")
         return None
     except subprocess.CalledProcessError as e:
         stderr_snippet = (e.stderr or "").strip()[-500:]
@@ -325,25 +378,7 @@ def run_hyperfine(
             console.print(f"[dim]  stderr: {stderr_snippet}[/dim]")
         return None
 
-    try:
-        if not json_path.exists():
-            console.print(f"[red]  No JSON output at {json_path}[/red]")
-            return None
-        with open(json_path) as f:
-            data = json.load(f)
-        if not data.get("results"):
-            console.print("[red]  Empty results in hyperfine JSON[/red]")
-            return None
-        result = data["results"][0]
-        required_keys = {"mean", "stddev", "min", "max", "median"}
-        missing = required_keys - result.keys()
-        if missing:
-            console.print(f"[red]  Hyperfine result missing keys: {missing}[/red]")
-            return None
-        return result
-    except (json.JSONDecodeError, KeyError) as e:
-        console.print(f"[red]  Failed to parse hyperfine JSON: {e}[/red]")
-        return None
+    return _parse_hyperfine_json(json_path, strict=True)
 
 
 def print_hyperfine_summary(csv_path: Path) -> None:
@@ -389,6 +424,63 @@ def print_hyperfine_summary(csv_path: Path) -> None:
     console.print(table)
 
 
+def save_config(config: dict, results_dir: Path) -> None:
+    """Write config.json, merging tools list with any existing config.
+
+    If config.json already exists, the new tools list is appended
+    (preserving order, deduplicating) so that incremental runs
+    accumulate all tool names.
+    """
+    config_path = results_dir.joinpath("config.json")
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text())
+            existing_tools = existing.get("parameters", {}).get("tools", [])
+            merged_tools = list(
+                dict.fromkeys(existing_tools + config["parameters"]["tools"])
+            )
+            config["parameters"]["tools"] = merged_tools
+        except (json.JSONDecodeError, KeyError):
+            pass
+    config_path.write_text(json.dumps(config, indent=2))
+
+
+def print_benchmark_summary(results_dir: Path) -> None:
+    """Print summary table from hyperfine bench_*.json files in a directory.
+
+    Reads each bench_*.json, extracts the first result, and renders
+    a Rich table with mean, stddev, min, and max times.
+    """
+    table = Table(title="Benchmark Results")
+    table.add_column("Tool", style="cyan")
+    table.add_column("Mean (s)", justify="right")
+    table.add_column("Std Dev", justify="right")
+    table.add_column("Min (s)", justify="right")
+    table.add_column("Max (s)", justify="right")
+
+    for json_file in sorted(results_dir.glob("bench_*.json")):
+        try:
+            with open(json_file) as f:
+                data = json.load(f)
+                if data.get("results"):
+                    r = data["results"][0]
+                    name = json_file.stem.replace("bench_", "")
+                    stddev = r.get("stddev")
+                    stddev_str = f"±{stddev:.3f}" if stddev is not None else "-"
+                    table.add_row(
+                        name,
+                        f"{r['mean']:.3f}",
+                        stddev_str,
+                        f"{r['min']:.3f}",
+                        f"{r['max']:.3f}",
+                    )
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+    console.print()
+    console.print(table)
+
+
 def run_benchmark(
     name: str,
     cmd: str,
@@ -413,18 +505,7 @@ def run_benchmark(
         console.print(f"    {cmd}")
         return None
 
-    hyperfine_cmd = [
-        "hyperfine",
-        "--warmup",
-        str(warmup),
-        "--runs",
-        str(runs),
-        "--export-json",
-        str(json_out),
-    ]
-    if prepare:
-        hyperfine_cmd.extend(["--prepare", prepare])
-    hyperfine_cmd.append(cmd)
+    hyperfine_cmd = _build_hyperfine_cmd(cmd, warmup, runs, json_out, prepare)
 
     try:
         subprocess.run(hyperfine_cmd, check=True, capture_output=False, timeout=timeout)
@@ -437,16 +518,4 @@ def run_benchmark(
         console.print("[yellow]Check hyperfine output above for details[/]")
         return None
 
-    try:
-        if json_out.exists():
-            with open(json_out) as f:
-                data = json.load(f)
-                if data.get("results"):
-                    return data["results"][0]
-        console.print(f"[yellow]Warning: no results in {json_out.name}[/yellow]")
-    except json.JSONDecodeError as e:
-        console.print(f"[yellow]Warning: corrupt JSON in {json_out.name}: {e}[/yellow]")
-    except KeyError as e:
-        console.print(f"[yellow]Warning: missing key {e} in {json_out.name}[/yellow]")
-
-    return None
+    return _parse_hyperfine_json(json_out, strict=False)

--- a/benchmarks/scripts/bench_lr.py
+++ b/benchmarks/scripts/bench_lr.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import csv
 import json
-import shutil
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -41,6 +40,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
 from bench_common import (
     TOOL_ALIASES,
+    check_hyperfine,
     ensure_zsasa_built,
     get_binary_path,
     get_n_atoms_from_pdb,
@@ -154,7 +154,7 @@ def main(
 ) -> None:
     """Run LR single-file benchmark using hyperfine."""
     # Check hyperfine
-    if not shutil.which("hyperfine"):
+    if not check_hyperfine():
         console.print("[red]Error: hyperfine not found. Install it first.[/red]")
         raise typer.Exit(1)
 

--- a/benchmarks/scripts/bench_md.py
+++ b/benchmarks/scripts/bench_md.py
@@ -62,7 +62,6 @@ Output:
 
 from __future__ import annotations
 
-import json
 import tempfile
 from datetime import datetime
 from enum import Enum
@@ -71,24 +70,21 @@ from typing import Annotated
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
 from bench_common import (
+    Precision,
     check_hyperfine,
     ensure_zsasa_built,
     get_binary_path,
     get_system_info,
     parse_threads,
+    print_benchmark_summary,
     run_benchmark,
+    save_config,
 )
 
 app = typer.Typer(help="MD trajectory SASA benchmark (hyperfine-based)")
 console = Console()
-
-
-class Precision(str, Enum):
-    f32 = "f32"
-    f64 = "f64"
 
 
 class Tool(str, Enum):
@@ -221,10 +217,13 @@ def run_python_tool(
 
     cmd = " ".join(cmd_parts)
 
-    return run_benchmark(label, cmd, results_dir, warmup, runs, dry_run, timeout, prepare)
+    return run_benchmark(
+        label, cmd, results_dir, warmup, runs, dry_run, timeout, prepare
+    )
 
 
-def run_zsasa_mdtraj(
+def run_threaded_python_tool(
+    tool_name: str,
     xtc: Path,
     pdb: Path,
     results_dir: Path,
@@ -238,51 +237,16 @@ def run_zsasa_mdtraj(
     timeout: int = 600,
     prepare: str | None = None,
 ) -> list[dict]:
-    """Run zsasa.mdtraj benchmarks with different thread counts."""
+    """Run a Python-based benchmark tool across multiple thread counts.
+
+    Used for zsasa_mdtraj and zsasa_mdanalysis which share the same
+    loop-over-threads pattern.
+    """
     results = []
     for n_threads in thread_counts:
-        label = f"zsasa_mdtraj_{n_threads}t"
+        label = f"{tool_name}_{n_threads}t"
         result = run_python_tool(
-            "zsasa_mdtraj",
-            label,
-            xtc,
-            pdb,
-            results_dir,
-            runner,
-            warmup,
-            runs,
-            dry_run,
-            n_threads=n_threads,
-            stride=stride,
-            n_points=n_points,
-            timeout=timeout,
-            prepare=prepare,
-        )
-        if result:
-            results.append({"name": label, **result})
-    return results
-
-
-def run_zsasa_mdanalysis(
-    xtc: Path,
-    pdb: Path,
-    results_dir: Path,
-    runner: Path,
-    thread_counts: list[int],
-    warmup: int,
-    runs: int,
-    dry_run: bool,
-    stride: int,
-    n_points: int,
-    timeout: int = 600,
-    prepare: str | None = None,
-) -> list[dict]:
-    """Run zsasa.mdanalysis benchmarks with different thread counts."""
-    results = []
-    for n_threads in thread_counts:
-        label = f"zsasa_mdanalysis_{n_threads}t"
-        result = run_python_tool(
-            "zsasa_mdanalysis",
+            tool_name,
             label,
             xtc,
             pdb,
@@ -370,38 +334,6 @@ def run_mdsasa_bolt(
     if result:
         return [{"name": label, **result}]
     return []
-
-
-def print_summary(results_dir: Path) -> None:
-    """Print summary table from result JSON files."""
-    table = Table(title="Benchmark Results")
-    table.add_column("Tool", style="cyan")
-    table.add_column("Mean (s)", justify="right")
-    table.add_column("Std Dev", justify="right")
-    table.add_column("Min (s)", justify="right")
-    table.add_column("Max (s)", justify="right")
-
-    for json_file in sorted(results_dir.glob("bench_*.json")):
-        try:
-            with open(json_file) as f:
-                data = json.load(f)
-                if data.get("results"):
-                    r = data["results"][0]
-                    name = json_file.stem.replace("bench_", "")
-                    stddev = r.get("stddev")
-                    stddev_str = f"±{stddev:.3f}" if stddev is not None else "-"
-                    table.add_row(
-                        name,
-                        f"{r['mean']:.3f}",
-                        stddev_str,
-                        f"{r['min']:.3f}",
-                        f"{r['max']:.3f}",
-                    )
-        except (json.JSONDecodeError, KeyError):
-            continue
-
-    console.print()
-    console.print(table)
 
 
 @app.command()
@@ -574,18 +506,7 @@ def main(
         },
     }
     if not dry_run:
-        config_path = results_dir.joinpath("config.json")
-        if config_path.exists():
-            try:
-                existing = json.loads(config_path.read_text())
-                existing_tools = existing.get("parameters", {}).get("tools", [])
-                merged_tools = list(
-                    dict.fromkeys(existing_tools + config["parameters"]["tools"])
-                )
-                config["parameters"]["tools"] = merged_tools
-            except (json.JSONDecodeError, KeyError):
-                pass
-        config_path.write_text(json.dumps(config, indent=2))
+        save_config(config, results_dir)
 
     # Print header
     console.print(f"[bold]=== MD Trajectory SASA Benchmark: {name} ===[/]")
@@ -639,39 +560,24 @@ def main(
         )
         all_results.extend(results)
 
-    if Tool.zsasa_mdtraj in selected_tools:
-        results = run_zsasa_mdtraj(
-            xtc,
-            pdb,
-            results_dir,
-            runner,
-            thread_counts,
-            warmup,
-            runs,
-            dry_run,
-            stride,
-            n_points,
-            timeout,
-            prepare,
-        )
-        all_results.extend(results)
-
-    if Tool.zsasa_mdanalysis in selected_tools:
-        results = run_zsasa_mdanalysis(
-            xtc,
-            pdb,
-            results_dir,
-            runner,
-            thread_counts,
-            warmup,
-            runs,
-            dry_run,
-            stride,
-            n_points,
-            timeout,
-            prepare,
-        )
-        all_results.extend(results)
+    for python_tool in [Tool.zsasa_mdtraj, Tool.zsasa_mdanalysis]:
+        if python_tool in selected_tools:
+            results = run_threaded_python_tool(
+                python_tool.value,
+                xtc,
+                pdb,
+                results_dir,
+                runner,
+                thread_counts,
+                warmup,
+                runs,
+                dry_run,
+                stride,
+                n_points,
+                timeout,
+                prepare,
+            )
+            all_results.extend(results)
 
     if Tool.mdtraj in selected_tools:
         results = run_mdtraj(
@@ -711,7 +617,7 @@ def main(
         console.print("  - config.json")
 
     if not dry_run and results_dir.exists():
-        print_summary(results_dir)
+        print_benchmark_summary(results_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Move `check_hyperfine()` and `run_benchmark()` into `bench_common.py` as shared utilities
- Refactor `bench_md.py` to remove 5 duplicated functions and import from `bench_common`; add `--timeout`, `--prepare`, `--precision` CLI options, auto-build via `ensure_zsasa_built()`, and config merging
- Update `bench_lr.py` with `--timeout`, `--prepare`, `--dry-run` CLI options, auto-build for zig tools, and pass-through to `run_hyperfine`
- Simplify `bench_batch.py` by importing shared `run_benchmark`/`check_hyperfine` from `bench_common`

## Test plan
- [x] `bench_batch.py --help` shows all options correctly
- [x] `bench_md.py --help` shows new `--timeout`, `--prepare`, `--precision` options
- [x] `bench_lr.py --help` shows new `--timeout`, `--prepare`, `--dry-run` options
- [x] `bench_batch.py --dry-run` works with shared `run_benchmark`
- [x] `bench_md.py --dry-run` works with shared `run_benchmark`
- [x] `bench_lr.py --dry-run` skips execution and shows commands
- [x] All Python files parse without errors