### PR TITLE
feat: add Python autodoc with pdoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           version: 0.15.2
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -41,6 +46,13 @@ jobs:
 
       - name: Build Zig autodoc
         run: zig build docs
+
+      - name: Build Python autodoc
+        working-directory: python
+        run: |
+          pip install "pdoc>=14.0"
+          pip install -e .
+          pdoc zsasa --output-dir /tmp/python-autodoc
 
       - name: Build Docusaurus site
         working-directory: website
@@ -57,6 +69,9 @@ jobs:
 
       - name: Copy Zig autodoc into site
         run: cp -r zig-out/docs website/build/zig-autodoc
+
+      - name: Copy Python autodoc into site
+        run: cp -r /tmp/python-autodoc website/build/python-autodoc
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/website/docs/python-api/autodoc.md
+++ b/website/docs/python-api/autodoc.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 6
+---
+
+# Python Autodoc (pdoc)
+
+Auto-generated API documentation from Python docstrings using [pdoc](https://pdoc.dev/).
+
+The autodoc provides searchable, browsable documentation for all public classes,
+functions, and modules in the zsasa Python package.
+
+**[Open Python Autodoc](pathname:///zsasa/python-autodoc/zsasa.html)**
+
+## Features
+
+- Complete API reference generated from source docstrings
+- Type annotations and signatures
+- Searchable across all modules
+- Covers core API, integrations, and analysis utilities
+
+## Generate Locally
+
+```bash
+cd python
+uv run pdoc zsasa --output-dir /tmp/python-autodoc
+# Open /tmp/python-autodoc/zsasa.html in browser
+```
+
+Or serve with live reload:
+
+```bash
+cd python
+uv run pdoc zsasa
+# Opens http://localhost:8080 automatically
+```

--- a/website/docs/python-api/index.md
+++ b/website/docs/python-api/index.md
@@ -28,6 +28,7 @@ The Python bindings provide:
 | [Classifier](classifier.md) | Atom classification, RSA calculation |
 | [Analysis](analysis.md) | Per-residue aggregation, examples |
 | [Native XTC Reader](xtc.md) | Standalone XTC reading, no dependencies |
+| [Autodoc (pdoc)](autodoc.md) | Auto-generated API reference from docstrings |
 
 For structure file parsing and MD trajectory integrations, see [Integrations](../integrations/).
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
         "python-api/classifier",
         "python-api/analysis",
         "python-api/xtc",
+        "python-api/autodoc",
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Add pdoc-based auto-generated Python API docs, mirroring Zig autodoc pattern
- CI workflow: Setup Python 3.13, build pdoc output, copy to `/python-autodoc/`
- New `python-api/autodoc.md` page with link to generated docs
- Add autodoc entry to Python API sidebar and overview table

## Changes
- `.github/workflows/docs.yml` - Add Python setup + pdoc build + copy steps
- `website/docs/python-api/autodoc.md` - New page with link and local build instructions
- `website/docs/python-api/index.md` - Add autodoc to contents table
- `website/sidebars.ts` - Add autodoc to Python API category

## Test plan
- [ ] Verify CI docs workflow passes with pdoc step
- [ ] Verify `/python-autodoc/zsasa.html` is accessible on deployed site
- [ ] Verify autodoc page renders correctly with working link