### PR TITLE
fix: sync conda-forge recipe with staged-recipes PR

### DIFF
--- a/packaging/conda-forge/meta.yaml
+++ b/packaging/conda-forge/meta.yaml
@@ -6,23 +6,23 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-x86_64  # [linux and x86_64]
-    sha256: 250c660de9d0de3f2ccb9e30c6aa8244ff5bb1ea92ac814549f27de1a71a3306  # [linux and x86_64]
-    fn: zsasa  # [linux and x86_64]
-  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-aarch64  # [linux and aarch64]
-    sha256: 82e99edaef90906fc414de35aee1529649efce50fe82f06510a46c490946ff3e  # [linux and aarch64]
-    fn: zsasa  # [linux and aarch64]
-  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-x86_64  # [osx and x86_64]
-    sha256: 97fdae690982d32bf5b6e7d78300480629a8d173acf55c9c0f849d038eeb44e9  # [osx and x86_64]
-    fn: zsasa  # [osx and x86_64]
-  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-aarch64  # [osx and arm64]
-    sha256: d25ff0904ef1300bc7b69affab780061055e0c5bf7f9f180983a708d381497a9  # [osx and arm64]
-    fn: zsasa  # [osx and arm64]
+  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-x86_64  # [linux and x86_64]
+  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-aarch64  # [linux and aarch64]
+  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-x86_64  # [osx and x86_64]
+  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-aarch64  # [osx and arm64]
+  sha256: 250c660de9d0de3f2ccb9e30c6aa8244ff5bb1ea92ac814549f27de1a71a3306  # [linux and x86_64]
+  sha256: 82e99edaef90906fc414de35aee1529649efce50fe82f06510a46c490946ff3e  # [linux and aarch64]
+  sha256: 97fdae690982d32bf5b6e7d78300480629a8d173acf55c9c0f849d038eeb44e9  # [osx and x86_64]
+  sha256: d25ff0904ef1300bc7b69affab780061055e0c5bf7f9f180983a708d381497a9  # [osx and arm64]
+  fn: zsasa
 
 build:
   number: 0
   skip: true  # [win]
+  binary_relocation: false
+  detect_binary_files_with_prefix: false
   script: |
+    mkdir -p ${PREFIX}/bin
     install -m 755 zsasa ${PREFIX}/bin/zsasa
 
 test:


### PR DESCRIPTION
## Summary
- Sync local `packaging/conda-forge/meta.yaml` with fixes applied to conda-forge/staged-recipes PR #32551
- Dict-style source with platform selectors (list-style didn't work)
- `mkdir -p ${PREFIX}/bin` for directory creation
- `binary_relocation: false` + `detect_binary_files_with_prefix: false` for statically-linked Zig binary

## Test plan
- [x] conda-forge staged-recipes CI passing with these changes