### PR TITLE
feat: bundle CLI binary in Python wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,12 @@ wheels/
 *.egg-info
 .venv/
 
-# Bundled native libraries (built during pip install)
+# Bundled native artifacts (built during pip install)
 python/zsasa/*.dylib
 python/zsasa/*.so
 python/zsasa/*.dll
+python/zsasa/zsasa
+python/zsasa/zsasa.exe
 
 # Zig
 .zig-cache/

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -1,8 +1,9 @@
-"""Custom build hook to compile Zig library during pip install."""
+"""Custom build hook to compile Zig library and CLI binary during pip install."""
 
 from __future__ import annotations
 
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -12,12 +13,12 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
 class ZigBuildHook(BuildHookInterface):
-    """Build hook that compiles the Zig library before packaging."""
+    """Build hook that compiles the Zig library and CLI binary before packaging."""
 
     PLUGIN_NAME = "zig-build"
 
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
-        """Build the Zig library and copy it to the package directory."""
+        """Build the Zig library and CLI binary, then copy them to the package directory."""
         # Mark as platform-specific wheel (required for .so/.dylib bundling)
         build_data["infer_tag"] = True
 
@@ -26,7 +27,7 @@ class ZigBuildHook(BuildHookInterface):
         python_dir = Path(self.root)
         package_dir = python_dir / "zsasa"
 
-        # Platform-specific library name
+        # Platform-specific names
         if sys.platform == "darwin":
             lib_name = "libzsasa.dylib"
         elif sys.platform == "win32":
@@ -34,30 +35,56 @@ class ZigBuildHook(BuildHookInterface):
         else:
             lib_name = "libzsasa.so"
 
-        # Zig outputs DLLs to zig-out/bin/ on Windows, .so/.dylib to zig-out/lib/
+        exe_name = "zsasa.exe" if sys.platform == "win32" else "zsasa"
+
+        # Source paths (zig-out/)
         if sys.platform == "win32":
             lib_src = root_dir / "zig-out" / "bin" / lib_name
         else:
             lib_src = root_dir / "zig-out" / "lib" / lib_name
+        exe_src = root_dir / "zig-out" / "bin" / exe_name
+
+        # Destination paths (zsasa/)
         lib_dst = package_dir / lib_name
+        exe_dst = package_dir / exe_name
 
-        # Check if library already exists and is newer than source
-        if lib_dst.exists():
-            # For development, always rebuild if zig-out doesn't exist
-            if not lib_src.exists():
-                self._build_zig(root_dir)
-                shutil.copy2(lib_src, lib_dst)
-            elif lib_src.stat().st_mtime > lib_dst.stat().st_mtime:
-                self._build_zig(root_dir)
-                shutil.copy2(lib_src, lib_dst)
-        else:
-            # Build if not exists
-            if not lib_src.exists():
-                self._build_zig(root_dir)
-            shutil.copy2(lib_src, lib_dst)
+        # Build if needed
+        needs_build = self._needs_build(lib_src, lib_dst) or self._needs_build(exe_src, exe_dst)
+        if needs_build:
+            self._build_zig(root_dir)
 
-        # Include the library in the wheel
+        # Copy library
+        self._copy_artifact(lib_src, lib_dst, "library")
+
+        # Copy CLI binary
+        self._copy_artifact(exe_src, exe_dst, "CLI binary")
+        # Ensure the binary is executable (no-op on Windows which uses ACLs)
+        if sys.platform != "win32":
+            exe_dst.chmod(exe_dst.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        # Include both artifacts in the wheel
         build_data["force_include"][str(lib_dst)] = f"zsasa/{lib_name}"
+        build_data["force_include"][str(exe_dst)] = f"zsasa/{exe_name}"
+
+    def _needs_build(self, src: Path, dst: Path) -> bool:
+        """Check if a build is needed based on file existence and timestamps."""
+        if not src.exists():
+            return True  # Must build if source artifact is missing
+        if not dst.exists():
+            return False  # Source exists, just needs copy
+        return src.stat().st_mtime > dst.stat().st_mtime
+
+    def _copy_artifact(self, src: Path, dst: Path, label: str) -> None:
+        """Copy a build artifact from zig-out to the package directory."""
+        if not src.exists():
+            msg = f"Zig build artifact not found: {src} ({label})"
+            raise FileNotFoundError(msg)
+        if not dst.exists() or src.stat().st_mtime > dst.stat().st_mtime:
+            try:
+                shutil.copy2(src, dst)
+            except OSError as e:
+                msg = f"Failed to copy {label} from {src} to {dst}"
+                raise RuntimeError(msg) from e
 
     def _find_zig(self) -> list[str]:
         """Find the Zig compiler command."""
@@ -78,7 +105,7 @@ class ZigBuildHook(BuildHookInterface):
 
     def _build_zig(self, root_dir: Path) -> None:
         """Run zig build command."""
-        self.app.display_info("Building Zig library...")
+        self.app.display_info("Building Zig library and CLI binary...")
 
         zig_cmd = self._find_zig()
         if not zig_cmd:
@@ -97,7 +124,7 @@ class ZigBuildHook(BuildHookInterface):
                 text=True,
                 timeout=600,  # 10 minute timeout
             )
-            self.app.display_success("Zig library built successfully")
+            self.app.display_success("Zig library and CLI binary built successfully")
         except subprocess.CalledProcessError as e:
             self.app.display_error(f"Zig build failed:\n{e.stderr}")
-            raise RuntimeError("Failed to build Zig library") from e
+            raise RuntimeError("Zig build failed") from e

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,9 @@ all = [
     "zsasa[mdanalysis]",
 ]
 
+[project.scripts]
+zsasa = "zsasa.cli:main"
+
 [project.urls]
 Homepage = "https://n283t.github.io/zsasa/"
 Repository = "https://github.com/N283T/zsasa"
@@ -65,7 +68,7 @@ python-version = "3.11"
 build = ["cp311-*", "cp312-*", "cp313-*"]
 skip = ["*-win32", "*-win_arm64", "*-musllinux_*", "*_s390x", "*_ppc64le"]
 test-requires = ["pytest", "numpy"]
-test-command = "pytest {project}/python/tests/test_sasa.py -x -q"
+test-command = "pytest {project}/python/tests/test_sasa.py {project}/python/tests/test_cli.py -x -q"
 
 [tool.cibuildwheel.linux]
 # Use manylinux_2_28 (glibc 2.28) containers to match Zig glibc target.

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,64 @@
+"""Tests for the CLI entry point."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).parent.parent.parent / "examples"
+
+
+def run_zsasa(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run zsasa CLI via the Python entry point."""
+    return subprocess.run(
+        [sys.executable, "-m", "zsasa.cli", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def get_output(result: subprocess.CompletedProcess[str]) -> str:
+    """Get combined stdout+stderr output (zsasa writes help/version to stderr)."""
+    return result.stdout + result.stderr
+
+
+class TestCLIEntryPoint:
+    """Test that the CLI binary is bundled and executable."""
+
+    def test_help(self):
+        result = run_zsasa("--help")
+        assert result.returncode == 0
+        output = get_output(result)
+        assert "USAGE" in output
+        assert "calc" in output
+
+    def test_version(self):
+        result = run_zsasa("--version")
+        assert result.returncode == 0
+        assert "zsasa" in get_output(result)
+
+    def test_calc_help(self):
+        result = run_zsasa("calc", "--help")
+        assert result.returncode == 0
+        assert "SASA" in get_output(result)
+
+    def test_calc_structure(self, tmp_path):
+        input_file = EXAMPLES_DIR / "1ubq.cif"
+        if not input_file.exists():
+            pytest.skip("Example structure not available")
+
+        output_file = tmp_path / "output.json"
+        result = run_zsasa("calc", str(input_file), str(output_file))
+        assert result.returncode == 0
+        assert output_file.exists()
+        assert output_file.stat().st_size > 0
+
+    def test_binary_exists(self):
+        from zsasa.cli import _find_binary
+
+        binary = _find_binary()
+        assert Path(binary).exists()

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1507,7 +1507,7 @@ wheels = [
 
 [[package]]
 name = "zsasa"
-version = "0.2.1"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },

--- a/python/zsasa/__main__.py
+++ b/python/zsasa/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running zsasa as a module: python -m zsasa."""
+
+from zsasa.cli import main
+
+main()

--- a/python/zsasa/cli.py
+++ b/python/zsasa/cli.py
@@ -1,0 +1,53 @@
+"""CLI entry point that delegates to the bundled zsasa binary."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _find_binary() -> str:
+    """Locate the bundled zsasa binary."""
+    package_dir = Path(__file__).parent
+    name = "zsasa.exe" if sys.platform == "win32" else "zsasa"
+    binary = package_dir / name
+    if not binary.exists():
+        msg = (
+            f"zsasa binary not found at {binary}. "
+            "This may indicate a broken installation. "
+            "Try reinstalling: pip install --force-reinstall zsasa"
+        )
+        raise FileNotFoundError(msg)
+    return str(binary)
+
+
+def main() -> None:
+    """Run the bundled zsasa CLI binary."""
+    binary = _find_binary()
+    _exec_msg = (
+        f"Error: failed to execute zsasa binary at {binary}: {{err}}\n"
+        "The binary may be corrupted or built for a different platform.\n"
+        "Try reinstalling: pip install --force-reinstall zsasa"
+    )
+    if sys.platform == "win32":
+        # Windows doesn't support execvp reliably, use subprocess
+        import subprocess
+
+        try:
+            sys.exit(subprocess.call([binary, *sys.argv[1:]]))
+        except KeyboardInterrupt:
+            sys.exit(130)
+        except OSError as e:
+            print(_exec_msg.format(err=e), file=sys.stderr)
+            sys.exit(1)
+    else:
+        try:
+            os.execvp(binary, [binary, *sys.argv[1:]])
+        except OSError as e:
+            print(_exec_msg.format(err=e), file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -30,6 +30,11 @@ uv add zsasa[gemmi]
 ### CLI
 
 ```bash
+# Via pip/uv (bundled with the Python package)
+pip install zsasa
+# or
+uv tool install zsasa
+
 # One-line install (downloads pre-built binary)
 curl -fsSL https://raw.githubusercontent.com/N283T/zsasa/main/install.sh | sh
 
@@ -43,6 +48,10 @@ zig build -Doptimize=ReleaseFast
 ```
 
 The binary is at `./zig-out/bin/zsasa` (source build) or `~/.local/bin/zsasa` (install.sh).
+
+:::note
+If you have both the standalone binary and the Python package installed, the one that appears first in your `PATH` will be used. To avoid confusion, use only one installation method for the CLI.
+:::
 
 ### Nix
 
@@ -90,13 +99,13 @@ for res in aggregate_from_result(result):
 
 ```bash
 # Calculate SASA from a structure file
-./zig-out/bin/zsasa calc structure.cif output.json
+zsasa calc structure.cif output.json
 
 # With atom classifier and per-residue output
-./zig-out/bin/zsasa calc --classifier=naccess --rsa structure.cif output.json
+zsasa calc --classifier=naccess --rsa structure.cif output.json
 
 # CSV output
-./zig-out/bin/zsasa calc --format=csv structure.cif output.csv
+zsasa calc --format=csv structure.cif output.csv
 ```
 
 ## What's Next?


### PR DESCRIPTION
## Summary
- Bundle the `zsasa` CLI binary in the Python wheel so users can get it via `pip install zsasa` or `uv tool install zsasa`
- Add thin Python wrapper (`cli.py`) that delegates to the bundled binary via `os.execvp`
- Add `__main__.py` for `python -m zsasa` support
- Extend `hatch_build.py` to copy CLI binary alongside shared library
- Update getting-started docs with pip/uv CLI install instructions

## Test plan
- [x] `uv build --wheel` produces wheel containing both binary and library
- [x] `uv tool install zsasa` → `zsasa calc` works end-to-end
- [x] `python -m zsasa --version` works
- [x] All 70 existing + new tests pass
- [x] Lint clean (ruff)