### PR TITLE
fix: output analyze plots under results/plots/single/

### DIFF
--- a/benchmarks/scripts/analyze_data.py
+++ b/benchmarks/scripts/analyze_data.py
@@ -9,7 +9,7 @@ import polars as pl
 
 _BENCHMARKS_DIR = Path(__file__).parent.parent
 RESULTS_BASE = _BENCHMARKS_DIR.joinpath("results", "single")
-PLOTS_DIR = _BENCHMARKS_DIR.joinpath("results", "plots")
+PLOTS_DIR = _BENCHMARKS_DIR.joinpath("results", "plots", "single")
 
 # === Visual Constants ===
 


### PR DESCRIPTION
## Summary
Move single-file benchmark plots from `results/plots/` to `results/plots/single/` for clearer organization alongside batch plots.

## Changes
- `analyze_data.py`: `PLOTS_DIR` path updated (`results/plots` → `results/plots/single`)

One-line change. All plot functions use `PLOTS_DIR` constant so they automatically follow.