### PR TITLE
fix: correct errors found in website docs audit

### DIFF
--- a/website/docs/benchmarks/batch.md
+++ b/website/docs/benchmarks/batch.md
@@ -32,9 +32,9 @@ Throughput benchmarks for processing complete proteome datasets using [hyperfine
 |------|----------|-------------|
 | zsasa | Zig | f64/f32 precision, standard neighbor lists |
 | zsasa_bitmask | Zig | f64/f32 precision, [LUT bitmask](../guide/algorithms.mdx#bitmask-lut-optimization) neighbor lists |
-| [Lahuta](https://github.com/your-repo/lahuta) | Zig | Standard neighbor lists |
-| Lahuta Bitmask | Zig | LUT bitmask neighbor lists |
-| [RustSASA](https://github.com/OWissett/rustsasa) | Rust | Native multi-threading |
+| [Lahuta](https://github.com/bisejdiu/lahuta) | C++ | Standard neighbor lists |
+| Lahuta Bitmask | C++ | LUT bitmask neighbor lists |
+| [RustSASA](https://github.com/maxall41/RustSASA) | Rust | Native multi-threading |
 | [FreeSASA](https://github.com/mittinatten/freesasa) | C | No native batch mode — custom wrapper ([`freesasa_batch.cc`](https://github.com/N283T/zsasa/tree/main/benchmarks/external/freesasa_batch)) |
 
 ## E. coli Proteome (4,370 structures)

--- a/website/docs/benchmarks/single-file.md
+++ b/website/docs/benchmarks/single-file.md
@@ -326,7 +326,7 @@ Measurement method for each implementation:
 | zsasa_f64_bitmask | f64 | Bitmask | ~15x less memory for 500k+ atoms |
 | zsasa_f32_bitmask | f32 | Bitmask | Lowest memory usage |
 | FreeSASA | f64 | — | C reference implementation |
-| RustSASA | f64 | — | Rust implementation |
+| RustSASA | f32 | — | Rust implementation |
 
 ### Stratified Sampling
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -65,7 +65,7 @@ result = calculate_sasa_from_structure("protein.cif")
 print(f"Total SASA: {result.total_area:.1f} Å²")
 
 # Per-residue analysis
-from zsasa.analysis import aggregate_from_result
+from zsasa import aggregate_from_result
 
 for res in aggregate_from_result(result):
     print(f"  {res.chain_id}:{res.residue_name}{res.residue_id} = {res.total_area:.1f} Å²")

--- a/website/docs/guide/trajectory.md
+++ b/website/docs/guide/trajectory.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Trajectory Analysis
 
 zsasa supports SASA calculation over MD trajectory frames using the CLI or Python bindings.


### PR DESCRIPTION
## Summary
- Fix Lahuta placeholder URL (`your-repo` → `bisejdiu/lahuta`) and wrong language (`Zig` → `C++`) in batch.md
- Fix RustSASA precision (`f64` → `f32`) in single-file.md — verified against source (`Vec<f32>` throughout lib.rs)
- Fix RustSASA URL (`OWissett/rustsasa` → `maxall41/RustSASA`) in batch.md
- Fix import path (`zsasa.analysis` → `zsasa`) in getting-started.md for consistency
- Add missing frontmatter to guide/trajectory.md

## Test plan
- [ ] Verify batch.md tool table renders correctly
- [ ] Verify all external links resolve