### PR TITLE
fix: unify tool name from "rust" to "rustsasa"

### DIFF
--- a/benchmarks/scripts/bench.py
+++ b/benchmarks/scripts/bench.py
@@ -72,11 +72,11 @@ SR_TOOLS = [
     "zig_f64_bitmask",
     "zig_f32_bitmask",
     "freesasa",
-    "rust",
+    "rustsasa",
 ]
 
 
-_TIMING_TOOLS = {"zig", "freesasa", "rust"}
+_TIMING_TOOLS = {"zig", "freesasa", "rustsasa"}
 
 
 def _build_command(
@@ -91,7 +91,7 @@ def _build_command(
 ) -> str:
     """Build shell command for a tool.
 
-    When timing=True, appends --timing flag (supported by zig, freesasa, rust).
+    When timing=True, appends --timing flag (supported by zig, freesasa, rustsasa).
 
     Raises:
         ValueError: If tool base is not recognized, or if use_bitmask is True
@@ -120,7 +120,7 @@ def _build_command(
             f"{binary} --shrake-rupley --resolution={n_points}"
             f" --n-threads={n_threads}{timing_flag} {quoted}"
         )
-    elif base == "rust":
+    elif base == "rustsasa":
         return (
             f"{binary} {quoted} /dev/null -n {n_points} -t {n_threads}"
             f" -o protein --allow-vdw-fallback{timing_flag}"

--- a/benchmarks/scripts/bench_batch.py
+++ b/benchmarks/scripts/bench_batch.py
@@ -107,7 +107,7 @@ def get_binary_paths() -> dict[str, Path]:
     return {
         "zsasa": get_binary_path("zig"),
         "freesasa_batch": bin_dir.joinpath("freesasa_batch"),
-        "rustsasa": get_binary_path("rust"),
+        "rustsasa": get_binary_path("rustsasa"),
         "lahuta": get_binary_path("lahuta"),
     }
 

--- a/benchmarks/scripts/bench_common.py
+++ b/benchmarks/scripts/bench_common.py
@@ -23,7 +23,7 @@ from rich.table import Table
 
 console = Console()
 
-TOOL_ALIASES = {"zig": "zig_f64", "zig_bitmask": "zig_f64_bitmask"}
+TOOL_ALIASES = {"zig": "zig_f64", "zig_bitmask": "zig_f64_bitmask", "rust": "rustsasa"}
 
 
 class Precision(str, Enum):
@@ -91,7 +91,8 @@ def parse_tool(tool: str) -> tuple[str, str, str, bool]:
         "zig_f32_bitmask"  -> ("zig_f32_bitmask", "zig", "f32", True)
         "zig_bitmask"      -> ("zig_f64_bitmask", "zig", "f64", True)  # alias
         "freesasa"         -> ("freesasa", "freesasa", "f64", False)
-        "rust"             -> ("rust", "rust", "f64", False)
+        "rustsasa"         -> ("rustsasa", "rustsasa", "f64", False)
+        "rust"             -> ("rustsasa", "rustsasa", "f64", False)  # alias
         "lahuta"           -> ("lahuta", "lahuta", "f64", False)
         "lahuta_bitmask"   -> ("lahuta_bitmask", "lahuta", "f64", True)
     """
@@ -155,7 +156,7 @@ def _bin_dir() -> Path:
 _TOOL_BINARIES = {
     "zig": "zsasa",
     "freesasa": "freesasa",
-    "rust": "rust-sasa",
+    "rustsasa": "rust-sasa",
     "lahuta": "lahuta",
 }
 
@@ -166,7 +167,7 @@ def get_binary_path(tool: str) -> Path:
     Tools:
         zig      -> bin/zsasa
         freesasa -> bin/freesasa
-        rust     -> bin/rust-sasa
+        rustsasa -> bin/rust-sasa
         lahuta   -> bin/lahuta
     """
     if tool not in _TOOL_BINARIES:


### PR DESCRIPTION
## Summary
- Rename `"rust"` → `"rustsasa"` as canonical tool name in `bench.py` and `bench_common.py`
- Add `"rust"` as alias in `TOOL_ALIASES` for backward compatibility (`--tool rust` still works)
- Update `bench_batch.py` to use `get_binary_path("rustsasa")`
- `analyze_data.py`'s `^rust$` → `rustsasa` remap is kept for old CSV compatibility

## Changes
| File | Change |
|------|--------|
| `bench_common.py` | `_TOOL_BINARIES`: `"rust"` → `"rustsasa"`, add `"rust"` alias |
| `bench.py` | `SR_TOOLS`, `_TIMING_TOOLS`, `_build_command`: `"rust"` → `"rustsasa"` |
| `bench_batch.py` | `get_binary_path("rust")` → `get_binary_path("rustsasa")` |

## Test plan
- [x] Syntax check passes
- [ ] `--tool rust` still resolves via alias
- [ ] `--tool rustsasa` works directly