### PR TITLE
fix: add --allow-vdw-fallback to rust-sasa commands

### DIFF
--- a/benchmarks/scripts/bench.py
+++ b/benchmarks/scripts/bench.py
@@ -113,7 +113,10 @@ def _build_command(
             f" --n-threads={n_threads} {quoted}"
         )
     elif base == "rust":
-        return f"{binary} {quoted} /dev/null -n {n_points} -t {n_threads} -o protein"
+        return (
+            f"{binary} {quoted} /dev/null -n {n_points} -t {n_threads}"
+            f" -o protein --allow-vdw-fallback"
+        )
     elif base == "lahuta":
         return (
             f"{binary} sasa-sr -f {quoted} --is_af2_model"

--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -224,7 +224,7 @@ def run_rustsasa(
         for n_threads in thread_counts:
             result = run_benchmark(
                 f"rustsasa_{n_threads}t",
-                f"{quote_path(rustsasa)} {quote_path(input_dir)} {quote_path(out_dir)} --format json -t {n_threads} -n {n_points}",
+                f"{quote_path(rustsasa)} {quote_path(input_dir)} {quote_path(out_dir)} --format json -t {n_threads} -n {n_points} --allow-vdw-fallback",
                 results_dir,
                 warmup,
                 runs,


### PR DESCRIPTION
## Summary

rust-sasa exits with code 2 on PDB structures containing non-standard residues (e.g. `UNK`) when `--allow-vdw-fallback` is not set. This caused ~805/2013 structures to fail in `bench.py` SR benchmarks.

```
error: SASA calculation failed: Radius not found for residue 'UNK' atom 'N' of type 'N'.
This error can be ignored, if you are using the CLI pass --allow-vdw-fallback
```

### Changes

- `bench.py`: Add `--allow-vdw-fallback` to rust-sasa command builder
- `bench_batch.py`: Same fix for batch mode

## Test plan

- [x] Verified failing structure (2pff, 71k atoms with UNK residues) now succeeds
- [x] Verified dry-run output shows correct command
- [ ] Re-run full SR benchmark for rust tool