### PR TITLE
fix: add BSD-2-Clause license notice for libxdrfile

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,37 @@
+# Third-Party Notices
+
+zsasa includes code derived from the following projects.
+
+## libxdrfile (via chemfiles/xdrfile)
+
+- **Used in**: `src/xtc.zig` (Zig port of XTC trajectory reader)
+- **Source**: https://github.com/chemfiles/xdrfile
+- **Original**: GROMACS libxdrfile 1.1.4
+- **License**: BSD-2-Clause
+
+```
+Copyright (c) 2009-2014, Erik Lindahl & David van der Spoel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```

--- a/src/xtc.zig
+++ b/src/xtc.zig
@@ -1,10 +1,35 @@
 // XTC trajectory file reader
-// Zig port of GROMACS libxdrfile (BSD-2-Clause)
-// Original: Erik Lindahl & David van der Spoel
+// Zig port of libxdrfile via chemfiles/xdrfile
+// https://github.com/chemfiles/xdrfile
 //
 // XTC is a compressed trajectory format using:
 // - XDR (External Data Representation) for portable binary I/O
 // - Custom 3D coordinate compression with delta encoding
+//
+// Copyright (c) 2009-2014, Erik Lindahl & David van der Spoel
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 //
 const std = @import("std");
 const Allocator = std.mem.Allocator;


### PR DESCRIPTION
## Summary

- Add full BSD-2-Clause copyright and license text to `src/xtc.zig` header (Zig port of libxdrfile via [chemfiles/xdrfile](https://github.com/chemfiles/xdrfile))
- Fix source attribution: GROMACS libxdrfile → chemfiles/xdrfile fork
- Create `THIRD_PARTY_NOTICES.md` for third-party license attribution

## Context

`src/xtc.zig` is a Zig port of the XTC trajectory reader from libxdrfile (Copyright 2009-2014, Erik Lindahl & David van der Spoel). BSD-2-Clause requires retaining copyright notice and license text in source redistributions.

## Test plan

- [x] `zig build` passes
- [x] `zig build test` passes
- [x] No functional changes — license headers only