### PR TITLE
feat: record user/system time and memory in bench CSV

### DIFF
--- a/benchmarks/scripts/bench.py
+++ b/benchmarks/scripts/bench.py
@@ -240,6 +240,9 @@ def _run_tool(
                 "min_s",
                 "max_s",
                 "median_s",
+                "user_s",
+                "system_s",
+                "memory_bytes",
             ],
         )
         writer.writeheader()
@@ -314,6 +317,13 @@ def _run_tool(
                                     "min_s": result["min"],
                                     "max_s": result["max"],
                                     "median_s": result["median"],
+                                    "user_s": result.get("user"),
+                                    "system_s": result.get("system"),
+                                    "memory_bytes": (
+                                        result["memory_usage_byte"][0]
+                                        if result.get("memory_usage_byte")
+                                        else None
+                                    ),
                                 }
                             )
                             f.flush()


### PR DESCRIPTION
## Summary
- Add `user_s`, `system_s`, `memory_bytes` columns to bench.py CSV output
- These fields are available in hyperfine JSON but were previously discarded
- Existing CSVs without these columns remain compatible (polars diagonal concat fills nulls)

## Test plan
- [x] New CSV output contains user_s, system_s, memory_bytes with valid values
- [x] `analyze.py summary -N 128` still works with existing CSVs (no new columns)