### PR TITLE
feat: default to SASA metric, add memory plots, remove efficiency

### DIFF
--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -25,7 +25,7 @@ Usage:
     ./benchmarks/scripts/analyze.py validation   # SASA validation
     ./benchmarks/scripts/analyze.py samples      # Per-bin sample plots
     ./benchmarks/scripts/analyze.py large        # Large structure analysis
-    ./benchmarks/scripts/analyze.py efficiency   # Parallel efficiency
+    ./benchmarks/scripts/analyze.py memory       # Peak memory comparison
     ./benchmarks/scripts/analyze.py speedup      # Best speedup structures
     ./benchmarks/scripts/analyze.py export-csv   # Export to CSV
 """
@@ -48,9 +48,9 @@ from analyze_data import (
     metric_suffix,
 )
 from analyze_plots import (
-    plot_efficiency,
     plot_grid,
     plot_large,
+    plot_memory,
     plot_samples,
     plot_scatter,
     plot_speedup,
@@ -77,10 +77,10 @@ NPointsOption = typer.Option(
     100, "--n-points", "-N", help="Number of sphere test points"
 )
 MetricOption = typer.Option(
-    Metric.wall,
+    Metric.sasa,
     "--metric",
     "-m",
-    help="Timing metric: wall (wall-clock) or sasa (SASA-only)",
+    help="Timing metric: sasa (SASA-only, default) or wall (wall-clock incl. I/O)",
 )
 
 
@@ -307,9 +307,9 @@ def large(n_points: int = NPointsOption, metric: Metric = MetricOption):
 
 
 @app.command()
-def efficiency(n_points: int = NPointsOption, metric: Metric = MetricOption):
-    """Calculate and plot parallel efficiency."""
-    plot_efficiency(n_points, time_col=_METRIC_COL[metric])
+def memory(n_points: int = NPointsOption):
+    """Generate peak memory (RSS) comparison plots."""
+    plot_memory(n_points)
 
 
 @app.command()
@@ -340,7 +340,7 @@ def all(n_points: int = NPointsOption, metric: Metric = MetricOption):
     plot_grid(n_points, time_col=time_col)
     plot_samples(n_points, time_col=time_col)
     plot_large(n_points, time_col=time_col)
-    plot_efficiency(n_points, time_col=time_col)
+    plot_memory(n_points)
     plot_speedup(min_atoms=50000, top_n=5, n_points=n_points, time_col=time_col)
     rprint(f"\n[bold green]All plots saved to:[/bold green] {PLOTS_DIR}")
 

--- a/benchmarks/scripts/analyze_data.py
+++ b/benchmarks/scripts/analyze_data.py
@@ -119,6 +119,10 @@ def load_data(n_points: int = 100) -> pl.DataFrame:
             if col not in df.columns:
                 df = df.with_columns(pl.lit(None).cast(pl.Float64).alias(col))
 
+        # Memory column (from hyperfine, may be absent in old CSVs)
+        if "memory_bytes" not in df.columns:
+            df = df.with_columns(pl.lit(None).cast(pl.Int64).alias("memory_bytes"))
+
         return (
             df.select(
                 [
@@ -134,6 +138,7 @@ def load_data(n_points: int = 100) -> pl.DataFrame:
                     "total_sasa",
                     "parse_time_ms",
                     "sasa_time_ms",
+                    "memory_bytes",
                 ]
             )
             .with_columns(pl.lit(1).cast(pl.UInt32).alias("n_runs"))

--- a/benchmarks/scripts/analyze_plots.py
+++ b/benchmarks/scripts/analyze_plots.py
@@ -581,113 +581,98 @@ def plot_large(n_points: int = 100, time_col: str = "time_ms"):
         rprint(f"[green]Saved:[/green] {out_path2}")
 
 
-def plot_efficiency(n_points: int = 100, time_col: str = "time_ms"):
-    """Calculate and plot parallel efficiency from existing benchmark data."""
-    from rich.table import Table
-
+def plot_memory(n_points: int = 100):
+    """Generate peak memory (RSS) comparison plots."""
     setup_style()
     df = load_data(n_points)
     df = add_size_bin(df)
 
-    if df.height == 0:
-        rprint("[yellow]No SR data found[/yellow]")
+    # Filter to single-threaded and drop rows without memory data
+    df_t1 = df.filter((pl.col("threads") == 1) & pl.col("memory_bytes").is_not_null())
+
+    if df_t1.height == 0:
+        rprint("[yellow]No memory data found[/yellow]")
         return
 
-    suffix = metric_suffix(time_col)
-    plot_dir = PLOTS_DIR.joinpath(f"efficiency{suffix}")
+    df_t1 = df_t1.with_columns(
+        (pl.col("memory_bytes") / (1024 * 1024)).alias("memory_mb")
+    )
+
+    plot_dir = PLOTS_DIR.joinpath("memory")
     plot_dir.mkdir(parents=True, exist_ok=True)
 
-    # Baseline: threads=1
-    df_t1 = df.filter(pl.col("threads") == 1).select(
-        [
-            "tool_label",
-            "structure",
-            "n_atoms",
-            "size_bin",
-            pl.col(time_col).alias("t1_ms"),
-        ]
-    )
+    # Exclude f32 variants for cleaner comparison
+    tool_labels = [
+        t for t in sorted(df_t1["tool_label"].unique().to_list()) if "f32" not in t
+    ]
 
-    df_eff = df.join(df_t1, on=["tool_label", "structure", "n_atoms", "size_bin"])
-    df_eff = df_eff.with_columns(
-        (pl.col("t1_ms") / (pl.col(time_col) * pl.col("threads"))).alias("efficiency")
-    )
+    # --- Scatter: atoms vs memory ---
+    fig, ax = plt.subplots(figsize=(10, 6))
 
-    tool_labels = ["zsasa_f64", "freesasa", "rustsasa"]
-    max_threads = df["threads"].max()
+    for tool_label in tool_labels:
+        df_tool = df_t1.filter(pl.col("tool_label") == tool_label)
+        ax.scatter(
+            df_tool["n_atoms"].to_list(),
+            df_tool["memory_mb"].to_list(),
+            label=display_name(tool_label),
+            alpha=0.4,
+            s=10,
+            color=COLORS.get(tool_label, "#95a5a6"),
+        )
 
-    df_tmax = df_eff.filter(pl.col("threads") == max_threads)
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlabel("Number of Atoms")
+    ax.set_ylabel("Peak RSS (MB)")
+    ax.set_title("SR: Peak Memory vs Structure Size (threads=1)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
 
-    summary_table = Table(
-        title=f"Parallel Efficiency by Size (SR, threads={max_threads})"
-    )
-    summary_table.add_column("Size Bin", style="cyan")
-    summary_table.add_column("Count", justify="right")
-    summary_table.add_column("zsasa (f64)", justify="right")
-    summary_table.add_column("FreeSASA", justify="right")
-    summary_table.add_column("RustSASA", justify="right")
+    fig.tight_layout()
+    out_path = plot_dir.joinpath("scatter.png")
+    fig.savefig(out_path)
+    plt.close(fig)
+    rprint(f"[green]Saved:[/green] {out_path}")
 
+    # --- Bar chart: median memory by size bin ---
     bin_order = [b[2] for b in BINS]
+    available_bins = [b for b in bin_order if b in df_t1["size_bin"].unique().to_list()]
 
-    for bin_name in bin_order:
-        df_bin = df_tmax.filter(pl.col("size_bin") == bin_name)
-        if df_bin.height == 0:
-            continue
+    if not available_bins:
+        return
 
-        count = df_bin.select("structure").unique().height
-        row_values = [bin_name, f"{count:,}"]
-
-        for tool in tool_labels:
-            df_tool = df_bin.filter(pl.col("tool_label") == tool)
-            if df_tool.height > 0:
-                eff = df_tool["efficiency"].median()
-                row_values.append(f"{eff:.2f}")
-            else:
-                row_values.append("-")
-
-        summary_table.add_row(*row_values)
-
-    rprint(summary_table)
-    rprint("[dim]Efficiency = T1 / (TN * N). Higher = better thread utilization[/dim]")
-
-    # Plot efficiency by size bin
     fig, ax = plt.subplots(figsize=(14, 6))
 
-    x_labels = [b for b in bin_order if b in df_tmax["size_bin"].unique().to_list()]
-    x_pos = list(range(len(x_labels)))
-    bar_width = 0.25
+    x_pos = list(range(len(available_bins)))
+    bar_width = 0.8 / max(len(tool_labels), 1)
 
     for i, tool in enumerate(tool_labels):
-        tool_eff = []
-        for bin_name in x_labels:
-            df_bin_tool = df_tmax.filter(
+        medians = []
+        for bin_name in available_bins:
+            df_bt = df_t1.filter(
                 (pl.col("size_bin") == bin_name) & (pl.col("tool_label") == tool)
             )
-            if df_bin_tool.height > 0:
-                tool_eff.append(df_bin_tool["efficiency"].median())
-            else:
-                tool_eff.append(0)
+            medians.append(df_bt["memory_mb"].median() if df_bt.height > 0 else 0)
 
-        offset = (i - 1) * bar_width
+        offset = (i - len(tool_labels) / 2 + 0.5) * bar_width
         ax.bar(
             [x + offset for x in x_pos],
-            tool_eff,
+            medians,
             bar_width,
             label=display_name(tool),
             color=COLORS.get(tool, "#95a5a6"),
         )
 
     ax.set_xlabel("Structure Size (atoms)")
-    ax.set_ylabel(f"Parallel Efficiency (threads={max_threads})")
-    ax.set_title("Parallel Efficiency by Structure Size")
+    ax.set_ylabel("Median Peak RSS (MB)")
+    ax.set_title("SR: Peak Memory by Structure Size (threads=1)")
     ax.set_xticks(x_pos)
-    ax.set_xticklabels(x_labels, rotation=45, ha="right")
+    ax.set_xticklabels(available_bins, rotation=45, ha="right")
     ax.legend()
     ax.grid(True, alpha=0.3, axis="y")
-    ax.set_ylim(0, 0.5)
 
     fig.tight_layout()
-    out_path = plot_dir.joinpath("summary.png")
+    out_path = plot_dir.joinpath("by_size.png")
     fig.savefig(out_path)
     plt.close(fig)
     rprint(f"[green]Saved:[/green] {out_path}")


### PR DESCRIPTION
## Summary
- Default `--metric` changed from `wall` to `sasa` (SASA-only timing, I/O excluded)
- New `memory` command: peak RSS scatter plot + bar chart by size bin (from hyperfine `memory_bytes`)
- Removed `efficiency` command (unused)

## Changes
| File | Change |
|------|--------|
| `analyze.py` | Default `Metric.sasa`, replace `efficiency` → `memory` command |
| `analyze_data.py` | Add `memory_bytes` to `load_data()` output |
| `analyze_plots.py` | Remove `plot_efficiency`, add `plot_memory` (scatter + bar) |

## Memory plots
- `memory/scatter.png`: atoms vs peak RSS (log-log, threads=1)
- `memory/by_size.png`: median peak RSS by size bin (bar chart, threads=1)

## Test plan
- [x] Syntax check passes
- [x] CLI shows `memory` command, `--metric` default is `sasa`
- [ ] `./analyze.py memory` generates plots with real data
- [ ] `./analyze.py all` runs successfully