### PR TITLE
fix: correct multiple documentation inaccuracies

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.2.0";
+const version = "0.2.1";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -71,10 +71,10 @@ See [Trajectory Mode](#trajectory-mode) section below for details.
 
 | Option | Description |
 |--------|-------------|
-| `--classifier=TYPE` | Built-in classifier: `naccess`, `protor`, or `oons` |
-| `--config=FILE` | Custom classifier config file (TOML or FreeSASA format, auto-detected by extension) |
+| `--classifier=TYPE` | Built-in classifier: `naccess`, `protor`, or `oons` | `protor` for PDB/mmCIF, none for JSON |
+| `--config=FILE` | Custom classifier config file (TOML or FreeSASA format, auto-detected by extension) | none |
 
-When `--classifier` is used, atom radii are assigned based on residue and atom names. If both `--classifier` and `--config` are specified, `--config` takes precedence.
+When `--classifier` is used, atom radii are assigned based on residue and atom names. For PDB/mmCIF input, `protor` is used by default (matching FreeSASA/RustSASA defaults). If both `--classifier` and `--config` are specified, `--config` takes precedence.
 
 ### Structure Filtering
 
@@ -83,7 +83,8 @@ When `--classifier` is used, atom radii are assigned based on residue and atom n
 | `--chain=ID` | Filter by chain ID (e.g., `A` or `A,B,C`) | all chains |
 | `--model=N` | Model number for NMR structures (≥1) | all models |
 | `--auth-chain` | Use auth_asym_id instead of label_asym_id | label_asym_id |
-| `--include-hydrogens` | Include hydrogen atoms | excluded |
+| `--include-hydrogens` | Include hydrogen atoms (calc/batch default: excluded) | excluded |
+| `--no-hydrogens` | Exclude hydrogen atoms (traj default: included) | — |
 | `--include-hetatm` | Include HETATM records | excluded |
 
 ### Analysis Options
@@ -522,7 +523,8 @@ zsasa traj <trajectory> <topology> [OPTIONS]
 | `--n-points=N` | Test points per atom (SR only) | `100` |
 | `--n-slices=N` | Slices per atom diameter (LR only) | `20` |
 | `--precision=P` | Floating-point precision: `f32` or `f64` | `f32` |
-| `--include-hydrogens` | Include hydrogen atoms | excluded |
+| `--no-hydrogens` | Exclude hydrogen atoms | included |
+| `--include-hydrogens` | Include hydrogen atoms (default, for backward compat) | included |
 | `--stride=N` | Process every Nth frame | `1` |
 | `--start=N` | Start from frame N | `0` |
 | `--end=N` | End at frame N | all |
@@ -564,7 +566,7 @@ zsasa traj trajectory.xtc topology.pdb --algorithm=lr --precision=f64
 
 - Supported trajectory formats: **XTC** (GROMACS) and **DCD** (NAMD/CHARMM), auto-detected from extension
 - XTC coordinates are in nm; automatically converted to Å. DCD coordinates are already in Å.
-- Hydrogen atoms are excluded by default; use `--include-hydrogens` to include them
+- Hydrogen atoms are **included** by default in trajectory mode; use `--no-hydrogens` to exclude them
 - Topology file provides atom names for radius classification
 - The number of atoms in XTC must match the topology
 - Default precision is `f32` (faster for trajectory processing)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -65,8 +65,10 @@ result = calculate_sasa_from_structure("protein.cif")
 print(f"Total SASA: {result.total_area:.1f} Å²")
 
 # Per-residue analysis
-for res in result.residue_areas:
-    print(f"  {res.chain}:{res.name}{res.number} = {res.area:.1f} Å²")
+from zsasa.analysis import aggregate_from_result
+
+for res in aggregate_from_result(result):
+    print(f"  {res.chain_id}:{res.residue_name}{res.residue_id} = {res.total_area:.1f} Å²")
 ```
 
 ### CLI

--- a/website/docs/guide/classifiers.mdx
+++ b/website/docs/guide/classifiers.mdx
@@ -11,8 +11,8 @@ Classifiers assign van der Waals radii and polarity classes to atoms based on re
 
 ## Quick Recommendation
 
-- **NACCESS**: Best default. Widely used, compatible with FreeSASA.
-- **ProtOr**: Hybridization-based radii. Use when comparing with ProtOr-based studies.
+- **ProtOr**: CLI default for PDB/mmCIF. Hybridization-based radii (Tsai et al. 1999).
+- **NACCESS**: Widely used, compatible with FreeSASA. Use when comparing with NACCESS-based studies.
 - **OONS**: Larger aliphatic carbon radii. Use when comparing with OONS-based studies.
 
 ## How Classifiers Work

--- a/website/docs/zig-api/autodoc.md
+++ b/website/docs/zig-api/autodoc.md
@@ -19,6 +19,6 @@ functions, and modules in zsasa.
 ```bash
 zig build docs
 # Serve with HTTP server (WASM requires HTTP, not file://)
-python3 -m http.server 8080 --directory zig-out/docs
+uv run python -m http.server 8080 --directory zig-out/docs
 # Open http://localhost:8080
 ```


### PR DESCRIPTION
## Summary
- **getting-started.md**: Fix nonexistent `result.residue_areas` → use `aggregate_from_result()`
- **cli.md**: Fix traj hydrogen default (included, not excluded), add `--no-hydrogens` option
- **cli.md**: Add classifier default to table (protor for PDB/mmCIF, none for JSON)
- **classifiers.mdx**: Fix quick recommendation to reflect ProtOr as actual CLI default
- **autodoc.md**: `python3` → `uv run python`
- **build.zig**: Sync version to 0.2.1 (matches build.zig.zon and pyproject.toml)

## Test plan
- [ ] Verify getting-started.md code example works
- [ ] Verify cli.md traj options table is accurate
- [ ] Verify classifiers.mdx renders correctly