### PR TITLE
feat: add multi-tool support to bench.py and bench_lr.py

### DIFF
--- a/benchmarks/scripts/bench.py
+++ b/benchmarks/scripts/bench.py
@@ -5,16 +5,21 @@
 # ///
 """SR single-file benchmark runner (hyperfine).
 
-Runs wall-clock benchmarks for a single tool using the Shrake-Rupley algorithm
-with configurable thread counts. Uses hyperfine for timing (includes I/O).
+Runs wall-clock benchmarks using the Shrake-Rupley algorithm with configurable
+thread counts. Uses hyperfine for timing (includes I/O).
 
 Tools: zig_f64, zig_f32, zig_f64_bitmask, zig_f32_bitmask, freesasa, rust,
        lahuta, lahuta_bitmask (zig = zig_f64, zig_bitmask = zig_f64_bitmask)
 
 Usage:
+    # All tools (default)
+    ./benchmarks/scripts/bench.py --threads 1,4,8
+
+    # Specific tools
+    ./benchmarks/scripts/bench.py --tool zig_f64 --tool freesasa --threads 1,4,8
+
+    # Single tool
     ./benchmarks/scripts/bench.py --tool zig_f64 --threads 1,4,8
-    ./benchmarks/scripts/bench.py --tool zig_f64_bitmask --threads 1,4,8
-    ./benchmarks/scripts/bench.py --tool freesasa --threads 1 --warmup 3 --runs 10
 
     # Quick test (single file, 1 hyperfine run, no warmup)
     ./benchmarks/scripts/bench.py --tool zig_f64 --threads 1 --warmup 0 --runs 1 \
@@ -118,104 +123,43 @@ def _build_command(
         raise ValueError(f"No command builder for tool base: {base}")
 
 
-@app.command()
-def main(
-    tool: Annotated[
-        str,
-        typer.Option(
-            "--tool",
-            "-t",
-            help=(
-                "Tool: zig_f64, zig_f32, zig_f64_bitmask, zig_f32_bitmask, "
-                "freesasa, rust, lahuta, lahuta_bitmask "
-                "(zig = zig_f64, zig_bitmask = zig_f64_bitmask)"
-            ),
-        ),
-    ],
-    threads: Annotated[
-        str,
-        typer.Option("--threads", "-T", help="Thread counts: '1,4,10' or '1-10'"),
-    ] = "1,4,10",
-    runs: Annotated[
-        int,
-        typer.Option("--runs", "-r", help="Number of hyperfine runs per configuration"),
-    ] = 5,
-    warmup: Annotated[
-        int,
-        typer.Option("--warmup", "-w", help="Hyperfine warmup runs"),
-    ] = 1,
-    output_dir: Annotated[
-        Path | None,
-        typer.Option("--output-dir", "-o", help="Output directory"),
-    ] = None,
-    input_dir: Annotated[
-        Path | None,
-        typer.Option("--input-dir", "-i", help="Input directory with .pdb files"),
-    ] = None,
-    input_file: Annotated[
-        Path | None,
-        typer.Option("--input", help="Single .pdb file to benchmark"),
-    ] = None,
-    sample_file: Annotated[
-        Path | None,
-        typer.Option("--sample-file", "-S", help="Sample file to filter structures"),
-    ] = None,
-    n_points: Annotated[
-        int,
-        typer.Option("--n-points", "-N", help="Number of sphere test points per atom"),
-    ] = 100,
-    timeout: Annotated[
-        int,
-        typer.Option(
-            "--timeout", help="Timeout per benchmark in seconds (default: 600)"
-        ),
-    ] = 600,
-    prepare: Annotated[
-        str | None,
-        typer.Option(
-            "--prepare",
-            "-p",
-            help="Shell command to run before each timing run (passed to hyperfine --prepare). "
-            "E.g. 'sync' or 'sudo purge' (macOS) to clear filesystem caches.",
-        ),
-    ] = None,
-    dry_run: Annotated[
-        bool,
-        typer.Option("--dry-run", help="Show commands without running"),
-    ] = False,
-    force: Annotated[
-        bool,
-        typer.Option("--force", "-f", help="Overwrite existing results"),
-    ] = False,
-) -> None:
-    """Run SR single-file benchmark using hyperfine."""
-    # Mutual exclusivity check
-    if input_file is not None and input_dir is not None:
-        console.print(
-            "[red]Error:[/red] --input and --input-dir are mutually exclusive"
-        )
-        raise typer.Exit(1)
+def _resolve_tools(tools: list[str] | None) -> list[str]:
+    """Resolve tool list: None or ["all"] -> SR_TOOLS, otherwise validate."""
+    if tools is None or tools == ["all"]:
+        return list(SR_TOOLS)
 
-    # Check hyperfine
-    if not dry_run and not check_hyperfine():
-        console.print("[red]Error: hyperfine not found. Install it first.[/red]")
-        raise typer.Exit(1)
-
-    # Parse tool
     all_valid = SR_TOOLS + list(TOOL_ALIASES.keys())
-    if tool not in all_valid:
-        console.print(f"[red]Error:[/red] Unknown tool: {tool}")
-        console.print(
-            f"Available: {', '.join(SR_TOOLS)} (zig = zig_f64, zig_bitmask = zig_f64_bitmask)"
-        )
-        raise typer.Exit(1)
+    for t in tools:
+        if t == "all":
+            return list(SR_TOOLS)
+        if t not in all_valid:
+            console.print(f"[red]Error:[/red] Unknown tool: {t}")
+            console.print(
+                f"Available: all, {', '.join(SR_TOOLS)} "
+                f"(zig = zig_f64, zig_bitmask = zig_f64_bitmask)"
+            )
+            raise typer.Exit(1)
+    return list(tools)
 
-    tool_canonical, tool_base, precision, use_bitmask = parse_tool(tool)
-    thread_counts = parse_threads(threads)
 
-    # Auto-build zsasa for zig-based tools
-    if not dry_run and tool_base == "zig":
-        ensure_zsasa_built()
+def _run_tool(
+    tool_name: str,
+    *,
+    structures: list[tuple[str, int]],
+    pdb_dir: Path,
+    thread_counts: list[int],
+    n_points: int,
+    warmup: int,
+    runs: int,
+    timeout: int,
+    prepare: str | None,
+    output_dir: Path,
+    force: bool,
+    timestamp: str,
+    sample_file: Path | None,
+) -> bool:
+    """Run benchmarks for a single tool. Returns True on success."""
+    tool_canonical, tool_base, precision, use_bitmask = parse_tool(tool_name)
 
     # Validate lahuta bitmask n_points
     if tool_base == "lahuta" and use_bitmask and n_points not in LAHUTA_BITMASK_POINTS:
@@ -223,102 +167,48 @@ def main(
             f"[red]Error:[/red] lahuta_bitmask only supports n_points "
             f"{sorted(LAHUTA_BITMASK_POINTS)}, got {n_points}."
         )
-        raise typer.Exit(1)
+        return False
 
     # Check binary exists
-    if not dry_run:
-        binary = get_binary_path(tool_base)
-        if not binary.exists():
-            console.print(f"[red]Error:[/red] Binary not found: {binary}")
-            raise typer.Exit(1)
-
-    # Resolve input: single file or directory
-    if input_file is not None:
-        if not input_file.exists():
-            console.print(f"[red]Error:[/red] Input file not found: {input_file}")
-            raise typer.Exit(1)
-        pdb_dir = input_file.parent
-        pdb_id = input_file.stem
-        structures = [(pdb_id, 0)]
-    else:
-        if input_dir is not None:
-            if not input_dir.exists():
-                console.print(
-                    f"[red]Error:[/red] Input directory not found: {input_dir}"
-                )
-                raise typer.Exit(1)
-            pdb_dir = input_dir
-        else:
-            pdb_dir = Path(__file__).parent.parent.joinpath("dataset", "pdb")
-            if not pdb_dir.exists():
-                console.print(f"[red]Error:[/red] Default dataset not found: {pdb_dir}")
-                raise typer.Exit(1)
-
-        structures = scan_input_directory(pdb_dir)
-        if not structures:
-            console.print(f"[red]Error:[/red] No .pdb files found in {pdb_dir}")
-            raise typer.Exit(1)
-
-        # Filter by sample file
-        if sample_file is not None:
-            if not sample_file.exists():
-                console.print(f"[red]Error:[/red] Sample file not found: {sample_file}")
-                raise typer.Exit(1)
-            sample_ids = set(load_sample_file(sample_file))
-            structures = [
-                (pdb_id, n) for pdb_id, n in structures if pdb_id in sample_ids
-            ]
-            if not structures:
-                console.print("[red]Error:[/red] No matching structures found")
-                raise typer.Exit(1)
-            console.print(
-                f"Loaded [cyan]{len(sample_ids):,}[/cyan] samples from {sample_file}"
-            )
-
-    console.print(f"Found [cyan]{len(structures):,}[/cyan] structures in {pdb_dir}")
+    binary = get_binary_path(tool_base)
+    if not binary.exists():
+        console.print(f"[red]Error:[/red] Binary not found: {binary}")
+        return False
 
     # Setup output directory
-    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-    if output_dir is None:
-        output_dir = Path(__file__).parent.parent.joinpath(
-            "results", "single", str(n_points), f"{tool_canonical}_sr"
+    existing_csv = output_dir.joinpath("results.csv")
+    if existing_csv.exists() and not force:
+        console.print(
+            f"[yellow]Warning:[/yellow] Results already exist: {output_dir}"
         )
+        console.print("Use [bold]--force[/bold] to overwrite")
+        return False
 
-    if not dry_run:
-        existing_csv = output_dir.joinpath("results.csv")
-        if existing_csv.exists() and not force:
-            console.print(
-                f"[yellow]Warning:[/yellow] Results already exist: {output_dir}"
-            )
-            console.print("Use [bold]--force[/bold] to overwrite")
-            raise typer.Exit(1)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        # Save config
-        config = {
-            "timestamp": timestamp,
-            "system": get_system_info(),
-            "parameters": {
-                "tool": tool_canonical,
-                "tool_base": tool_base,
-                "algorithm": "sr",
-                "precision": precision,
-                "thread_counts": thread_counts,
-                "warmup": warmup,
-                "runs": runs,
-                "n_points": n_points,
-                "n_structures": len(structures),
-                "input_dir": str(pdb_dir),
-                "sample_file": str(sample_file) if sample_file else None,
-                "prepare": prepare,
-            },
-        }
-        config_path = output_dir.joinpath("config.json")
-        config_path.write_text(json.dumps(config, indent=2))
+    # Save config
+    config = {
+        "timestamp": timestamp,
+        "system": get_system_info(),
+        "parameters": {
+            "tool": tool_canonical,
+            "tool_base": tool_base,
+            "algorithm": "sr",
+            "precision": precision,
+            "thread_counts": thread_counts,
+            "warmup": warmup,
+            "runs": runs,
+            "n_points": n_points,
+            "n_structures": len(structures),
+            "input_dir": str(pdb_dir),
+            "sample_file": str(sample_file) if sample_file else None,
+            "prepare": prepare,
+        },
+    }
+    config_path = output_dir.joinpath("config.json")
+    config_path.write_text(json.dumps(config, indent=2))
 
     total = len(structures) * len(thread_counts)
-
     prepare_info = f", Prepare: '{prepare}'" if prepare else ""
     console.print(f"\n[bold]{tool_canonical.upper()} SR (hyperfine)[/bold]")
     console.print(
@@ -326,18 +216,6 @@ def main(
         f"Structures: {len(structures)}, Total benchmarks: {total}"
         f"{prepare_info}\n"
     )
-
-    # Dry run: show commands and exit without file I/O
-    if dry_run:
-        for n_threads in thread_counts:
-            for pdb_id, _n_atoms in structures:
-                pdb_path = pdb_dir.joinpath(f"{pdb_id}.pdb")
-                cmd = _build_command(
-                    tool_base, precision, pdb_path, n_threads, n_points, use_bitmask
-                )
-                console.print(f"  [dim]{cmd}[/dim]")
-        console.print("\n[bold green]Dry run complete.[/bold green]")
-        return
 
     # Run benchmarks
     csv_path = output_dir.joinpath("results.csv")
@@ -445,7 +323,7 @@ def main(
 
     if n_success == 0:
         console.print("[red]Error: all benchmarks failed, no results recorded[/red]")
-        raise typer.Exit(1)
+        return False
 
     console.print(f"\n[green]Done![/green] {n_success}/{total} benchmarks completed")
     console.print(f"  Results: {output_dir}")
@@ -453,6 +331,203 @@ def main(
     console.print(f"  - {config_path.name}")
 
     print_hyperfine_summary(csv_path)
+    return True
+
+
+@app.command()
+def main(
+    tools: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--tool",
+            "-t",
+            help=(
+                "Tools to benchmark (can specify multiple: --tool X --tool Y). "
+                "Default: all. "
+                "Available: all, zig_f64, zig_f32, zig_f64_bitmask, zig_f32_bitmask, "
+                "freesasa, rust, lahuta, lahuta_bitmask "
+                "(zig = zig_f64, zig_bitmask = zig_f64_bitmask)"
+            ),
+        ),
+    ] = None,
+    threads: Annotated[
+        str,
+        typer.Option("--threads", "-T", help="Thread counts: '1,4,10' or '1-10'"),
+    ] = "1,4,10",
+    runs: Annotated[
+        int,
+        typer.Option("--runs", "-r", help="Number of hyperfine runs per configuration"),
+    ] = 5,
+    warmup: Annotated[
+        int,
+        typer.Option("--warmup", "-w", help="Hyperfine warmup runs"),
+    ] = 1,
+    output_dir: Annotated[
+        Path | None,
+        typer.Option("--output-dir", "-o", help="Output directory (per-tool subdirs when multiple tools)"),
+    ] = None,
+    input_dir: Annotated[
+        Path | None,
+        typer.Option("--input-dir", "-i", help="Input directory with .pdb files"),
+    ] = None,
+    input_file: Annotated[
+        Path | None,
+        typer.Option("--input", help="Single .pdb file to benchmark"),
+    ] = None,
+    sample_file: Annotated[
+        Path | None,
+        typer.Option("--sample-file", "-S", help="Sample file to filter structures"),
+    ] = None,
+    n_points: Annotated[
+        int,
+        typer.Option("--n-points", "-N", help="Number of sphere test points per atom"),
+    ] = 100,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            "--timeout", help="Timeout per benchmark in seconds (default: 600)"
+        ),
+    ] = 600,
+    prepare: Annotated[
+        str | None,
+        typer.Option(
+            "--prepare",
+            "-p",
+            help="Shell command to run before each timing run (passed to hyperfine --prepare). "
+            "E.g. 'sync' or 'sudo purge' (macOS) to clear filesystem caches.",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show commands without running"),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Overwrite existing results"),
+    ] = False,
+) -> None:
+    """Run SR single-file benchmark using hyperfine."""
+    # Mutual exclusivity check
+    if input_file is not None and input_dir is not None:
+        console.print(
+            "[red]Error:[/red] --input and --input-dir are mutually exclusive"
+        )
+        raise typer.Exit(1)
+
+    # Resolve and validate tools
+    selected_tools = _resolve_tools(tools)
+
+    # Check hyperfine
+    if not dry_run and not check_hyperfine():
+        console.print("[red]Error: hyperfine not found. Install it first.[/red]")
+        raise typer.Exit(1)
+
+    thread_counts = parse_threads(threads)
+
+    # Auto-build zsasa if any zig tool selected
+    has_zig = any(parse_tool(t)[1] == "zig" for t in selected_tools)
+    if not dry_run and has_zig:
+        ensure_zsasa_built()
+
+    # Resolve input: single file or directory
+    if input_file is not None:
+        if not input_file.exists():
+            console.print(f"[red]Error:[/red] Input file not found: {input_file}")
+            raise typer.Exit(1)
+        pdb_dir = input_file.parent
+        pdb_id = input_file.stem
+        structures = [(pdb_id, 0)]
+    else:
+        if input_dir is not None:
+            if not input_dir.exists():
+                console.print(
+                    f"[red]Error:[/red] Input directory not found: {input_dir}"
+                )
+                raise typer.Exit(1)
+            pdb_dir = input_dir
+        else:
+            pdb_dir = Path(__file__).parent.parent.joinpath("dataset", "pdb")
+            if not pdb_dir.exists():
+                console.print(f"[red]Error:[/red] Default dataset not found: {pdb_dir}")
+                raise typer.Exit(1)
+
+        structures = scan_input_directory(pdb_dir)
+        if not structures:
+            console.print(f"[red]Error:[/red] No .pdb files found in {pdb_dir}")
+            raise typer.Exit(1)
+
+        # Filter by sample file
+        if sample_file is not None:
+            if not sample_file.exists():
+                console.print(f"[red]Error:[/red] Sample file not found: {sample_file}")
+                raise typer.Exit(1)
+            sample_ids = set(load_sample_file(sample_file))
+            structures = [
+                (pdb_id, n) for pdb_id, n in structures if pdb_id in sample_ids
+            ]
+            if not structures:
+                console.print("[red]Error:[/red] No matching structures found")
+                raise typer.Exit(1)
+            console.print(
+                f"Loaded [cyan]{len(sample_ids):,}[/cyan] samples from {sample_file}"
+            )
+
+    console.print(f"Found [cyan]{len(structures):,}[/cyan] structures in {pdb_dir}")
+    console.print(f"Tools: [cyan]{', '.join(selected_tools)}[/cyan]")
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+
+    # Dry run: show commands for all tools and exit
+    if dry_run:
+        for tool_name in selected_tools:
+            tool_canonical, tool_base, precision, use_bitmask = parse_tool(tool_name)
+            console.print(f"\n[bold]{tool_canonical.upper()} SR[/bold]")
+            for n_threads in thread_counts:
+                for pdb_id, _n_atoms in structures:
+                    pdb_path = pdb_dir.joinpath(f"{pdb_id}.pdb")
+                    cmd = _build_command(
+                        tool_base, precision, pdb_path, n_threads, n_points, use_bitmask
+                    )
+                    console.print(f"  [dim]{cmd}[/dim]")
+        console.print("\n[bold green]Dry run complete.[/bold green]")
+        return
+
+    # Run benchmarks for each tool
+    results_base = Path(__file__).parent.parent.joinpath("results", "single", str(n_points))
+    n_succeeded = 0
+    n_tools = len(selected_tools)
+
+    for tool_name in selected_tools:
+        tool_canonical = parse_tool(tool_name)[0]
+        tool_output_dir = (
+            output_dir
+            if output_dir is not None and n_tools == 1
+            else results_base.joinpath(f"{tool_canonical}_sr")
+        )
+
+        success = _run_tool(
+            tool_name,
+            structures=structures,
+            pdb_dir=pdb_dir,
+            thread_counts=thread_counts,
+            n_points=n_points,
+            warmup=warmup,
+            runs=runs,
+            timeout=timeout,
+            prepare=prepare,
+            output_dir=tool_output_dir,
+            force=force,
+            timestamp=timestamp,
+            sample_file=sample_file,
+        )
+        if success:
+            n_succeeded += 1
+
+    if n_tools > 1:
+        console.print(
+            f"\n[bold]{'=' * 40}[/bold]"
+            f"\n[bold green]Completed {n_succeeded}/{n_tools} tools[/bold green]"
+        )
 
 
 if __name__ == "__main__":

--- a/benchmarks/scripts/bench_lr.py
+++ b/benchmarks/scripts/bench_lr.py
@@ -5,15 +5,21 @@
 # ///
 """LR single-file benchmark runner (hyperfine).
 
