### PR TITLE
chore: remove lahuta from default single benchmark tools

### DIFF
--- a/benchmarks/scripts/bench.py
+++ b/benchmarks/scripts/bench.py
@@ -8,8 +8,8 @@
 Runs wall-clock benchmarks using the Shrake-Rupley algorithm with configurable
 thread counts. Uses hyperfine for timing (includes I/O).
 
-Tools: zig_f64, zig_f32, zig_f64_bitmask, zig_f32_bitmask, freesasa, rust,
-       lahuta, lahuta_bitmask (zig = zig_f64, zig_bitmask = zig_f64_bitmask)
+Tools: zig_f64, zig_f32, zig_f64_bitmask, zig_f32_bitmask, freesasa, rust
+       (zig = zig_f64, zig_bitmask = zig_f64_bitmask)
 
 Usage:
     # All tools (default)
@@ -71,8 +71,6 @@ SR_TOOLS = [
     "zig_f32_bitmask",
     "freesasa",
     "rust",
-    "lahuta",
-    "lahuta_bitmask",
 ]
 
 
@@ -362,7 +360,7 @@ def main(
                 "Tools to benchmark (can specify multiple: --tool X --tool Y). "
                 "Default: all. "
                 "Available: all, zig_f64, zig_f32, zig_f64_bitmask, zig_f32_bitmask, "
-                "freesasa, rust, lahuta, lahuta_bitmask "
+                "freesasa, rust "
                 "(zig = zig_f64, zig_bitmask = zig_f64_bitmask)"
             ),
         ),


### PR DESCRIPTION
## Summary
- Remove lahuta and lahuta_bitmask from `SR_TOOLS` default list in bench.py
- lahuta only supports AlphaFold models and is not suited for general single-structure benchmarking
- Can still be used explicitly via `--tool lahuta` or `--tool lahuta_bitmask`

## Test plan
- [x] Verify `--tool lahuta` still works for explicit invocation
- [x] Verify default tool list no longer includes lahuta