### PR TITLE
docs: add bitmask LUT links across all docs

### DIFF
--- a/website/docs/benchmarks/batch.md
+++ b/website/docs/benchmarks/batch.md
@@ -31,7 +31,7 @@ Throughput benchmarks for processing complete proteome datasets using [hyperfine
 | Tool | Language | Description |
 |------|----------|-------------|
 | zsasa | Zig | f64/f32 precision, standard neighbor lists |
-| zsasa_bitmask | Zig | f64/f32 precision, LUT bitmask neighbor lists |
+| zsasa_bitmask | Zig | f64/f32 precision, [LUT bitmask](../guide/algorithms.mdx#bitmask-lut-optimization) neighbor lists |
 | [Lahuta](https://github.com/your-repo/lahuta) | Zig | Standard neighbor lists |
 | Lahuta Bitmask | Zig | LUT bitmask neighbor lists |
 | [RustSASA](https://github.com/OWissett/rustsasa) | Rust | Native multi-threading |

--- a/website/docs/benchmarks/md.md
+++ b/website/docs/benchmarks/md.md
@@ -144,7 +144,7 @@ Benchmark: warmup=1, runs=3, threads=1,8,10.
 
 ## Bitmask Variants
 
-The `_bitmask` variants use LUT (look-up table) bitmask neighbor lists:
+The `_bitmask` variants use [LUT bitmask neighbor lists](../guide/algorithms.mdx#bitmask-lut-optimization):
 
 - **~2.1x faster** than standard zsasa across all system sizes
 - Minimal memory overhead for CLI variants (~2 MB extra)

--- a/website/docs/benchmarks/single-file.md
+++ b/website/docs/benchmarks/single-file.md
@@ -136,7 +136,7 @@ Single-threaded comparison (excluding parallelization effects):
 
 ## Bitmask Variants
 
-Bitmask mode uses bit-level neighbor storage instead of full float arrays. This dramatically reduces memory usage at the cost of slightly higher per-structure computation time and minor accuracy differences.
+[Bitmask mode](../guide/algorithms.mdx#bitmask-lut-optimization) uses LUT bitmask neighbor lists instead of full float arrays. This dramatically reduces memory usage at the cost of slightly higher per-structure computation time and minor accuracy differences.
 
 ### When to Use
 

--- a/website/docs/benchmarks/validation.md
+++ b/website/docs/benchmarks/validation.md
@@ -65,7 +65,7 @@ Dataset: AlphaFold E. coli K-12 proteome, 4,370 structures. Reference: FreeSASA.
 
 - **zsasa f64**: Bit-identical to FreeSASA at all point counts (same algorithm parameters)
 - **zsasa f32**: Max 0.015% error from floating-point rounding — negligible for practical use
-- **Bitmask variants**: Mean error ~0.7–0.8%, plateaus regardless of point count (LUT approximation error)
+- **[Bitmask](../guide/algorithms.mdx#bitmask-lut-optimization) variants**: Mean error ~0.7–0.8%, plateaus regardless of point count (LUT approximation error)
 - **RustSASA**: Converges toward FreeSASA with increasing points (0.32% → 0.06% mean error)
 - **f32 vs f64 bitmask**: Virtually identical — bitmask error dominates floating-point error
 

--- a/website/docs/integrations/mdanalysis.md
+++ b/website/docs/integrations/mdanalysis.md
@@ -82,7 +82,7 @@ def run(
 | `algorithm` | `"sr"` or `"lr"` | `"sr"` | Algorithm to use |
 | `n_slices` | `int` | `20` | Slices per atom (LR) |
 | `n_threads` | `int` | `0` | Threads (0 = auto) |
-| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 1..1024) |
+| `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
 
 **Returns:** `self` for method chaining.
 

--- a/website/docs/integrations/mdtraj.md
+++ b/website/docs/integrations/mdtraj.md
@@ -49,7 +49,7 @@ def compute_sasa(
 | `n_slices` | `int` | `20` | Slices per atom (LR) |
 | `n_threads` | `int` | `0` | Threads (0 = auto) |
 | `mode` | `"atom"`, `"residue"`, `"total"` | `"atom"` | Output mode |
-| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 1..1024) |
+| `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
 
 **Returns:** SASA values in nm² (matching MDTraj's output units).
 

--- a/website/docs/python-api/core.md
+++ b/website/docs/python-api/core.md
@@ -31,7 +31,7 @@ Calculate Solvent Accessible Surface Area.
 | `n_slices` | `int` | `20` | Slices per atom (LR only) |
 | `probe_radius` | `float` | `1.4` | Water probe radius in Å |
 | `n_threads` | `int` | `0` | Number of threads (0 = auto) |
-| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 1..1024) |
+| `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
 
 **Returns:** `SasaResult`
 
@@ -83,7 +83,7 @@ Calculate SASA for multiple frames in batch.
 | `probe_radius` | `float` | `1.4` | Water probe radius in Å |
 | `n_threads` | `int` | `0` | Number of threads (0 = auto) |
 | `precision` | `"f64"` or `"f32"` | `"f64"` | Floating-point precision |
-| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 1..1024) |
+| `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
 
 **Returns:** `BatchSasaResult`
 

--- a/website/docs/python-api/xtc.md
+++ b/website/docs/python-api/xtc.md
@@ -147,7 +147,7 @@ def compute_sasa_trajectory(
 | `start` | `int` | `0` | First frame to process |
 | `stop` | `int \| None` | `None` | Stop before this frame (None = all) |
 | `step` | `int` | `1` | Process every Nth frame |
-| `use_bitmask` | `bool` | `False` | Use bitmask LUT optimization (SR only, n_points must be 1..1024) |
+| `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
 
 **Returns:** `TrajectorySasaResult`
 


### PR DESCRIPTION
## Summary
Add links to `guide/algorithms.mdx#bitmask-lut-optimization` from all pages that mention bitmask:
- **benchmarks**: single-file, batch, md, validation
- **python-api**: core, xtc
- **integrations**: mdtraj, mdanalysis

## Test plan
- [ ] Verify all internal links resolve correctly