### PR TITLE
fix: Windows build errors in mmap_reader and batch

### DIFF
--- a/src/batch.zig
+++ b/src/batch.zig
@@ -890,7 +890,8 @@ pub fn runBatchParallel(
     };
 
     // Set up the stream writer on the stack (if JSONL streaming is active).
-    // When jsonl_file is null, jsonl_stream_ptr is null so the storage is never accessed.
+    // SAFETY: `undefined` when jsonl_file is null — never accessed because
+    // jsonl_stream_ptr is also null in that case.
     var jsonl_stream_storage: JsonlStreamWriter = if (jsonl_file) |jf|
         JsonlStreamWriter{ .file = jf }
     else

--- a/src/mmap_reader.zig
+++ b/src/mmap_reader.zig
@@ -7,32 +7,33 @@ pub const is_windows = builtin.os.tag == .windows;
 ///
 /// Ownership: single-owner, non-copyable by convention. Exactly one `deinit`
 /// call must occur per `mmapFile` call.
-/// Typical usage: `const mapped = try mmapFile(alloc, path); defer mapped.deinit(alloc);`
+/// Typical usage: `const mapped = try mmapFile(alloc, path); defer mapped.deinit();`
 pub const MappedFile = struct {
     data: if (is_windows) []const u8 else []align(std.heap.page_size_min) const u8,
+    allocator: if (is_windows) std.mem.Allocator else void,
 
-    pub fn deinit(self: MappedFile, allocator: if (is_windows) std.mem.Allocator else void) void {
+    pub fn deinit(self: MappedFile) void {
         if (self.data.len == 0) return;
         if (is_windows) {
-            allocator.free(self.data);
+            self.allocator.free(self.data);
         } else {
             std.posix.munmap(@alignCast(self.data));
         }
     }
 };
 
-pub fn mmapFile(allocator: if (is_windows) std.mem.Allocator else void, path: []const u8) !MappedFile {
+pub fn mmapFile(allocator: std.mem.Allocator, path: []const u8) !MappedFile {
     const file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 
-    if (is_windows) {
-        const data = try file.readToEndAlloc(allocator, std.math.maxInt(u32));
-        return .{ .data = data };
-    } else {
-        const stat = try file.stat();
-        const size: usize = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
-        if (size == 0) return .{ .data = &.{} };
+    const stat = try file.stat();
+    const size: usize = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
+    if (size == 0) return .{ .data = &.{}, .allocator = if (is_windows) allocator else {} };
 
+    if (is_windows) {
+        const data = try file.readToEndAlloc(allocator, size);
+        return .{ .data = data, .allocator = allocator };
+    } else {
         const mapped = try std.posix.mmap(
             null,
             size,
@@ -41,14 +42,13 @@ pub fn mmapFile(allocator: if (is_windows) std.mem.Allocator else void, path: []
             file.handle,
             0,
         );
-        return .{ .data = mapped };
+        return .{ .data = mapped, .allocator = {} };
     }
 }
 
 test "mmapFile reads valid PDB" {
-    const alloc_arg = if (is_windows) std.testing.allocator else {};
-    const mapped = try mmapFile(alloc_arg, "test_data/1l2y.pdb");
-    defer mapped.deinit(alloc_arg);
+    const mapped = try mmapFile(std.testing.allocator, "test_data/1l2y.pdb");
+    defer mapped.deinit();
     try std.testing.expect(mapped.data.len > 0);
     try std.testing.expect(std.mem.startsWith(u8, mapped.data, "REMARK") or
         std.mem.startsWith(u8, mapped.data, "HEADER") or

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -137,9 +137,8 @@ pub const MmcifParser = struct {
 
     /// Parse mmCIF from a file
     pub fn parseFile(self: *MmcifParser, path: []const u8) !AtomInput {
-        const alloc_arg = if (mmap_reader.is_windows) self.allocator else {};
-        const mapped = try mmap_reader.mmapFile(alloc_arg, path);
-        defer mapped.deinit(alloc_arg);
+        const mapped = try mmap_reader.mmapFile(self.allocator, path);
+        defer mapped.deinit();
         return self.parse(mapped.data);
     }
 

--- a/src/pdb_parser.zig
+++ b/src/pdb_parser.zig
@@ -214,9 +214,8 @@ pub const PdbParser = struct {
 
     /// Parse PDB from a file
     pub fn parseFile(self: *PdbParser, path: []const u8) !AtomInput {
-        const alloc_arg = if (mmap_reader.is_windows) self.allocator else {};
-        const mapped = try mmap_reader.mmapFile(alloc_arg, path);
-        defer mapped.deinit(alloc_arg);
+        const mapped = try mmap_reader.mmapFile(self.allocator, path);
+        defer mapped.deinit();
         return self.parse(mapped.data);
     }
 


### PR DESCRIPTION
## Summary

- `mmap_reader.zig`: Fall back to heap allocation (`readToEndAlloc`) on Windows where POSIX `mmap` is unavailable
- `batch.zig`: Replace `std.mem.zeroes(JsonlStreamWriter)` with `undefined` — zeroes fails on Windows because `std.fs.File` contains non-nullable pointers
- Update `pdb_parser.zig` and `mmcif_parser.zig` call sites for new `mmapFile` signature

## Context

v0.2.2 release CI failed on Windows (`src/mmap_reader.zig:29: error: type 'void' does not support struct initialization syntax`) and a secondary `std.mem.zeroes` error in batch.zig.

## Test plan

- [x] `zig build` passes (native)
- [x] `zig build test` passes (native)
- [x] `zig build -Dtarget=x86_64-windows-gnu` cross-compilation passes