### PR TITLE
feat: add bitmask variants for Python MD wrappers

### DIFF
--- a/benchmarks/scripts/bench_md.py
+++ b/benchmarks/scripts/bench_md.py
@@ -55,7 +55,9 @@ Output:
     ├── bench_zig_f32_bitmask_4t.json   # --tool zig_bitmask
     ├── bench_zig_f64_bitmask_4t.json   # --tool zig_bitmask
     ├── bench_zsasa_mdtraj_4t.json
+    ├── bench_zsasa_mdtraj_bitmask_4t.json
     ├── bench_zsasa_mdanalysis_4t.json
+    ├── bench_zsasa_mdanalysis_bitmask_4t.json
     ├── bench_mdtraj_1t.json
     └── bench_mdsasa_bolt_all.json
 """
@@ -91,7 +93,9 @@ class Tool(str, Enum):
     zig = "zig"
     zig_bitmask = "zig_bitmask"
     zsasa_mdtraj = "zsasa_mdtraj"
+    zsasa_mdtraj_bitmask = "zsasa_mdtraj_bitmask"
     zsasa_mdanalysis = "zsasa_mdanalysis"
+    zsasa_mdanalysis_bitmask = "zsasa_mdanalysis_bitmask"
     mdtraj = "mdtraj"
     mdsasa_bolt = "mdsasa_bolt"
 
@@ -100,7 +104,9 @@ ALL_TOOLS = [
     Tool.zig,
     Tool.zig_bitmask,
     Tool.zsasa_mdtraj,
+    Tool.zsasa_mdtraj_bitmask,
     Tool.zsasa_mdanalysis,
+    Tool.zsasa_mdanalysis_bitmask,
     Tool.mdtraj,
     Tool.mdsasa_bolt,
 ]
@@ -202,6 +208,7 @@ def run_python_tool(
     n_points: int = 100,
     timeout: int = 600,
     prepare: str | None = None,
+    use_bitmask: bool = False,
 ) -> dict | None:
     """Run a Python-based benchmark tool via the runner script."""
     cmd_parts = [
@@ -214,6 +221,8 @@ def run_python_tool(
     ]
     if n_threads is not None:
         cmd_parts.append(f"--threads {n_threads}")
+    if use_bitmask:
+        cmd_parts.append("--use-bitmask")
 
     cmd = " ".join(cmd_parts)
 
@@ -236,15 +245,17 @@ def run_threaded_python_tool(
     n_points: int,
     timeout: int = 600,
     prepare: str | None = None,
+    use_bitmask: bool = False,
 ) -> list[dict]:
     """Run a Python-based benchmark tool across multiple thread counts.
 
     Used for zsasa_mdtraj and zsasa_mdanalysis which share the same
     loop-over-threads pattern.
     """
+    bitmask_suffix = "_bitmask" if use_bitmask else ""
     results = []
     for n_threads in thread_counts:
-        label = f"{tool_name}_{n_threads}t"
+        label = f"{tool_name}{bitmask_suffix}_{n_threads}t"
         result = run_python_tool(
             tool_name,
             label,
@@ -260,6 +271,7 @@ def run_threaded_python_tool(
             n_points=n_points,
             timeout=timeout,
             prepare=prepare,
+            use_bitmask=use_bitmask,
         )
         if result:
             results.append({"name": label, **result})
@@ -478,8 +490,15 @@ def main(
     selected_tools = tools if tools else ALL_TOOLS
 
     # Rebuild zsasa in ReleaseFast mode to ensure benchmarks use optimized code
-    zig_tools = {Tool.zig, Tool.zig_bitmask}
-    if not dry_run and zig_tools & set(selected_tools):
+    zsasa_tools = {
+        Tool.zig,
+        Tool.zig_bitmask,
+        Tool.zsasa_mdtraj,
+        Tool.zsasa_mdtraj_bitmask,
+        Tool.zsasa_mdanalysis,
+        Tool.zsasa_mdanalysis_bitmask,
+    }
+    if not dry_run and zsasa_tools & set(selected_tools):
         ensure_zsasa_built()
 
     # Get trajectory metadata
@@ -560,10 +579,19 @@ def main(
         )
         all_results.extend(results)
 
-    for python_tool in [Tool.zsasa_mdtraj, Tool.zsasa_mdanalysis]:
+    # Python wrappers: normal and bitmask variants
+    python_tool_pairs = [
+        (Tool.zsasa_mdtraj, False),
+        (Tool.zsasa_mdtraj_bitmask, True),
+        (Tool.zsasa_mdanalysis, False),
+        (Tool.zsasa_mdanalysis_bitmask, True),
+    ]
+    for python_tool, use_bitmask in python_tool_pairs:
         if python_tool in selected_tools:
+            # Runner tool name is the base name (without _bitmask suffix)
+            runner_tool = python_tool.value.removesuffix("_bitmask")
             results = run_threaded_python_tool(
-                python_tool.value,
+                runner_tool,
                 xtc,
                 pdb,
                 results_dir,
@@ -576,6 +604,7 @@ def main(
                 n_points,
                 timeout,
                 prepare,
+                use_bitmask=use_bitmask,
             )
             all_results.extend(results)
 

--- a/benchmarks/scripts/bench_md_runner.py
+++ b/benchmarks/scripts/bench_md_runner.py
@@ -51,7 +51,12 @@ def run_mdtraj(xtc: Path, pdb: Path, n_points: int, stride: int) -> None:
 
 
 def run_zsasa_mdtraj(
-    xtc: Path, pdb: Path, n_threads: int, n_points: int, stride: int
+    xtc: Path,
+    pdb: Path,
+    n_threads: int,
+    n_points: int,
+    stride: int,
+    use_bitmask: bool = False,
 ) -> None:
     """Run zsasa via MDTraj wrapper."""
     import mdtraj as md
@@ -59,11 +64,22 @@ def run_zsasa_mdtraj(
     from zsasa.mdtraj import compute_sasa
 
     traj = md.load(str(xtc), top=str(pdb), stride=stride)
-    compute_sasa(traj, n_points=n_points, n_threads=n_threads, mode="total")
+    compute_sasa(
+        traj,
+        n_points=n_points,
+        n_threads=n_threads,
+        mode="total",
+        use_bitmask=use_bitmask,
+    )
 
 
 def run_zsasa_mdanalysis(
-    xtc: Path, pdb: Path, n_threads: int, n_points: int, stride: int
+    xtc: Path,
+    pdb: Path,
+    n_threads: int,
+    n_points: int,
+    stride: int,
+    use_bitmask: bool = False,
 ) -> None:
     """Run zsasa via MDAnalysis wrapper."""
     import MDAnalysis as mda
@@ -72,7 +88,9 @@ def run_zsasa_mdanalysis(
 
     u = mda.Universe(str(pdb), str(xtc))
     analysis = SASAAnalysis(u)
-    analysis.run(step=stride, n_points=n_points, n_threads=n_threads)
+    analysis.run(
+        step=stride, n_points=n_points, n_threads=n_threads, use_bitmask=use_bitmask
+    )
 
 
 def run_mdsasa_bolt(xtc: Path, pdb: Path, n_points: int, stride: int) -> None:
@@ -99,14 +117,19 @@ def main(
         int, typer.Option("--n-points", help="Test points per atom")
     ] = 100,
     stride: Annotated[int, typer.Option("--stride", help="Frame stride")] = 1,
+    use_bitmask: Annotated[
+        bool, typer.Option("--use-bitmask", help="Use bitmask LUT optimization")
+    ] = False,
 ) -> None:
     """Execute a single SASA benchmark tool."""
     if tool == Tool.mdtraj:
         run_mdtraj(xtc, pdb, n_points, stride)
     elif tool == Tool.zsasa_mdtraj:
-        run_zsasa_mdtraj(xtc, pdb, threads, n_points, stride)
+        run_zsasa_mdtraj(xtc, pdb, threads, n_points, stride, use_bitmask=use_bitmask)
     elif tool == Tool.zsasa_mdanalysis:
-        run_zsasa_mdanalysis(xtc, pdb, threads, n_points, stride)
+        run_zsasa_mdanalysis(
+            xtc, pdb, threads, n_points, stride, use_bitmask=use_bitmask
+        )
     elif tool == Tool.mdsasa_bolt:
         run_mdsasa_bolt(xtc, pdb, n_points, stride)
 


### PR DESCRIPTION
## Summary
- Add `zsasa_mdtraj_bitmask` and `zsasa_mdanalysis_bitmask` as benchmark tools
- Pass `--use-bitmask` flag through `bench_md_runner.py` to Python zsasa wrappers
- Both `zsasa.mdtraj` and `zsasa.mdanalysis` already had `use_bitmask` param but it wasn't exposed in benchmarks

## Test plan
- [x] Dry-run confirms correct command generation with `--use-bitmask` flag
- [ ] Run with small dataset: `--tool zsasa_mdtraj_bitmask --tool zsasa_mdanalysis_bitmask`