### PR TITLE
fix: update analyze scripts for new benchmark CSV format

### DIFF
--- a/benchmarks/scripts/analyze_data.py
+++ b/benchmarks/scripts/analyze_data.py
@@ -89,20 +89,51 @@ def load_data(n_points: int = 100) -> pl.DataFrame:
     if "precision" not in df.columns:
         df = df.with_columns(pl.lit(None).cast(pl.Utf8).alias("precision"))
 
-    # Remap tool names: zig → zsasa, rust → rustsasa
+    # Remap tool names: zig* → zsasa, rust → rustsasa
+    # Tool column may contain compound names like zig_f64, zig_f32_bitmask
     df = df.with_columns(
-        pl.col("tool").replace({"zig": "zsasa", "rust": "rustsasa"}).alias("tool"),
+        pl.col("tool")
+        .str.replace(r"^zig", "zsasa")
+        .str.replace(r"^rust$", "rustsasa")
+        .alias("tool"),
     )
 
-    # Create tool_label: zsasa_f64, zsasa_f32, freesasa, rustsasa
-    df = df.with_columns(
-        pl.when((pl.col("tool") == "zsasa") & pl.col("precision").is_not_null())
-        .then(pl.concat_str([pl.col("tool"), pl.lit("_"), pl.col("precision")]))
-        .otherwise(pl.col("tool"))
-        .alias("tool_label")
-    )
+    # Create tool_label from tool column (already contains precision/variant info)
+    df = df.with_columns(pl.col("tool").alias("tool_label"))
 
-    # Aggregate by structure (mean across runs)
+    # Convert current CSV format (mean_s etc.) to time_ms used downstream.
+    # Old format had sasa_time_ms per-run rows; new format has pre-aggregated
+    # mean_s/stddev_s/median_s in seconds.
+    if "mean_s" in df.columns:
+        df = df.with_columns(
+            (pl.col("mean_s") * 1000).alias("time_ms"),
+            (pl.col("stddev_s") * 1000).alias("time_std"),
+            (pl.col("median_s") * 1000).alias("median_ms"),
+        )
+        # total_sasa not available in new format
+        if "total_sasa" not in df.columns:
+            df = df.with_columns(pl.lit(None).cast(pl.Float64).alias("total_sasa"))
+
+        return (
+            df.select(
+                [
+                    "tool",
+                    "tool_label",
+                    "structure",
+                    "n_atoms",
+                    "algorithm",
+                    "precision",
+                    "threads",
+                    "time_ms",
+                    "time_std",
+                    "total_sasa",
+                ]
+            )
+            .with_columns(pl.lit(1).cast(pl.UInt32).alias("n_runs"))
+            .sort(["algorithm", "tool_label", "n_atoms"])
+        )
+
+    # Legacy format: per-run rows with sasa_time_ms
     return (
         df.group_by(
             [

--- a/benchmarks/scripts/analyze_lr.py
+++ b/benchmarks/scripts/analyze_lr.py
@@ -119,7 +119,36 @@ def load_lr_data(n_slices: int = 20) -> pl.DataFrame:
         .alias("tool_label")
     )
 
-    # Aggregate by structure (mean across runs)
+    # Convert current CSV format (mean_s etc.) to time_ms used downstream.
+    if "mean_s" in df.columns:
+        df = df.with_columns(
+            (pl.col("mean_s") * 1000).alias("time_ms"),
+            (pl.col("stddev_s") * 1000).alias("time_std"),
+            (pl.col("median_s") * 1000).alias("median_ms"),
+        )
+        if "total_sasa" not in df.columns:
+            df = df.with_columns(pl.lit(None).cast(pl.Float64).alias("total_sasa"))
+
+        return (
+            df.select(
+                [
+                    "tool",
+                    "tool_label",
+                    "structure",
+                    "n_atoms",
+                    "algorithm",
+                    "precision",
+                    "threads",
+                    "time_ms",
+                    "time_std",
+                    "total_sasa",
+                ]
+            )
+            .with_columns(pl.lit(1).cast(pl.UInt32).alias("n_runs"))
+            .sort(["tool_label", "n_atoms"])
+        )
+
+    # Legacy format: per-run rows with sasa_time_ms
     return (
         df.group_by(
             [
@@ -214,9 +243,7 @@ def summary(
             (pl.col("zsasa_f64") / pl.col("zsasa_f32")).alias("speedup")
         )
         med = speedup["speedup"].median()
-        rprint(
-            f"  LR: zsasa(f32) vs zsasa(f64) = [green]{med:.2f}x[/green] (median)"
-        )
+        rprint(f"  LR: zsasa(f32) vs zsasa(f64) = [green]{med:.2f}x[/green] (median)")
 
 
 @app.command()

--- a/benchmarks/scripts/analyze_plots.py
+++ b/benchmarks/scripts/analyze_plots.py
@@ -272,6 +272,10 @@ def plot_validation(n_points: int = 100):
         rprint("[yellow]No single-threaded SR data found[/yellow]")
         return
 
+    if "total_sasa" not in df_t1.columns or df_t1["total_sasa"].is_null().all():
+        rprint("[yellow]No total_sasa data available for validation[/yellow]")
+        return
+
     pivot = (
         df_t1.select(["structure", "tool_label", "total_sasa"])
         .pivot(on="tool_label", index="structure", values="total_sasa")


### PR DESCRIPTION
## Summary
- Update `analyze_data.py` and `analyze_lr.py` to support new CSV format (`mean_s`/`stddev_s`/`median_s` instead of per-run `sasa_time_ms` rows)
- Fix `zig` → `zsasa` tool name remap to handle compound names (`zig_f64`, `zig_f32_bitmask`, etc.)
- Skip validation plot when `total_sasa` is unavailable in new format

## Test plan
- [x] `./benchmarks/scripts/analyze.py all -N 128` runs without errors
- [x] Summary table shows correct tool names (zsasa_f64, rustsasa, etc.)
- [x] Speedup table populated with values
- [x] All plots generated successfully