### PR TITLE
docs: comment out install.sh instructions until next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,22 @@ print(f"Total SASA: {result.total_area:.2f} Å²")
 
 ### CLI
 
+Requires [Zig 0.15.2](https://ziglang.org/download/).
+
+```bash
+git clone https://github.com/N283T/zsasa.git
+cd zsasa && zig build -Doptimize=ReleaseFast
+```
+
+<!-- TODO: uncomment after next release with CLI binary assets
 ```bash
 # One-line install (downloads pre-built binary)
 curl -fsSL https://raw.githubusercontent.com/N283T/zsasa/main/install.sh | sh
 
 # Or with custom install directory
 curl -fsSL https://raw.githubusercontent.com/N283T/zsasa/main/install.sh | INSTALL_DIR=/usr/local/bin sh
-
-# Or build from source (requires Zig 0.15.2)
-git clone https://github.com/N283T/zsasa.git
-cd zsasa && zig build -Doptimize=ReleaseFast
 ```
+-->
 
 ```bash
 zsasa calc structure.cif output.json


### PR DESCRIPTION
## Summary

- Comment out `curl | sh` install instructions in README since CLI binary assets don't exist in releases yet
- Restore source build instructions with Zig version requirement
- Added HTML comment with TODO to uncomment after next release

## Test plan

- [x] README renders correctly with source build instructions visible
- [x] curl instructions hidden until CLI binaries are available