### PR TITLE
ci: cache cibuildwheel downloads to avoid rate limits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           version: 0.15.2
 
+      - name: Cache cibuildwheel
+        if: runner.os != 'Linux'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: |
+            ~/Library/Caches/cibuildwheel
+            ~/AppData/Local/pypa/cibuildwheel/Cache
+          key: cibw-${{ runner.os }}-${{ hashFiles('python/pyproject.toml') }}
+          restore-keys: cibw-${{ runner.os }}-
+
       - name: Build wheels
         uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22
         with:


### PR DESCRIPTION
## Summary

Add `actions/cache` for cibuildwheel's download cache on macOS/Windows runners.

cibuildwheel downloads virtualenv.pyz and CPython from GitHub on every run. When 5 runners start simultaneously, this triggers HTTP 429 (Too Many Requests) from GitHub's rate limiting. This has caused v0.2.2 and v0.2.3 release CIs to fail repeatedly.

### Changes

- Cache `~/Library/Caches/cibuildwheel` (macOS) and `~/AppData/Local/pypa/cibuildwheel/Cache` (Windows)
- Key based on `runner.os` + `pyproject.toml` hash
- Linux excluded (uses container-provided Python, no external downloads)

### Expected behavior

- First run: downloads as usual, populates cache
- Subsequent runs: cache hit, no downloads, no rate limit risk

## Test plan

- [ ] Verify on next tag push (cache cold on first run, warm on subsequent)