### PR TITLE
ci: remove obsolete cibuildwheel v3 skip selectors

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,7 +63,7 @@ python-version = "3.11"
 
 [tool.cibuildwheel]
 build = ["cp311-*", "cp312-*", "cp313-*"]
-skip = ["pp*", "*-win32", "*-win_arm64", "*-manylinux_i686", "*-musllinux_*", "*_s390x", "*_ppc64le"]
+skip = ["*-win32", "*-win_arm64", "*-musllinux_*", "*_s390x", "*_ppc64le"]
 test-requires = ["pytest", "numpy"]
 test-command = "pytest {project}/python/tests/test_sasa.py -x -q"
 


### PR DESCRIPTION
## Summary

Remove `pp*` and `*-manylinux_i686` from cibuildwheel skip list.

Both are disabled by default in cibuildwheel v3 and produce warnings:
> Warning: cibuildwheel: Invalid skip selector: 'pp*'. This selector matches a group that wasn't enabled.

## Test plan

- [x] No functional change — just removes warnings