-Runs wall-clock benchmarks for a single tool using the Lee-Richards algorithm
-with configurable thread counts. Uses hyperfine for timing (includes I/O).
+Runs wall-clock benchmarks using the Lee-Richards algorithm with configurable
+thread counts. Uses hyperfine for timing (includes I/O).
 
 Tools: zig_f64, zig_f32, freesasa (zig is an alias for zig_f64)
 Note: RustSASA and Lahuta do not support the LR algorithm.
 
 Usage:
+    # All tools (default)
+    ./benchmarks/scripts/bench_lr.py --threads 1,4,8
+
+    # Specific tools
+    ./benchmarks/scripts/bench_lr.py --tool zig_f64 --tool freesasa --threads 1,4,8
+
+    # Single tool
     ./benchmarks/scripts/bench_lr.py --tool zig_f64 --threads 1,4,8
-    ./benchmarks/scripts/bench_lr.py --tool freesasa --threads 1 --warmup 3 --runs 10
 
     # Quick test (single file, 1 hyperfine run, no warmup)
     ./benchmarks/scripts/bench_lr.py --tool zig_f64 --threads 1 --warmup 0 --runs 1 \
@@ -86,191 +92,90 @@ def _build_command(
         raise ValueError(f"No command builder for tool base: {base}")
 
 
-@app.command()
-def main(
-    tool: Annotated[
-        str,
-        typer.Option(
-            "--tool",
-            "-t",
-            help="Tool: zig_f64, zig_f32, freesasa (zig = zig_f64)",
-        ),
-    ],
-    threads: Annotated[
-        str,
-        typer.Option("--threads", "-T", help="Thread counts: '1,4,10' or '1-10'"),
-    ] = "1,4,10",
-    runs: Annotated[
-        int,
-        typer.Option("--runs", "-r", help="Number of hyperfine runs per configuration"),
-    ] = 5,
-    warmup: Annotated[
-        int,
-        typer.Option("--warmup", "-w", help="Hyperfine warmup runs"),
-    ] = 1,
-    output_dir: Annotated[
-        Path | None,
-        typer.Option("--output-dir", "-o", help="Output directory"),
-    ] = None,
-    input_dir: Annotated[
-        Path | None,
-        typer.Option("--input-dir", "-i", help="Input directory with .pdb files"),
-    ] = None,
-    input_file: Annotated[
-        Path | None,
-        typer.Option("--input", help="Single .pdb file to benchmark"),
-    ] = None,
-    sample_file: Annotated[
-        Path | None,
-        typer.Option("--sample-file", "-S", help="Sample file to filter structures"),
-    ] = None,
-    n_slices: Annotated[
-        int,
-        typer.Option("--n-slices", help="Number of slices per atom diameter"),
-    ] = 20,
-    timeout: Annotated[
-        int,
-        typer.Option(
-            "--timeout", help="Timeout per benchmark in seconds (default: 600)"
-        ),
-    ] = 600,
-    prepare: Annotated[
-        str | None,
-        typer.Option(
-            "--prepare",
-            "-p",
-            help="Shell command to run before each timing run (passed to hyperfine --prepare). "
-            "E.g. 'sync' or 'sudo purge' (macOS) to clear filesystem caches.",
-        ),
-    ] = None,
-    dry_run: Annotated[
-        bool,
-        typer.Option("--dry-run", help="Show commands without running"),
-    ] = False,
-    force: Annotated[
-        bool,
-        typer.Option("--force", "-f", help="Overwrite existing results"),
-    ] = False,
-) -> None:
-    """Run LR single-file benchmark using hyperfine."""
-    # Check hyperfine
-    if not dry_run and not check_hyperfine():
-        console.print("[red]Error: hyperfine not found. Install it first.[/red]")
-        raise typer.Exit(1)
+def _resolve_tools(tools: list[str] | None) -> list[str]:
+    """Resolve tool list: None or ["all"] -> LR_TOOLS, otherwise validate."""
+    if tools is None or tools == ["all"]:
+        return list(LR_TOOLS)
 
-    # Parse tool
     all_valid = LR_TOOLS + [k for k, v in TOOL_ALIASES.items() if v in LR_TOOLS]
-    if tool not in all_valid:
-        console.print(f"[red]Error:[/red] Unknown or unsupported tool for LR: {tool}")
-        console.print(f"Available: {', '.join(LR_TOOLS)} (zig = zig_f64)")
-        raise typer.Exit(1)
+    for t in tools:
+        if t == "all":
+            return list(LR_TOOLS)
+        if t not in all_valid:
+            console.print(
+                f"[red]Error:[/red] Unknown or unsupported tool for LR: {t}"
+            )
+            console.print(f"Available: all, {', '.join(LR_TOOLS)} (zig = zig_f64)")
+            raise typer.Exit(1)
+        # Reject bitmask tools for LR
+        _, _, _, use_bitmask = parse_tool(t)
+        if use_bitmask:
+            console.print(
+                "[red]Error:[/red] Bitmask mode is not supported for LR benchmarks"
+            )
+            raise typer.Exit(1)
+    return list(tools)
 
-    tool_canonical, tool_base, precision, use_bitmask = parse_tool(tool)
-    if use_bitmask:
-        console.print(
-            "[red]Error:[/red] Bitmask mode is not supported for LR benchmarks"
-        )
-        raise typer.Exit(1)
-    thread_counts = parse_threads(threads)
 
-    # Auto-build zsasa for zig-based tools
-    if not dry_run and tool_base == "zig":
-        ensure_zsasa_built()
+def _run_tool(
+    tool_name: str,
+    *,
+    structures: list[tuple[str, int]],
+    pdb_dir: Path,
+    thread_counts: list[int],
+    n_slices: int,
+    warmup: int,
+    runs: int,
+    timeout: int,
+    prepare: str | None,
+    output_dir: Path,
+    force: bool,
+    timestamp: str,
+    sample_file: Path | None,
+) -> bool:
+    """Run benchmarks for a single tool. Returns True on success."""
+    tool_canonical, tool_base, precision, _use_bitmask = parse_tool(tool_name)
 
     # Check binary exists
-    if not dry_run:
-        binary = get_binary_path(tool_base)
-        if not binary.exists():
-            console.print(f"[red]Error:[/red] Binary not found: {binary}")
-            raise typer.Exit(1)
-
-    # Resolve input: single file or directory
-    if input_file is not None:
-        if not input_file.exists():
-            console.print(f"[red]Error:[/red] Input file not found: {input_file}")
-            raise typer.Exit(1)
-        pdb_dir = input_file.parent
-        pdb_id = input_file.stem
-        structures = [(pdb_id, 0)]
-    else:
-        if input_dir is not None:
-            if not input_dir.exists():
-                console.print(
-                    f"[red]Error:[/red] Input directory not found: {input_dir}"
-                )
-                raise typer.Exit(1)
-            pdb_dir = input_dir
-        else:
-            pdb_dir = Path(__file__).parent.parent.joinpath("dataset", "pdb")
-            if not pdb_dir.exists():
-                console.print(f"[red]Error:[/red] Default dataset not found: {pdb_dir}")
-                raise typer.Exit(1)
-
-        structures = scan_input_directory(pdb_dir)
-        if not structures:
-            console.print(f"[red]Error:[/red] No .pdb files found in {pdb_dir}")
-            raise typer.Exit(1)
-
-        # Filter by sample file
-        if sample_file is not None:
-            if not sample_file.exists():
-                console.print(f"[red]Error:[/red] Sample file not found: {sample_file}")
-                raise typer.Exit(1)
-            sample_ids = set(load_sample_file(sample_file))
-            structures = [
-                (pdb_id, n) for pdb_id, n in structures if pdb_id in sample_ids
-            ]
-            if not structures:
-                console.print("[red]Error:[/red] No matching structures found")
-                raise typer.Exit(1)
-            console.print(
-                f"Loaded [cyan]{len(sample_ids):,}[/cyan] samples from {sample_file}"
-            )
-
-    console.print(f"Found [cyan]{len(structures):,}[/cyan] structures in {pdb_dir}")
+    binary = get_binary_path(tool_base)
+    if not binary.exists():
+        console.print(f"[red]Error:[/red] Binary not found: {binary}")
+        return False
 
     # Setup output directory
-    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-    if output_dir is None:
-        output_dir = Path(__file__).parent.parent.joinpath(
-            "results", "single_lr", str(n_slices), f"{tool_canonical}_lr"
+    existing_csv = output_dir.joinpath("results.csv")
+    if existing_csv.exists() and not force:
+        console.print(
+            f"[yellow]Warning:[/yellow] Results already exist: {output_dir}"
         )
+        console.print("Use [bold]--force[/bold] to overwrite")
+        return False
 
-    if not dry_run:
-        existing_csv = output_dir.joinpath("results.csv")
-        if existing_csv.exists() and not force:
-            console.print(
-                f"[yellow]Warning:[/yellow] Results already exist: {output_dir}"
-            )
-            console.print("Use [bold]--force[/bold] to overwrite")
-            raise typer.Exit(1)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        # Save config
-        config = {
-            "timestamp": timestamp,
-            "system": get_system_info(),
-            "parameters": {
-                "tool": tool_canonical,
-                "tool_base": tool_base,
-                "algorithm": "lr",
-                "precision": precision,
-                "thread_counts": thread_counts,
-                "warmup": warmup,
-                "runs": runs,
-                "n_slices": n_slices,
-                "n_structures": len(structures),
-                "input_dir": str(pdb_dir),
-                "sample_file": str(sample_file) if sample_file else None,
-                "prepare": prepare,
-            },
-        }
-        config_path = output_dir.joinpath("config.json")
-        config_path.write_text(json.dumps(config, indent=2))
+    # Save config
+    config = {
+        "timestamp": timestamp,
+        "system": get_system_info(),
+        "parameters": {
+            "tool": tool_canonical,
+            "tool_base": tool_base,
+            "algorithm": "lr",
+            "precision": precision,
+            "thread_counts": thread_counts,
+            "warmup": warmup,
+            "runs": runs,
+            "n_slices": n_slices,
+            "n_structures": len(structures),
+            "input_dir": str(pdb_dir),
+            "sample_file": str(sample_file) if sample_file else None,
+            "prepare": prepare,
+        },
+    }
+    config_path = output_dir.joinpath("config.json")
+    config_path.write_text(json.dumps(config, indent=2))
 
     total = len(structures) * len(thread_counts)
-
     prepare_info = f", Prepare: '{prepare}'" if prepare else ""
     console.print(f"\n[bold]{tool_canonical.upper()} LR (hyperfine)[/bold]")
     console.print(
@@ -278,18 +183,6 @@ def main(
         f"Structures: {len(structures)}, Total benchmarks: {total}"
         f"{prepare_info}\n"
     )
-
-    # Dry run: show commands and exit without file I/O
-    if dry_run:
-        for n_threads in thread_counts:
-            for pdb_id, _n_atoms in structures:
-                pdb_path = pdb_dir.joinpath(f"{pdb_id}.pdb")
-                cmd = _build_command(
-                    tool_base, precision, pdb_path, n_threads, n_slices
-                )
-                console.print(f"  [dim]{cmd}[/dim]")
-        console.print("\n[bold green]Dry run complete.[/bold green]")
-        return
 
     # Run benchmarks
     csv_path = output_dir.joinpath("results.csv")
@@ -388,7 +281,7 @@ def main(
 
     if n_success == 0:
         console.print("[red]Error: all benchmarks failed, no results recorded[/red]")
-        raise typer.Exit(1)
+        return False
 
     console.print(f"\n[green]Done![/green] {n_success}/{total} benchmarks completed")
     console.print(f"  Results: {output_dir}")
@@ -396,6 +289,203 @@ def main(
     console.print(f"  - {config_path.name}")
 
     print_hyperfine_summary(csv_path)
+    return True
+
+
+@app.command()
+def main(
+    tools: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--tool",
+            "-t",
+            help=(
+                "Tools to benchmark (can specify multiple: --tool X --tool Y). "
+                "Default: all. "
+                "Available: all, zig_f64, zig_f32, freesasa (zig = zig_f64)"
+            ),
+        ),
+    ] = None,
+    threads: Annotated[
+        str,
+        typer.Option("--threads", "-T", help="Thread counts: '1,4,10' or '1-10'"),
+    ] = "1,4,10",
+    runs: Annotated[
+        int,
+        typer.Option("--runs", "-r", help="Number of hyperfine runs per configuration"),
+    ] = 5,
+    warmup: Annotated[
+        int,
+        typer.Option("--warmup", "-w", help="Hyperfine warmup runs"),
+    ] = 1,
+    output_dir: Annotated[
+        Path | None,
+        typer.Option("--output-dir", "-o", help="Output directory (per-tool subdirs when multiple tools)"),
+    ] = None,
+    input_dir: Annotated[
+        Path | None,
+        typer.Option("--input-dir", "-i", help="Input directory with .pdb files"),
+    ] = None,
+    input_file: Annotated[
+        Path | None,
+        typer.Option("--input", help="Single .pdb file to benchmark"),
+    ] = None,
+    sample_file: Annotated[
+        Path | None,
+        typer.Option("--sample-file", "-S", help="Sample file to filter structures"),
+    ] = None,
+    n_slices: Annotated[
+        int,
+        typer.Option("--n-slices", help="Number of slices per atom diameter"),
+    ] = 20,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            "--timeout", help="Timeout per benchmark in seconds (default: 600)"
+        ),
+    ] = 600,
+    prepare: Annotated[
+        str | None,
+        typer.Option(
+            "--prepare",
+            "-p",
+            help="Shell command to run before each timing run (passed to hyperfine --prepare). "
+            "E.g. 'sync' or 'sudo purge' (macOS) to clear filesystem caches.",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show commands without running"),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Overwrite existing results"),
+    ] = False,
+) -> None:
+    """Run LR single-file benchmark using hyperfine."""
+    # Mutual exclusivity check
+    if input_file is not None and input_dir is not None:
+        console.print(
+            "[red]Error:[/red] --input and --input-dir are mutually exclusive"
+        )
+        raise typer.Exit(1)
+
+    # Resolve and validate tools
+    selected_tools = _resolve_tools(tools)
+
+    # Check hyperfine
+    if not dry_run and not check_hyperfine():
+        console.print("[red]Error: hyperfine not found. Install it first.[/red]")
+        raise typer.Exit(1)
+
+    thread_counts = parse_threads(threads)
+
+    # Auto-build zsasa if any zig tool selected
+    has_zig = any(parse_tool(t)[1] == "zig" for t in selected_tools)
+    if not dry_run and has_zig:
+        ensure_zsasa_built()
+
+    # Resolve input: single file or directory
+    if input_file is not None:
+        if not input_file.exists():
+            console.print(f"[red]Error:[/red] Input file not found: {input_file}")
+            raise typer.Exit(1)
+        pdb_dir = input_file.parent
+        pdb_id = input_file.stem
+        structures = [(pdb_id, 0)]
+    else:
+        if input_dir is not None:
+            if not input_dir.exists():
+                console.print(
+                    f"[red]Error:[/red] Input directory not found: {input_dir}"
+                )
+                raise typer.Exit(1)
+            pdb_dir = input_dir
+        else:
+            pdb_dir = Path(__file__).parent.parent.joinpath("dataset", "pdb")
+            if not pdb_dir.exists():
+                console.print(f"[red]Error:[/red] Default dataset not found: {pdb_dir}")
+                raise typer.Exit(1)
+
+        structures = scan_input_directory(pdb_dir)
+        if not structures:
+            console.print(f"[red]Error:[/red] No .pdb files found in {pdb_dir}")
+            raise typer.Exit(1)
+
+        # Filter by sample file
+        if sample_file is not None:
+            if not sample_file.exists():
+                console.print(f"[red]Error:[/red] Sample file not found: {sample_file}")
+                raise typer.Exit(1)
+            sample_ids = set(load_sample_file(sample_file))
+            structures = [
+                (pdb_id, n) for pdb_id, n in structures if pdb_id in sample_ids
+            ]
+            if not structures:
+                console.print("[red]Error:[/red] No matching structures found")
+                raise typer.Exit(1)
+            console.print(
+                f"Loaded [cyan]{len(sample_ids):,}[/cyan] samples from {sample_file}"
+            )
+
+    console.print(f"Found [cyan]{len(structures):,}[/cyan] structures in {pdb_dir}")
+    console.print(f"Tools: [cyan]{', '.join(selected_tools)}[/cyan]")
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+
+    # Dry run: show commands for all tools and exit
+    if dry_run:
+        for tool_name in selected_tools:
+            tool_canonical, tool_base, precision, _use_bitmask = parse_tool(tool_name)
+            console.print(f"\n[bold]{tool_canonical.upper()} LR[/bold]")
+            for n_threads in thread_counts:
+                for pdb_id, _n_atoms in structures:
+                    pdb_path = pdb_dir.joinpath(f"{pdb_id}.pdb")
+                    cmd = _build_command(
+                        tool_base, precision, pdb_path, n_threads, n_slices
+                    )
+                    console.print(f"  [dim]{cmd}[/dim]")
+        console.print("\n[bold green]Dry run complete.[/bold green]")
+        return
+
+    # Run benchmarks for each tool
+    results_base = Path(__file__).parent.parent.joinpath(
+        "results", "single_lr", str(n_slices)
+    )
+    n_succeeded = 0
+    n_tools = len(selected_tools)
+
+    for tool_name in selected_tools:
+        tool_canonical = parse_tool(tool_name)[0]
+        tool_output_dir = (
+            output_dir
+            if output_dir is not None and n_tools == 1
+            else results_base.joinpath(f"{tool_canonical}_lr")
+        )
+
+        success = _run_tool(
+            tool_name,
+            structures=structures,
+            pdb_dir=pdb_dir,
+            thread_counts=thread_counts,
+            n_slices=n_slices,
+            warmup=warmup,
+            runs=runs,
+            timeout=timeout,
+            prepare=prepare,
+            output_dir=tool_output_dir,
+            force=force,
+            timestamp=timestamp,
+            sample_file=sample_file,
+        )
+        if success:
+            n_succeeded += 1
+
+    if n_tools > 1:
+        console.print(
+            f"\n[bold]{'=' * 40}[/bold]"
+            f"\n[bold green]Completed {n_succeeded}/{n_tools} tools[/bold green]"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `--tool all` / multi-tool selection to `bench.py` (SR) and `bench_lr.py` (LR)
- `--tool` is now optional (`list[str] | None`), defaulting to all tools
- Supports: no flag (all), `--tool all`, `--tool X --tool Y` (multiple), `--tool X` (single)
- Aligns with `bench_batch.py`'s multi-tool pattern
- Extract `_run_tool()` and `_resolve_tools()` for cleaner per-tool execution

## Test plan

- [x] `bench.py --help` shows updated `--tool` option (optional, multi-value)
- [x] `bench.py --dry-run --input ...` runs all 8 SR tools
- [x] `bench.py --tool all --dry-run --input ...` runs all 8 SR tools
- [x] `bench.py --tool zig_f64 --dry-run --input ...` runs single tool
- [x] `bench.py --tool zig_f64 --tool freesasa --dry-run --input ...` runs 2 tools
- [x] `bench_lr.py --dry-run --input ...` runs all 3 LR tools
- [x] `bench_lr.py --tool all --dry-run --input ...` runs all 3 LR tools