### PR TITLE
fix: wrap atom serial numbers to avoid hybrid36 in PDB files

### DIFF
--- a/benchmarks/scripts/generate_pdb.py
+++ b/benchmarks/scripts/generate_pdb.py
@@ -121,7 +121,19 @@ def clean_cif_to_pdb(cif_path: Path, output_path: Path) -> tuple[str, int]:
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     st.shorten_chain_names()
-    st.write_pdb(str(output_path))
+
+    # Wrap atom serial numbers to stay within PDB 5-digit limit (≤99999).
+    # Avoids hybrid36 encoding that some parsers (e.g. pdbtbx) cannot read.
+    if n_atoms > 99999:
+        serial = 0
+        for chain in model:
+            for res in chain:
+                for atom in res:
+                    serial = (serial % 99999) + 1
+                    atom.serial = serial
+        st.write_pdb(str(output_path), preserve_serial=True)
+    else:
+        st.write_pdb(str(output_path))
 
     return (cif_path.stem.replace(".cif", ""), n_atoms)
 


### PR DESCRIPTION
## Summary

PDB format limits ATOM serial number to 5 digits (max 99,999). Structures with >99,999 atoms get hybrid36 encoding (e.g. `A0000`), which pdbtbx (used by rust-sasa) cannot parse.

- Wrap serial numbers modulo 99,999 in `generate_pdb.py` for large structures
- Use `preserve_serial=True` with gemmi's `write_pdb` to keep pure numeric serials
- Only applies when n_atoms > 99,999 (513/2,013 benchmark structures)
- AFDB (human) structures are all <22k atoms, so unaffected

Serial numbers are not used in SASA calculation (coordinate-based), only for atom identification in output. Wrapping is safe for benchmarking purposes.

Relates to #250

## Verification

```
$ rust-sasa /tmp/3j3q_wrap.pdb /dev/null -n 128 -t 1 -o protein --allow-vdw-fallback
Processing single file...
Finished!
```
3j3q (2.4M atoms) previously failed with `Invalid number format`, now succeeds.

## Test plan

- [x] Verified 3j3q (2.4M atoms) writes with pure numeric serials
- [x] Verified rust-sasa reads the wrapped PDB successfully
- [x] AFDB structures don't exceed 99,999 atoms (no change needed)
- [ ] Re-generate PDB dataset and re-run rust-sasa benchmarks