### PR TITLE
fix: skip non-AlphaFold structures for lahuta benchmark

### DIFF
--- a/benchmarks/scripts/bench.py
+++ b/benchmarks/scripts/bench.py
@@ -263,6 +263,11 @@ def _run_tool(
                             progress.advance(task)
                             continue
 
+                        # lahuta only supports AlphaFold models
+                        if tool_base == "lahuta" and not pdb_id.startswith("af-"):
+                            progress.advance(task)
+                            continue
+
                         # Resolve n_atoms lazily
                         if n_atoms == 0:
                             if pdb_id not in n_atoms_cache:


### PR DESCRIPTION
## Summary
- Skip non-AF structures when running lahuta in bench.py (lahuta requires `--is_af2_model`)
- Previously recorded meaningless ~10ms skip times for 931 non-AF structures
- lahuta results now correctly show 1,082 structures (AF only) instead of 2,013

## Test plan
- [x] `analyze.py summary -N 128` shows lahuta with 1,082 structures
- [x] Speedup table correctly limited to AF size range