### PR TITLE
feat: add --metric wall|sasa option to analyze CLI

### DIFF
--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -30,7 +30,7 @@ Usage:
     ./benchmarks/scripts/analyze.py export-csv   # Export to CSV
 """
 
-from pathlib import Path
+from enum import StrEnum
 
 import polars as pl
 import typer
@@ -45,6 +45,7 @@ from analyze_data import (
     compute_speedup_by_bin,
     load_data,
     metric_label,
+    metric_suffix,
 )
 from analyze_plots import (
     plot_efficiency,
@@ -59,27 +60,37 @@ from analyze_plots import (
 
 app = typer.Typer(help="SR benchmark analysis CLI")
 
-# Map CLI --metric values to DataFrame column names
-_METRIC_MAP = {"wall": "time_ms", "sasa": "sasa_time_ms"}
+
+# === Shared CLI Option Defaults ===
+
+
+class Metric(StrEnum):
+    """Timing metric for analysis."""
+
+    wall = "wall"
+    sasa = "sasa"
+
+
+_METRIC_COL = {"wall": "time_ms", "sasa": "sasa_time_ms"}
+
+NPointsOption = typer.Option(
+    100, "--n-points", "-N", help="Number of sphere test points"
+)
+MetricOption = typer.Option(
+    Metric.wall,
+    "--metric",
+    "-m",
+    help="Timing metric: wall (wall-clock) or sasa (SASA-only)",
+)
 
 
 # === CLI Commands ===
 
 
 @app.command()
-def summary(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall",
-        "--metric",
-        "-m",
-        help="Timing metric: wall (wall-clock) or sasa (SASA-only)",
-    ),
-):
+def summary(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Print summary statistics table."""
-    time_col = _METRIC_MAP[metric]
+    time_col = _METRIC_COL[metric]
     df = load_data(n_points)
 
     # Single-threaded comparison
