### PR TITLE
ci: update cibuildwheel v2.22 to v3.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: cibw-${{ runner.os }}-
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22
+        uses: pypa/cibuildwheel@54a71d3375df80d84b6d4537d04614fec04e637f # v3.4.0
         with:
           package-dir: python
 


### PR DESCRIPTION
## Summary

Update cibuildwheel from v2.22 to v3.4.0 (latest).

No breaking changes for our configuration:
- manylinux_2_28 already explicitly set (now the v3 default)
- hatchling build backend (v3 dropped setuptools preinstall — doesn't affect us)
- Python 3.11+ only (v3 dropped 3.6/3.7)

## Test plan

- [ ] Verify on next tag push