@@ -201,23 +212,14 @@ def summary(
 
 
 @app.command(name="export-csv")
-def export_csv(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall",
-        "--metric",
-        "-m",
-        help="Timing metric: wall (wall-clock) or sasa (SASA-only)",
-    ),
-):
+def export_csv(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Export summary tables as CSV files per thread count."""
-    time_col = _METRIC_MAP[metric]
+    time_col = _METRIC_COL[metric]
     df = load_data(n_points)
     df = add_size_bin(df)
 
-    csv_dir = RESULTS_BASE.joinpath(str(n_points), "csv")
+    suffix = metric_suffix(time_col)
+    csv_dir = RESULTS_BASE.joinpath(str(n_points), f"csv{suffix}")
     csv_dir.mkdir(parents=True, exist_ok=True)
 
     thread_counts = sorted(df["threads"].unique().to_list())
@@ -269,124 +271,67 @@ def export_csv(
 
 
 @app.command()
-def scatter(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
-):
+def scatter(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Generate atoms vs time scatter plot."""
-    plot_scatter(n_points, time_col=_METRIC_MAP[metric])
+    plot_scatter(n_points, time_col=_METRIC_COL[metric])
 
 
 @app.command()
-def threads(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
-):
+def threads(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Generate thread scaling plot."""
-    plot_threads(n_points, time_col=_METRIC_MAP[metric])
+    plot_threads(n_points, time_col=_METRIC_COL[metric])
 
 
 @app.command()
-def grid(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
-):
+def grid(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Generate grid of speedup plots for all thread counts."""
-    plot_grid(n_points, time_col=_METRIC_MAP[metric])
+    plot_grid(n_points, time_col=_METRIC_COL[metric])
 
 
 @app.command()
-def validation(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-):
+def validation(n_points: int = NPointsOption):
     """Generate SASA validation scatter plot (zsasa vs FreeSASA)."""
     plot_validation(n_points)
 
 
 @app.command()
-def samples(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
-):
+def samples(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Generate thread scaling plots for representative structures per size bin."""
-    plot_samples(n_points, time_col=_METRIC_MAP[metric])
+    plot_samples(n_points, time_col=_METRIC_COL[metric])
 
 
 @app.command()
-def large(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
-):
+def large(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Generate speedup bar chart for large structures (50k+ atoms)."""
-    plot_large(n_points, time_col=_METRIC_MAP[metric])
+    plot_large(n_points, time_col=_METRIC_COL[metric])
 
 
 @app.command()
-def efficiency(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
-):
+def efficiency(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Calculate and plot parallel efficiency."""
-    plot_efficiency(n_points, time_col=_METRIC_MAP[metric])
+    plot_efficiency(n_points, time_col=_METRIC_COL[metric])
 
 
 @app.command()
 def speedup(
     min_atoms: int = typer.Option(50000, help="Minimum atom count for filtering"),
     top_n: int = typer.Option(5, help="Number of top entries to show"),
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
+    n_points: int = NPointsOption,
+    metric: Metric = MetricOption,
 ):
     """Find structures with best zsasa speedup at any thread count."""
     plot_speedup(
         min_atoms=min_atoms,
         top_n=top_n,
         n_points=n_points,
-        time_col=_METRIC_MAP[metric],
+        time_col=_METRIC_COL[metric],
     )
 
 
 @app.command()
-def all(
-    n_points: int = typer.Option(
-        100, "--n-points", "-N", help="Number of sphere test points"
-    ),
-    metric: str = typer.Option(
-        "wall", "--metric", "-m", help="Timing metric: wall or sasa"
-    ),
-):
+def all(n_points: int = NPointsOption, metric: Metric = MetricOption):
     """Generate all plots and summary."""
-    time_col = _METRIC_MAP[metric]
+    time_col = _METRIC_COL[metric]
     summary(n_points, metric=metric)
     rprint("\n[bold]Generating plots...[/bold]\n")
     plot_validation(n_points)

--- a/benchmarks/scripts/analyze_data.py
+++ b/benchmarks/scripts/analyze_data.py
@@ -250,6 +250,11 @@ def metric_label(time_col: str) -> str:
     return METRIC_LABELS.get(time_col, time_col)
 
 
+def metric_suffix(time_col: str) -> str:
+    """File-name suffix for a time column (empty for wall-clock)."""
+    return "_sasa" if time_col == "sasa_time_ms" else ""
+
+
 def setup_style():
     """Set up matplotlib style for clean plots."""
     plt.rcParams.update(

--- a/benchmarks/scripts/analyze_plots.py
+++ b/benchmarks/scripts/analyze_plots.py
@@ -14,6 +14,7 @@ from analyze_data import (
     display_name,
     load_data,
     metric_label,
+    metric_suffix,
     setup_style,
 )
 
@@ -139,7 +140,7 @@ def plot_scatter(n_points: int = 100, time_col: str = "time_ms"):
     setup_style()
     df = load_data(n_points)
 
-    suffix = "_sasa" if time_col == "sasa_time_ms" else ""
+    suffix = metric_suffix(time_col)
     plot_dir = PLOTS_DIR.joinpath("scatter", f"sr{suffix}")
     individual_dir = plot_dir.joinpath("individual")
     individual_dir.mkdir(parents=True, exist_ok=True)
@@ -193,7 +194,7 @@ def plot_threads(n_points: int = 100, time_col: str = "time_ms"):
     setup_style()
     df = load_data(n_points)
 
-    suffix = "_sasa" if time_col == "sasa_time_ms" else ""
+    suffix = metric_suffix(time_col)
     plot_dir = PLOTS_DIR.joinpath("thread_scaling")
     plot_dir.mkdir(parents=True, exist_ok=True)
 
@@ -216,7 +217,7 @@ def plot_grid(n_points: int = 100, time_col: str = "time_ms"):
         rprint("[yellow]No SR data found[/yellow]")
         return
 
-    suffix = "_sasa" if time_col == "sasa_time_ms" else ""
+    suffix = metric_suffix(time_col)
     mlabel = metric_label(time_col)
     plot_dir = PLOTS_DIR.joinpath(f"speedup_by_bin{suffix}")
     individual_dir = plot_dir.joinpath("individual")
@@ -353,7 +354,7 @@ def plot_samples(n_points: int = 100, time_col: str = "time_ms"):
 
     df = add_size_bin(df)
 
-    suffix = "_sasa" if time_col == "sasa_time_ms" else ""
+    suffix = metric_suffix(time_col)
     plot_dir = PLOTS_DIR.joinpath(f"samples{suffix}")
     plot_dir.mkdir(parents=True, exist_ok=True)
 
@@ -477,7 +478,7 @@ def plot_large(n_points: int = 100, time_col: str = "time_ms"):
     df = load_data(n_points)
     df = add_size_bin(df)
 
-    suffix = "_sasa" if time_col == "sasa_time_ms" else ""
+    suffix = metric_suffix(time_col)
     plot_dir = PLOTS_DIR.joinpath(f"large{suffix}")
     plot_dir.mkdir(parents=True, exist_ok=True)
 
@@ -592,7 +593,7 @@ def plot_efficiency(n_points: int = 100, time_col: str = "time_ms"):
         rprint("[yellow]No SR data found[/yellow]")
         return
 
-    suffix = "_sasa" if time_col == "sasa_time_ms" else ""
+    suffix = metric_suffix(time_col)
     plot_dir = PLOTS_DIR.joinpath(f"efficiency{suffix}")
     plot_dir.mkdir(parents=True, exist_ok=True)
 
@@ -736,7 +737,7 @@ def plot_speedup(
         )
         speedup_cols.append("vs_rustsasa")
 
-    suffix = "_sasa" if time_col == "sasa_time_ms" else ""
+    suffix = metric_suffix(time_col)
     plot_dir = PLOTS_DIR.joinpath(f"speedup{suffix}")
     plot_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Add `--metric wall|sasa` (`-m`) option to all analyze CLI commands
- `wall` (default): uses hyperfine wall-clock timing (`time_ms`)
- `sasa`: uses internal SASA-only timing (`sasa_time_ms`) from `--timing` runs
- Output directories get `_sasa` suffix when using SASA-only metric to avoid overwriting

## Changes
- **analyze_data.py**: Add `METRIC_LABELS`, `metric_label()` helper, `time_col` param on `compute_speedup_by_bin`
- **analyze_plots.py**: Thread `time_col` parameter through all plot functions (`plot_samples`, `plot_large`, `plot_efficiency`, `plot_speedup` and internal helpers)
- **analyze.py**: Add `--metric`/`-m` option to `summary`, `export-csv`, `scatter`, `threads`, `grid`, `samples`, `large`, `efficiency`, `speedup`, `all` commands

## Test plan
- [x] Syntax check passes
- [x] CLI `--help` shows `--metric` option on all commands
- [ ] `./analyze.py scatter` produces same output as before (backward compat)
- [ ] `./analyze.py scatter --metric sasa` uses `sasa_time_ms` column