### PR TITLE
feat: add CCD-based classifier for universal atom radius assignment

### DIFF
--- a/docs/superpowers/specs/2026-04-12-ccd-classifier-design.md
+++ b/docs/superpowers/specs/2026-04-12-ccd-classifier-design.md
@@ -1,0 +1,262 @@
+# CCD Classifier Design Spec
+
+## Summary
+
+Introduce a new classifier (`ClassifierType.ccd`) for freesasa-zig that derives van der Waals radii from CCD (Chemical Component Dictionary) bond topology. By analyzing `_chem_comp_atom` and `_chem_comp_bond` data, the classifier determines each atom's hybridization and implicit hydrogen count, then maps these to ProtOr-compatible radii. This enables accurate radius assignment for any chemical component, not just standard amino acids.
+
+## Motivation
+
+Current classifiers (NACCESS, ProtOr, OONS) use hardcoded `(residue, atom_name) -> radius` lookup tables limited to standard amino acids and nucleic acids. Non-standard residues (modified AAs, ligands, cofactors) fall back to element-based VdW radii, losing hybridization-aware accuracy.
+
+PDB's official mmCIF files now include inline `_chem_comp_bond`/`_chem_comp_atom` categories, making bond topology available without external CCD files.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Radius granularity | Level 3: element + hybridization + H count | ProtOr/ChimeraX-compatible; CCD provides the data to derive this |
+| CCD data supply | Hybrid: hardcoded + inline CCD + external CCD | Fast path for common residues; full coverage with CCD |
+| Lookup priority | Hardcoded > inline CCD > external CCD > element fallback | Optimizes for the common case (stdAA-only structures) |
+| New struct vs existing | New `CcdClassifier` struct (separate from `Classifier`) | Avoids forcing CCD semantics into flat HashMap; future flexibility |
+| Integration method | `calc.zig` branches on `ClassifierType` | Simple; avoids premature abstraction of a shared interface |
+| AtomClass assignment | Element-based: N,O=polar; C,S,P,Se=apolar | Sufficient for SASA; IDATM-level classification is overkill |
+| Ionic radii | Out of scope | Requires coordination number from `_struct_conn`; defer |
+
+## Architecture
+
+### Data Flow
+
+```
+mmCIF file
+  |
+  +--> _atom_site (coordinates, residue names, atom names)
+  |
+  +--> _chem_comp_atom / _chem_comp_bond (inline CCD, if present)
+         |
+         v
+CcdClassifier.getRadius(residue, atom_name)
+  |
+  1. Hardcoded table lookup (StaticStringMap, O(1))
+  |    hit? -> return radius
+  |
+  2. Runtime component lookup (HashMap)
+  |    - Populated from inline CCD or external CCD
+  |    - Derive: bond orders -> hybridization -> implicit H count -> ProtOr radius
+  |    hit? -> return radius
+  |
+  3. Element fallback (existing classifier.guessRadiusFromAtomName)
+       -> return VdW radius
+```
+
+### Data Structures
+
+#### CCD Component Representation
+
+```zig
+const CompAtom = struct {
+    atom_id: FixedString4,
+    type_symbol: FixedString4,
+    aromatic: bool,
+    leaving: bool,
+};
+
+const CompBond = struct {
+    atom_idx_1: u16,
+    atom_idx_2: u16,
+    order: BondOrder,
+    aromatic: bool,
+};
+
+const BondOrder = enum { single, double, triple, aromatic, delocalized, unknown };
+
+const Component = struct {
+    comp_id: FixedString5,
+    atoms: []const CompAtom,
+    bonds: []const CompBond,
+};
+```
+
+#### Hybridization Derivation
+
+```zig
+const Hybridization = enum { sp3, sp2, sp, unknown };
+
+const AtomTypeInfo = struct {
+    hybridization: Hybridization,
+    heavy_bond_count: u8,
+    implicit_h_count: u8,
+};
+```
+
+#### CcdClassifier
+
+```zig
+const CcdClassifier = struct {
+    hardcoded: StaticStringMap(AtomProperties),
+    runtime_components: HashMap(FixedString5, RuntimeComponent),
+    allocator: Allocator,
+
+    pub fn getRadius(self: *const CcdClassifier, residue: []const u8, atom: []const u8) ?f64;
+    pub fn getClass(self: *const CcdClassifier, residue: []const u8, atom: []const u8) AtomClass;
+    pub fn getProperties(self: *const CcdClassifier, residue: []const u8, atom: []const u8) ?AtomProperties;
+    pub fn addComponent(self: *CcdClassifier, component: Component) !void;
+    pub fn deinit(self: *CcdClassifier) void;
+};
+```
+
+### Hybridization Derivation Pipeline
+
+**Step 1: Bond order -> Hybridization** (reference: zreduce `ccd_derive.zig`)
+
+```
+For each atom in component:
+  - Collect all bonds involving this atom
+  - If any triple bond -> sp
+  - If any double or aromatic bond -> sp2
+  - Otherwise -> sp3
+```
+
+**Step 2: Implicit hydrogen count**
+
+```
+implicit_h = typical_valence(element) - heavy_bond_count
+
+typical_valence: C=4, N=3, O=2, S=2, P=5
+```
+
+When CCD includes explicit hydrogen atoms in `_chem_comp_atom`, count H bonds directly instead.
+
+**Step 3: ProtOr radius table lookup**
+
+| Element | Hybridization | H count | Radius |
+|---|---|---|---|
+| C | sp2 | 0 | 1.61 |
+| C | sp2 | 1 | 1.76 |
+| C | sp3 | 0 | 1.61 (same as sp2/H0; quaternary C not in original ProtOr, inferred) |
+| C | sp3 | 1-3 | 1.88 |
+| N | any | any | 1.64 |
+| O | sp2 | 0 | 1.42 |
+| O | sp3 | 0 | 1.46 |
+| O | sp3 | 1 | 1.46 |
+| S | any | any | 1.77 |
+| P | any | any | 1.80 |
+| Se | any | any | 1.90 |
+
+**Step 4: AtomClass**
+
+- N, O -> `.polar`
+- C, S, P, Se, others -> `.apolar`
+
+### Hardcoded Components
+
+The following comp_ids are pre-computed at compile time:
+
+**Standard amino acids (20):** ALA, ARG, ASN, ASP, CYS, GLN, GLU, GLY, HIS, ILE, LEU, LYS, MET, PHE, PRO, SER, THR, TRP, TYR, VAL
+
+**Nucleic acids:** A, C, G, T, U, DA, DC, DG, DT, I, DI
+
+**Modified residues:** MSE, SEC, PYL, HYP, MLY, SEP, TPO, ASX, GLX, PSU
+
+**Caps/other:** ACE, NH2, HOH
+
+Format: `StaticStringMap` keyed by `AtomKey(comp_id, atom_id)` -> `AtomProperties(radius, class)`.
+
+### CCD Parsing
+
+#### Inline CCD (mmCIF)
+
+Extend `mmcif_parser.zig` to detect and parse `_chem_comp_atom`/`_chem_comp_bond` loops using the existing `cif_tokenizer.zig`. Only parse components whose comp_id is not in the hardcoded table.
+
+#### External CCD
+
+New `ccd_parser.zig` implementing a streaming parser (reference: zmmol `component_dict.zig`). Reads `_chem_comp_atom`/`_chem_comp_bond` loops from a multi-block CIF file without building a full document tree. Supports gzip-compressed input.
+
+Future: zreduce-style binary CCD format for faster loading.
+
+### Integration Points
+
+#### classifier.zig
+
+Add `.ccd` to `ClassifierType` enum.
+
+#### calc.zig
+
+Branch on classifier type:
+
+```zig
+if (classifier_type == .ccd) {
+    var ccd_clf = CcdClassifier.init(allocator);
+    defer ccd_clf.deinit();
+
+    // Add inline CCD components (from mmCIF parse result)
+    for (inline_components) |comp| {
+        if (!ccd_clf.isHardcoded(comp.comp_id))
+            try ccd_clf.addComponent(comp);
+    }
+
+    // Add external CCD components (if --ccd option)
+    if (ccd_path) |path| {
+        try ccd_clf.loadExternalCcd(path);
+    }
+
+    // Assign radii
+    for (atoms, 0..) |atom, i| {
+        radii[i] = ccd_clf.getRadius(atom.residue, atom.name)
+            orelse classifier.guessRadiusFromAtomName(atom.name)
+            orelse radii[i]; // keep element-based VdW
+    }
+} else {
+    // existing classifier path
+}
+```
+
+#### c_api.zig
+
+Add `ZSASA_CLASSIFIER_CCD = 3`.
+
+#### root.zig
+
+Export `ccd_classifier`, `ccd_parser`, `hybridization` modules.
+
+## File Plan
+
+### New Files
+
+| File | Purpose |
+|---|---|
+| `src/classifier_ccd.zig` | CcdClassifier struct, hardcoded table, public API |
+| `src/ccd_parser.zig` | Streaming CCD `_chem_comp_atom`/`_chem_comp_bond` parser |
+| `src/hybridization.zig` | Bond order -> hybridization -> H count -> radius derivation |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `src/classifier.zig` | Add `.ccd` to `ClassifierType` |
+| `src/mmcif_parser.zig` | Parse inline `_chem_comp_atom`/`_chem_comp_bond` |
+| `src/calc.zig` | Add `.ccd` branch |
+| `src/c_api.zig` | Add `ZSASA_CLASSIFIER_CCD` constant |
+| `src/root.zig` | Export new modules |
+
+## Test Strategy
+
+1. **Hybridization unit tests** - Verify derivation from known CCD data (ALA, HEM, ATP) produces correct hybridization and H counts
+2. **ProtOr compatibility tests** - For all stdAA atoms, CcdClassifier and ProtOr return identical radii (or document intentional differences)
+3. **Inline CCD parse tests** - Parse `_chem_comp_bond` from real mmCIF files and verify correct Component construction
+4. **E2E tests** - Compare `zsasa calc -c ccd` output with existing classifiers on test structures (1ubq.cif, 1crn.pdb)
+
+## Out of Scope
+
+- Ionic radii based on coordination number (requires `_struct_conn` parsing)
+- Shared interface between `Classifier` and `CcdClassifier`
+- External CCD binary format support
+- Python bindings for `CcdClassifier`
+- PDB format support for CCD (PDB files lack inline CCD data)
+
+## References
+
+- Tsai, J., Taylor, R., Chothia, C., & Gerstein, M. (1999). The packing density in proteins: standard radii and volumes. J Mol Biol, 290(1), 253-266. (ProtOr radii)
+- ChimeraX radii: https://www.rbvi.ucsf.edu/chimerax/docs/user/radii.html
+- zreduce `ccd_derive.zig`: hybridization derivation from CCD bond orders
+- zmmol `component_dict.zig`: streaming CCD parser
+- ChimeraX `stdresidues.cif`: template components for standard residues

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -13,6 +13,7 @@ const classifier = @import("classifier.zig");
 const classifier_protor = @import("classifier_protor.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_oons = @import("classifier_oons.zig");
+const classifier_ccd = @import("classifier_ccd.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -332,6 +333,10 @@ fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType) !void {
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
+    // For CCD: create classifier instance (hardcoded table is compile-time, no setup cost)
+    var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd) classifier_ccd.CcdClassifier.init(input.allocator) else null;
+    defer if (ccd_clf) |*c| c.deinit();
+
     const new_radii = try input.allocator.alloc(f64, n);
     errdefer input.allocator.free(new_radii);
 
@@ -340,6 +345,7 @@ fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType) !void {
             .naccess => classifier_naccess.getRadius(residues[i].slice(), atom_names[i].slice()),
             .protor => classifier_protor.getRadius(residues[i].slice(), atom_names[i].slice()),
             .oons => classifier_oons.getRadius(residues[i].slice(), atom_names[i].slice()),
+            .ccd => if (ccd_clf) |*c| c.getRadius(residues[i].slice(), atom_names[i].slice()) else null,
         };
 
         if (maybe_radius) |r| {
@@ -1087,7 +1093,7 @@ fn parseClassifierType(value: []const u8) ClassifierType {
         return ct;
     } else {
         std.debug.print("Error: Invalid classifier: {s}\n", .{value});
-        std.debug.print("Valid classifiers: naccess, protor, oons\n", .{});
+        std.debug.print("Valid classifiers: naccess, protor, oons, ccd\n", .{});
         std.process.exit(1);
     }
 }
@@ -1300,7 +1306,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\OPTIONS:
         \\    --algorithm=ALGO    Algorithm: sr (shrake-rupley), lr (lee-richards)
         \\                        Default: sr
-        \\    --classifier=TYPE   Built-in classifier: naccess, protor, oons
+        \\    --classifier=TYPE   Built-in classifier: naccess, protor, oons, ccd
         \\                        Default: protor
         \\    --threads=N         Number of threads (default: auto-detect)
         \\    --probe-radius=R    Probe radius in Angstroms (default: 1.4)

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -1191,8 +1191,8 @@ fn getRadiusByClassifier(classifier_type: c_int, residue: []const u8, atom: []co
         ZSASA_CLASSIFIER_PROTOR => classifier_protor.getRadius(residue, atom),
         ZSASA_CLASSIFIER_OONS => classifier_oons.getRadius(residue, atom),
         ZSASA_CLASSIFIER_CCD => blk: {
-            // Stack-local instance; hardcoded lookup needs no allocator
-            const ccd = classifier_ccd.CcdClassifier.init(std.heap.page_allocator);
+            var ccd = classifier_ccd.CcdClassifier.init(std.heap.page_allocator);
+            defer ccd.deinit();
             break :blk ccd.getRadius(residue, atom);
         },
         else => null,
@@ -1206,7 +1206,8 @@ fn getClassByClassifier(classifier_type: c_int, residue: []const u8, atom: []con
         ZSASA_CLASSIFIER_PROTOR => classifier_protor.getClass(residue, atom),
         ZSASA_CLASSIFIER_OONS => classifier_oons.getClass(residue, atom),
         ZSASA_CLASSIFIER_CCD => blk: {
-            const ccd = classifier_ccd.CcdClassifier.init(std.heap.page_allocator);
+            var ccd = classifier_ccd.CcdClassifier.init(std.heap.page_allocator);
+            defer ccd.deinit();
             break :blk ccd.getClass(residue, atom);
         },
         else => .unknown,

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -13,6 +13,7 @@ const classifier = @import("classifier.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_protor = @import("classifier_protor.zig");
 const classifier_oons = @import("classifier_oons.zig");
+const classifier_ccd = @import("classifier_ccd.zig");
 const analysis = @import("analysis.zig");
 const xtc = @import("zxdrfile").xtc;
 const dcd = @import("dcd.zig");
@@ -54,6 +55,8 @@ pub const ZSASA_CLASSIFIER_NACCESS: c_int = 0;
 pub const ZSASA_CLASSIFIER_PROTOR: c_int = 1;
 /// OONS radii (older FreeSASA default)
 pub const ZSASA_CLASSIFIER_OONS: c_int = 2;
+/// CCD-based radii derived from bond topology
+pub const ZSASA_CLASSIFIER_CCD: c_int = 3;
 
 // =============================================================================
 // Atom Classes
@@ -1187,6 +1190,11 @@ fn getRadiusByClassifier(classifier_type: c_int, residue: []const u8, atom: []co
         ZSASA_CLASSIFIER_NACCESS => classifier_naccess.getRadius(residue, atom),
         ZSASA_CLASSIFIER_PROTOR => classifier_protor.getRadius(residue, atom),
         ZSASA_CLASSIFIER_OONS => classifier_oons.getRadius(residue, atom),
+        ZSASA_CLASSIFIER_CCD => blk: {
+            // Stack-local instance; hardcoded lookup needs no allocator
+            const ccd = classifier_ccd.CcdClassifier.init(std.heap.page_allocator);
+            break :blk ccd.getRadius(residue, atom);
+        },
         else => null,
     };
 }
@@ -1197,6 +1205,10 @@ fn getClassByClassifier(classifier_type: c_int, residue: []const u8, atom: []con
         ZSASA_CLASSIFIER_NACCESS => classifier_naccess.getClass(residue, atom),
         ZSASA_CLASSIFIER_PROTOR => classifier_protor.getClass(residue, atom),
         ZSASA_CLASSIFIER_OONS => classifier_oons.getClass(residue, atom),
+        ZSASA_CLASSIFIER_CCD => blk: {
+            const ccd = classifier_ccd.CcdClassifier.init(std.heap.page_allocator);
+            break :blk ccd.getClass(residue, atom);
+        },
         else => .unknown,
     };
 }
@@ -1317,7 +1329,7 @@ export fn zsasa_classify_atoms(
     }
 
     // Validate classifier type
-    if (classifier_type < ZSASA_CLASSIFIER_NACCESS or classifier_type > ZSASA_CLASSIFIER_OONS) {
+    if (classifier_type < ZSASA_CLASSIFIER_NACCESS or classifier_type > ZSASA_CLASSIFIER_CCD) {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -2411,6 +2423,7 @@ export fn zsasa_batch_dir_process(
         ZSASA_CLASSIFIER_NACCESS => .naccess,
         ZSASA_CLASSIFIER_PROTOR => .protor,
         ZSASA_CLASSIFIER_OONS => .oons,
+        ZSASA_CLASSIFIER_CCD => .ccd,
         -1 => null,
         else => {
             setError(error_code, ZSASA_ERROR_INVALID_INPUT);

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -18,6 +18,7 @@ const classifier_parser = @import("classifier_parser.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_protor = @import("classifier_protor.zig");
 const classifier_oons = @import("classifier_oons.zig");
+const classifier_ccd = @import("classifier_ccd.zig");
 
 const Config = types.Config;
 const Configf32 = types.Configf32;
@@ -45,7 +46,7 @@ pub const CalcArgs = struct {
     algorithm: Algorithm = .sr, // Default: Shrake-Rupley
     precision: Precision = .f64, // f32 or f64 (default: f64)
     output_format: OutputFormat = .json,
-    classifier_type: ?ClassifierType = null, // Built-in classifier (naccess/protor/oons)
+    classifier_type: ?ClassifierType = null, // Built-in classifier (naccess/protor/oons/ccd)
     config_path: ?[]const u8 = null, // Custom config file path
     chain_filter: ?[]const u8 = null, // Chain filter (e.g., "A" or "A,B,C")
     model_num: ?u32 = null, // Model number for NMR structures
@@ -139,7 +140,7 @@ fn parseClassifierType(value: []const u8) ClassifierType {
         return ct;
     } else {
         std.debug.print("Error: Invalid classifier: {s}\n", .{value});
-        std.debug.print("Valid classifiers: naccess, protor, oons\n", .{});
+        std.debug.print("Valid classifiers: naccess, protor, oons, ccd\n", .{});
         std.process.exit(1);
     }
 }
@@ -443,7 +444,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\OPTIONS:
         \\    --algorithm=ALGO   Algorithm: sr (shrake-rupley), lr (lee-richards)
         \\                       Default: sr
-        \\    --classifier=TYPE  Built-in classifier: naccess, protor, oons
+        \\    --classifier=TYPE  Built-in classifier: naccess, protor, oons, ccd
         \\                       Default: protor for PDB/mmCIF, none for JSON
         \\    --config=FILE      Custom classifier config file (FreeSASA format)
         \\    --chain=ID         Filter by chain ID (e.g., --chain=A or --chain=A,B,C)
@@ -608,6 +609,10 @@ fn applyBuiltinClassifier(
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
+    // For CCD: create classifier instance (hardcoded table is compile-time, no setup cost)
+    var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd) classifier_ccd.CcdClassifier.init(input.allocator) else null;
+    defer if (ccd_clf) |*c| c.deinit();
+
     // Allocate new radii array (use input.allocator for consistency with deinit)
     const new_radii = try input.allocator.alloc(f64, n);
     errdefer input.allocator.free(new_radii);
@@ -621,6 +626,7 @@ fn applyBuiltinClassifier(
             .naccess => classifier_naccess.getRadius(residues[i].slice(), atom_names[i].slice()),
             .protor => classifier_protor.getRadius(residues[i].slice(), atom_names[i].slice()),
             .oons => classifier_oons.getRadius(residues[i].slice(), atom_names[i].slice()),
+            .ccd => if (ccd_clf) |*c| c.getRadius(residues[i].slice(), atom_names[i].slice()) else null,
         };
 
         if (maybe_radius) |r| {
@@ -815,6 +821,9 @@ pub fn run(allocator: std.mem.Allocator, args: CalcArgs) !void {
             };
         } else if (effective_classifier) |ct| {
             // Use built-in classifier
+            // TODO: For CCD classifier with mmCIF input, parse inline CCD components
+            // and feed them to CcdClassifier.addComponent() to handle non-standard residues.
+            // The hardcoded table already covers all 20 standard amino acids.
             applyBuiltinClassifier(&input, ct, args.quiet) catch |err| {
                 std.debug.print("Error applying classifier: {s}\n", .{@errorName(err)});
                 std.process.exit(1);

--- a/src/ccd_parser.zig
+++ b/src/ccd_parser.zig
@@ -1,0 +1,867 @@
+//! CCD (Chemical Component Dictionary) streaming parser.
+//!
+//! Parses `_chem_comp_atom` and `_chem_comp_bond` loops from CIF data
+//! using the existing `cif_tokenizer.zig`. Returns a `ComponentDict` keyed
+//! by comp_id, where each entry owns its atom and bond arrays.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const cif = @import("cif_tokenizer.zig");
+const Token = cif.Token;
+const Tokenizer = cif.Tokenizer;
+const hyb = @import("hybridization.zig");
+const CompAtom = hyb.CompAtom;
+const CompBond = hyb.CompBond;
+const Component = hyb.Component;
+const BondOrder = hyb.BondOrder;
+
+// =============================================================================
+// StoredComponent — owns allocated atom/bond arrays
+// =============================================================================
+
+/// A component that owns its atom and bond data (heap-allocated).
+pub const StoredComponent = struct {
+    comp_id: [5]u8,
+    comp_id_len: u3,
+    atoms: []CompAtom,
+    bonds: []CompBond,
+    allocator: Allocator,
+
+    pub fn deinit(self: *StoredComponent) void {
+        self.allocator.free(self.atoms);
+        self.allocator.free(self.bonds);
+    }
+
+    /// Return a non-owning `Component` view.
+    pub fn view(self: *const StoredComponent) Component {
+        return .{
+            .comp_id = self.comp_id,
+            .comp_id_len = self.comp_id_len,
+            .atoms = self.atoms,
+            .bonds = self.bonds,
+        };
+    }
+};
+
+// =============================================================================
+// ComponentDict — stores parsed components keyed by comp_id
+// =============================================================================
+
+/// Dictionary of parsed CCD components.
+pub const ComponentDict = struct {
+    components: std.StringHashMap(StoredComponent),
+    allocator: Allocator,
+    /// Keys that we allocated and must free.
+    owned_keys: std.ArrayListUnmanaged([]const u8),
+
+    pub fn init(allocator: Allocator) ComponentDict {
+        return .{
+            .components = std.StringHashMap(StoredComponent).init(allocator),
+            .allocator = allocator,
+            .owned_keys = .{},
+        };
+    }
+
+    pub fn deinit(self: *ComponentDict) void {
+        var it = self.components.iterator();
+        while (it.next()) |entry| {
+            var stored = entry.value_ptr;
+            stored.deinit();
+        }
+        // Free all owned keys
+        for (self.owned_keys.items) |key| {
+            self.allocator.free(key);
+        }
+        self.owned_keys.deinit(self.allocator);
+        self.components.deinit();
+    }
+
+    /// Look up a component by comp_id string, returning a non-owning view.
+    pub fn get(self: *const ComponentDict, comp_id: []const u8) ?Component {
+        const stored = self.components.get(comp_id) orelse return null;
+        return stored.view();
+    }
+
+    /// Number of components stored.
+    pub fn count(self: *const ComponentDict) usize {
+        return self.components.count();
+    }
+};
+
+// =============================================================================
+// Column index helpers
+// =============================================================================
+
+/// Indices of relevant columns within a `_chem_comp_atom` loop.
+const AtomColumns = struct {
+    comp_id: ?usize = null,
+    atom_id: ?usize = null,
+    type_symbol: ?usize = null,
+    pdbx_aromatic_flag: ?usize = null,
+    pdbx_leaving_atom_flag: ?usize = null,
+    total: usize = 0,
+
+    fn isValid(self: *const AtomColumns) bool {
+        return self.comp_id != null and self.atom_id != null and self.type_symbol != null;
+    }
+};
+
+/// Indices of relevant columns within a `_chem_comp_bond` loop.
+const BondColumns = struct {
+    comp_id: ?usize = null,
+    atom_id_1: ?usize = null,
+    atom_id_2: ?usize = null,
+    value_order: ?usize = null,
+    pdbx_aromatic_flag: ?usize = null,
+    total: usize = 0,
+
+    fn isValid(self: *const BondColumns) bool {
+        return self.comp_id != null and self.atom_id_1 != null and self.atom_id_2 != null;
+    }
+};
+
+// =============================================================================
+// Temp builders
+// =============================================================================
+
+/// Temporary per-component data accumulated during parsing.
+const ComponentBuilder = struct {
+    atoms: std.ArrayListUnmanaged(CompAtom),
+    bonds: std.ArrayListUnmanaged(CompBond),
+    /// Map from atom_id (fixed-size key) -> index in atoms list.
+    atom_name_map: std.StringHashMap(u16),
+
+    fn init(allocator: Allocator) ComponentBuilder {
+        return .{
+            .atoms = .{},
+            .bonds = .{},
+            .atom_name_map = std.StringHashMap(u16).init(allocator),
+        };
+    }
+
+    fn deinit(self: *ComponentBuilder, allocator: Allocator) void {
+        self.atoms.deinit(allocator);
+        self.bonds.deinit(allocator);
+        // Free owned keys in atom_name_map
+        var it = self.atom_name_map.iterator();
+        while (it.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+        }
+        self.atom_name_map.deinit();
+    }
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Parse CCD data from a CIF source string.
+///
+/// If `filter` is non-null, only components whose comp_id appears in the
+/// filter list are included in the result. All others are skipped.
+///
+/// The returned `ComponentDict` owns all allocated data; call `.deinit()`
+/// when done.
+pub fn parseCcdData(
+    allocator: Allocator,
+    source: []const u8,
+    filter: ?[]const []const u8,
+) !ComponentDict {
+    var dict = ComponentDict.init(allocator);
+    errdefer dict.deinit();
+
+    // Temporary builders keyed by comp_id (duped key).
+    var builders = std.StringHashMap(ComponentBuilder).init(allocator);
+    defer {
+        var bit = builders.iterator();
+        while (bit.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(allocator);
+        }
+        builders.deinit();
+    }
+
+    var tokenizer = Tokenizer.init(source);
+
+    while (true) {
+        const tok = tokenizer.next();
+        switch (tok) {
+            .eof => break,
+            .loop => {
+                // Peek at the first tag to determine which loop this is.
+                const first_tag_tok = tokenizer.next();
+                switch (first_tag_tok) {
+                    .tag => |tag_str| {
+                        if (isAtomTag(tag_str)) {
+                            try parseAtomLoop(allocator, &tokenizer, first_tag_tok, &builders, filter);
+                        } else if (isBondTag(tag_str)) {
+                            try parseBondLoop(allocator, &tokenizer, first_tag_tok, &builders, filter);
+                        }
+                        // else: unrelated loop, skip tokens until next structural token
+                        // (the parse*Loop functions consume the loop; for unrelated loops
+                        // we just let the outer loop continue — the tokenizer will
+                        // naturally skip values until the next data_block/loop/eof).
+                    },
+                    .eof => break,
+                    else => {},
+                }
+            },
+            else => {},
+        }
+    }
+
+    // Convert builders into StoredComponents and insert into dict.
+    var bit = builders.iterator();
+    while (bit.next()) |entry| {
+        const comp_id_str = entry.key_ptr.*;
+        const builder = entry.value_ptr;
+
+        var stored = StoredComponent{
+            .comp_id = .{ 0, 0, 0, 0, 0 },
+            .comp_id_len = 0,
+            .atoms = try builder.atoms.toOwnedSlice(allocator),
+            .bonds = try builder.bonds.toOwnedSlice(allocator),
+            .allocator = allocator,
+        };
+
+        const cid_len: usize = @min(comp_id_str.len, 5);
+        stored.comp_id_len = @intCast(cid_len);
+        for (comp_id_str[0..cid_len], 0..) |c, i| {
+            stored.comp_id[i] = c;
+        }
+
+        // Dupe the key for the dict
+        const dict_key = try allocator.dupe(u8, comp_id_str);
+        dict.owned_keys.append(allocator, dict_key) catch |e| {
+            allocator.free(dict_key);
+            return e;
+        };
+        try dict.components.put(dict_key, stored);
+    }
+
+    return dict;
+}
+
+// =============================================================================
+// Tag classification
+// =============================================================================
+
+fn isAtomTag(tag: []const u8) bool {
+    return std.mem.startsWith(u8, tag, "_chem_comp_atom.");
+}
+
+fn isBondTag(tag: []const u8) bool {
+    return std.mem.startsWith(u8, tag, "_chem_comp_bond.");
+}
+
+// =============================================================================
+// Atom loop parsing
+// =============================================================================
+
+fn parseAtomLoop(
+    allocator: Allocator,
+    tokenizer: *Tokenizer,
+    first_tag: Token,
+    builders: *std.StringHashMap(ComponentBuilder),
+    filter: ?[]const []const u8,
+) !void {
+    var cols = AtomColumns{};
+
+    // Process the first tag we already consumed.
+    classifyAtomTag(first_tag.tag, 0, &cols);
+    cols.total = 1;
+
+    // Read remaining tags.
+    while (true) {
+        // Save position in case we need to "unread" the token.
+        const saved_pos = tokenizer.pos;
+        const saved_line = tokenizer.line;
+        const saved_col = tokenizer.col;
+
+        const tok = tokenizer.next();
+        switch (tok) {
+            .tag => |tag_str| {
+                classifyAtomTag(tag_str, cols.total, &cols);
+                cols.total += 1;
+            },
+            else => {
+                // Not a tag — this is the first value. Restore position
+                // so the value-reading loop picks it up.
+                tokenizer.pos = saved_pos;
+                tokenizer.line = saved_line;
+                tokenizer.col = saved_col;
+                break;
+            },
+        }
+    }
+
+    if (!cols.isValid()) return;
+
+    // Read row values.
+    var col_idx: usize = 0;
+    var row_comp_id: ?[]const u8 = null;
+    var row_atom_id: ?[]const u8 = null;
+    var row_type_symbol: ?[]const u8 = null;
+    var row_aromatic: bool = false;
+    var row_leaving: bool = false;
+
+    while (true) {
+        const saved_pos = tokenizer.pos;
+        const saved_line = tokenizer.line;
+        const saved_col = tokenizer.col;
+
+        const tok = tokenizer.next();
+        switch (tok) {
+            .value => |val| {
+                if (col_idx == cols.comp_id.?) {
+                    row_comp_id = val;
+                } else if (col_idx == cols.atom_id.?) {
+                    row_atom_id = val;
+                } else if (col_idx == cols.type_symbol.?) {
+                    row_type_symbol = val;
+                } else if (cols.pdbx_aromatic_flag != null and col_idx == cols.pdbx_aromatic_flag.?) {
+                    row_aromatic = (val.len == 1 and (val[0] == 'Y' or val[0] == 'y'));
+                } else if (cols.pdbx_leaving_atom_flag != null and col_idx == cols.pdbx_leaving_atom_flag.?) {
+                    row_leaving = (val.len == 1 and (val[0] == 'Y' or val[0] == 'y'));
+                }
+
+                col_idx += 1;
+                if (col_idx >= cols.total) {
+                    // End of row — emit atom.
+                    if (row_comp_id) |cid| {
+                        if (row_atom_id) |aid| {
+                            if (row_type_symbol) |ts| {
+                                if (!isFiltered(cid, filter)) {
+                                    const builder = try getOrCreateBuilder(allocator, builders, cid);
+                                    var atom = CompAtom.init(aid, ts);
+                                    atom.aromatic = row_aromatic;
+                                    atom.leaving = row_leaving;
+
+                                    const atom_idx: u16 = @intCast(builder.atoms.items.len);
+                                    try builder.atoms.append(allocator, atom);
+
+                                    // Store atom name -> index mapping for bond resolution.
+                                    const name_key = try allocator.dupe(u8, aid);
+                                    builder.atom_name_map.put(name_key, atom_idx) catch |e| {
+                                        allocator.free(name_key);
+                                        return e;
+                                    };
+                                }
+                            }
+                        }
+                    }
+
+                    // Reset for next row.
+                    col_idx = 0;
+                    row_comp_id = null;
+                    row_atom_id = null;
+                    row_type_symbol = null;
+                    row_aromatic = false;
+                    row_leaving = false;
+                }
+            },
+            .loop, .data_block => {
+                // New structural token — put it back and return.
+                tokenizer.pos = saved_pos;
+                tokenizer.line = saved_line;
+                tokenizer.col = saved_col;
+                return;
+            },
+            .tag => {
+                // A tag outside a loop signals a key-value pair at block level.
+                tokenizer.pos = saved_pos;
+                tokenizer.line = saved_line;
+                tokenizer.col = saved_col;
+                return;
+            },
+            .eof => return,
+            else => {},
+        }
+    }
+}
+
+fn classifyAtomTag(tag: []const u8, idx: usize, cols: *AtomColumns) void {
+    const prefix = "_chem_comp_atom.";
+    if (tag.len <= prefix.len) return;
+    const field = tag[prefix.len..];
+
+    if (std.mem.eql(u8, field, "comp_id")) {
+        cols.comp_id = idx;
+    } else if (std.mem.eql(u8, field, "atom_id")) {
+        cols.atom_id = idx;
+    } else if (std.mem.eql(u8, field, "type_symbol")) {
+        cols.type_symbol = idx;
+    } else if (std.mem.eql(u8, field, "pdbx_aromatic_flag")) {
+        cols.pdbx_aromatic_flag = idx;
+    } else if (std.mem.eql(u8, field, "pdbx_leaving_atom_flag")) {
+        cols.pdbx_leaving_atom_flag = idx;
+    }
+}
+
+// =============================================================================
+// Bond loop parsing
+// =============================================================================
+
+fn parseBondLoop(
+    allocator: Allocator,
+    tokenizer: *Tokenizer,
+    first_tag: Token,
+    builders: *std.StringHashMap(ComponentBuilder),
+    filter: ?[]const []const u8,
+) !void {
+    var cols = BondColumns{};
+
+    classifyBondTag(first_tag.tag, 0, &cols);
+    cols.total = 1;
+
+    // Read remaining tags.
+    while (true) {
+        const saved_pos = tokenizer.pos;
+        const saved_line = tokenizer.line;
+        const saved_col = tokenizer.col;
+
+        const tok = tokenizer.next();
+        switch (tok) {
+            .tag => |tag_str| {
+                classifyBondTag(tag_str, cols.total, &cols);
+                cols.total += 1;
+            },
+            else => {
+                tokenizer.pos = saved_pos;
+                tokenizer.line = saved_line;
+                tokenizer.col = saved_col;
+                break;
+            },
+        }
+    }
+
+    if (!cols.isValid()) return;
+
+    // Read row values.
+    var col_idx: usize = 0;
+    var row_comp_id: ?[]const u8 = null;
+    var row_atom_id_1: ?[]const u8 = null;
+    var row_atom_id_2: ?[]const u8 = null;
+    var row_value_order: ?[]const u8 = null;
+    var row_aromatic: bool = false;
+
+    while (true) {
+        const saved_pos = tokenizer.pos;
+        const saved_line = tokenizer.line;
+        const saved_col = tokenizer.col;
+
+        const tok = tokenizer.next();
+        switch (tok) {
+            .value => |val| {
+                if (col_idx == cols.comp_id.?) {
+                    row_comp_id = val;
+                } else if (col_idx == cols.atom_id_1.?) {
+                    row_atom_id_1 = val;
+                } else if (col_idx == cols.atom_id_2.?) {
+                    row_atom_id_2 = val;
+                } else if (cols.value_order != null and col_idx == cols.value_order.?) {
+                    row_value_order = val;
+                } else if (cols.pdbx_aromatic_flag != null and col_idx == cols.pdbx_aromatic_flag.?) {
+                    row_aromatic = (val.len == 1 and (val[0] == 'Y' or val[0] == 'y'));
+                }
+
+                col_idx += 1;
+                if (col_idx >= cols.total) {
+                    // End of row — emit bond.
+                    if (row_comp_id) |cid| {
+                        if (row_atom_id_1) |aid1| {
+                            if (row_atom_id_2) |aid2| {
+                                if (!isFiltered(cid, filter)) {
+                                    const builder = try getOrCreateBuilder(allocator, builders, cid);
+
+                                    // Resolve atom names to indices.
+                                    const idx1 = builder.atom_name_map.get(aid1);
+                                    const idx2 = builder.atom_name_map.get(aid2);
+
+                                    if (idx1 != null and idx2 != null) {
+                                        const order = if (row_value_order) |vo|
+                                            BondOrder.fromString(vo)
+                                        else
+                                            BondOrder.unknown;
+
+                                        try builder.bonds.append(allocator, .{
+                                            .atom_idx_1 = idx1.?,
+                                            .atom_idx_2 = idx2.?,
+                                            .order = order,
+                                            .aromatic = row_aromatic,
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Reset for next row.
+                    col_idx = 0;
+                    row_comp_id = null;
+                    row_atom_id_1 = null;
+                    row_atom_id_2 = null;
+                    row_value_order = null;
+                    row_aromatic = false;
+                }
+            },
+            .loop, .data_block => {
+                tokenizer.pos = saved_pos;
+                tokenizer.line = saved_line;
+                tokenizer.col = saved_col;
+                return;
+            },
+            .tag => {
+                tokenizer.pos = saved_pos;
+                tokenizer.line = saved_line;
+                tokenizer.col = saved_col;
+                return;
+            },
+            .eof => return,
+            else => {},
+        }
+    }
+}
+
+fn classifyBondTag(tag: []const u8, idx: usize, cols: *BondColumns) void {
+    const prefix = "_chem_comp_bond.";
+    if (tag.len <= prefix.len) return;
+    const field = tag[prefix.len..];
+
+    if (std.mem.eql(u8, field, "comp_id")) {
+        cols.comp_id = idx;
+    } else if (std.mem.eql(u8, field, "atom_id_1")) {
+        cols.atom_id_1 = idx;
+    } else if (std.mem.eql(u8, field, "atom_id_2")) {
+        cols.atom_id_2 = idx;
+    } else if (std.mem.eql(u8, field, "value_order")) {
+        cols.value_order = idx;
+    } else if (std.mem.eql(u8, field, "pdbx_aromatic_flag")) {
+        cols.pdbx_aromatic_flag = idx;
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Return true if `comp_id` should be SKIPPED (not in filter list).
+fn isFiltered(comp_id: []const u8, filter: ?[]const []const u8) bool {
+    const f = filter orelse return false; // no filter => include everything
+    for (f) |allowed| {
+        if (std.mem.eql(u8, comp_id, allowed)) return false; // found in filter => include
+    }
+    return true; // not found in filter => skip
+}
+
+/// Get or create a ComponentBuilder for a given comp_id.
+fn getOrCreateBuilder(
+    allocator: Allocator,
+    builders: *std.StringHashMap(ComponentBuilder),
+    comp_id: []const u8,
+) !*ComponentBuilder {
+    const gop = try builders.getOrPut(comp_id);
+    if (!gop.found_existing) {
+        // Dupe the key so the builder map owns it.
+        const key_copy = try allocator.dupe(u8, comp_id);
+        gop.key_ptr.* = key_copy;
+        gop.value_ptr.* = ComponentBuilder.init(allocator);
+    }
+    return gop.value_ptr;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "parseCcdData — single ALA component" {
+    const source =
+        \\data_ALA
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\_chem_comp_atom.pdbx_aromatic_flag
+        \\_chem_comp_atom.pdbx_leaving_atom_flag
+        \\ALA N   N N N
+        \\ALA CA  C N N
+        \\ALA C   C N N
+        \\ALA O   O N N
+        \\ALA CB  C N N
+        \\ALA OXT O N Y
+        \\ALA H   H N N
+        \\ALA HA  H N N
+        \\#
+        \\loop_
+        \\_chem_comp_bond.comp_id
+        \\_chem_comp_bond.atom_id_1
+        \\_chem_comp_bond.atom_id_2
+        \\_chem_comp_bond.value_order
+        \\_chem_comp_bond.pdbx_aromatic_flag
+        \\ALA N   CA  SING N
+        \\ALA CA  C   SING N
+        \\ALA CA  CB  SING N
+        \\ALA CA  HA  SING N
+        \\ALA C   O   DOUB N
+        \\ALA C   OXT SING N
+        \\ALA N   H   SING N
+        \\#
+    ;
+
+    var dict = try parseCcdData(std.testing.allocator, source, null);
+    defer dict.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), dict.count());
+
+    const comp = dict.get("ALA") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("ALA", comp.compIdSlice());
+
+    // 8 atoms: N, CA, C, O, CB, OXT, H, HA
+    try std.testing.expectEqual(@as(usize, 8), comp.atoms.len);
+
+    // 7 bonds
+    try std.testing.expectEqual(@as(usize, 7), comp.bonds.len);
+
+    // Verify C=O is double bond. Find the bond where atom names are C and O.
+    // C is index 2, O is index 3 in our atom list.
+    var found_co_double = false;
+    for (comp.bonds) |bond| {
+        const a1 = comp.atoms[bond.atom_idx_1].atomIdSlice();
+        const a2 = comp.atoms[bond.atom_idx_2].atomIdSlice();
+        if (std.mem.eql(u8, a1, "C") and std.mem.eql(u8, a2, "O")) {
+            try std.testing.expectEqual(BondOrder.double, bond.order);
+            found_co_double = true;
+        }
+    }
+    try std.testing.expect(found_co_double);
+
+    // Verify OXT is a leaving atom
+    var found_oxt_leaving = false;
+    for (comp.atoms) |atom| {
+        if (std.mem.eql(u8, atom.atomIdSlice(), "OXT")) {
+            try std.testing.expect(atom.leaving);
+            found_oxt_leaving = true;
+        }
+    }
+    try std.testing.expect(found_oxt_leaving);
+}
+
+test "parseCcdData — filter by comp_id" {
+    const source =
+        \\data_ALA
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\ALA N  N
+        \\ALA CA C
+        \\ALA C  C
+        \\ALA O  O
+        \\ALA CB C
+        \\#
+        \\data_GLY
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\GLY N  N
+        \\GLY CA C
+        \\GLY C  C
+        \\GLY O  O
+        \\#
+    ;
+
+    const filter = &[_][]const u8{"GLY"};
+    var dict = try parseCcdData(std.testing.allocator, source, filter);
+    defer dict.deinit();
+
+    // Only GLY should be present.
+    try std.testing.expectEqual(@as(usize, 1), dict.count());
+    try std.testing.expect(dict.get("GLY") != null);
+    try std.testing.expect(dict.get("ALA") == null);
+
+    const gly = dict.get("GLY").?;
+    try std.testing.expectEqual(@as(usize, 4), gly.atoms.len);
+}
+
+test "parseCcdData — minimal columns (HOH, no aromatic/leaving flags, no bonds)" {
+    const source =
+        \\data_HOH
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\HOH O  O
+        \\HOH H1 H
+        \\HOH H2 H
+        \\#
+    ;
+
+    var dict = try parseCcdData(std.testing.allocator, source, null);
+    defer dict.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), dict.count());
+
+    const comp = dict.get("HOH") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 3), comp.atoms.len);
+    try std.testing.expectEqual(@as(usize, 0), comp.bonds.len);
+
+    // Aromatic/leaving should default to false.
+    for (comp.atoms) |atom| {
+        try std.testing.expect(!atom.aromatic);
+        try std.testing.expect(!atom.leaving);
+    }
+}
+
+test "parseCcdData — aromatic flags" {
+    const source =
+        \\data_PHE
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\_chem_comp_atom.pdbx_aromatic_flag
+        \\PHE CB  C N
+        \\PHE CG  C Y
+        \\PHE CD1 C Y
+        \\PHE CD2 C Y
+        \\PHE CE1 C Y
+        \\PHE CE2 C Y
+        \\PHE CZ  C Y
+        \\#
+        \\loop_
+        \\_chem_comp_bond.comp_id
+        \\_chem_comp_bond.atom_id_1
+        \\_chem_comp_bond.atom_id_2
+        \\_chem_comp_bond.value_order
+        \\_chem_comp_bond.pdbx_aromatic_flag
+        \\PHE CB  CG  SING N
+        \\PHE CG  CD1 DOUB Y
+        \\PHE CG  CD2 SING Y
+        \\PHE CD1 CE1 SING Y
+        \\PHE CD2 CE2 DOUB Y
+        \\PHE CE1 CZ  DOUB Y
+        \\PHE CE2 CZ  SING Y
+        \\#
+    ;
+
+    var dict = try parseCcdData(std.testing.allocator, source, null);
+    defer dict.deinit();
+
+    const comp = dict.get("PHE") orelse return error.TestUnexpectedResult;
+
+    // CB should NOT be aromatic; CG, CD1, CD2, CE1, CE2, CZ should be aromatic.
+    for (comp.atoms) |atom| {
+        const name = atom.atomIdSlice();
+        if (std.mem.eql(u8, name, "CB")) {
+            try std.testing.expect(!atom.aromatic);
+        } else {
+            try std.testing.expect(atom.aromatic);
+        }
+    }
+
+    // Bond CG-CD1 should be aromatic.
+    var found_cg_cd1 = false;
+    for (comp.bonds) |bond| {
+        const a1 = comp.atoms[bond.atom_idx_1].atomIdSlice();
+        const a2 = comp.atoms[bond.atom_idx_2].atomIdSlice();
+        if (std.mem.eql(u8, a1, "CG") and std.mem.eql(u8, a2, "CD1")) {
+            try std.testing.expect(bond.aromatic);
+            try std.testing.expectEqual(BondOrder.double, bond.order);
+            found_cg_cd1 = true;
+        }
+    }
+    try std.testing.expect(found_cg_cd1);
+
+    // Bond CB-CG should NOT be aromatic.
+    var found_cb_cg = false;
+    for (comp.bonds) |bond| {
+        const a1 = comp.atoms[bond.atom_idx_1].atomIdSlice();
+        const a2 = comp.atoms[bond.atom_idx_2].atomIdSlice();
+        if (std.mem.eql(u8, a1, "CB") and std.mem.eql(u8, a2, "CG")) {
+            try std.testing.expect(!bond.aromatic);
+            try std.testing.expectEqual(BondOrder.single, bond.order);
+            found_cb_cg = true;
+        }
+    }
+    try std.testing.expect(found_cb_cg);
+}
+
+test "parseCcdData — extra columns are skipped" {
+    // Real CCD files have many more columns. Verify we handle extra columns.
+    const source =
+        \\data_ALA
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.alt_atom_id
+        \\_chem_comp_atom.type_symbol
+        \\_chem_comp_atom.charge
+        \\_chem_comp_atom.pdbx_align
+        \\_chem_comp_atom.pdbx_aromatic_flag
+        \\_chem_comp_atom.pdbx_leaving_atom_flag
+        \\_chem_comp_atom.pdbx_stereo_config
+        \\_chem_comp_atom.model_Cartn_x
+        \\_chem_comp_atom.model_Cartn_y
+        \\_chem_comp_atom.model_Cartn_z
+        \\ALA N   N   N 0 1 N N N 0.000 0.000 0.000
+        \\ALA CA  CA  C 0 1 N N S 1.458 0.000 0.000
+        \\ALA C   C   C 0 1 N N N 2.009 1.420 0.000
+        \\#
+    ;
+
+    var dict = try parseCcdData(std.testing.allocator, source, null);
+    defer dict.deinit();
+
+    const comp = dict.get("ALA") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 3), comp.atoms.len);
+
+    // Verify atom data was correctly extracted despite extra columns.
+    try std.testing.expectEqualStrings("N", comp.atoms[0].atomIdSlice());
+    try std.testing.expectEqualStrings("N", comp.atoms[0].typeSymbolSlice());
+    try std.testing.expectEqualStrings("CA", comp.atoms[1].atomIdSlice());
+    try std.testing.expectEqualStrings("C", comp.atoms[1].typeSymbolSlice());
+    try std.testing.expectEqualStrings("C", comp.atoms[2].atomIdSlice());
+    try std.testing.expectEqualStrings("C", comp.atoms[2].typeSymbolSlice());
+}
+
+test "parseCcdData — multiple comp_ids in single loop" {
+    // CCD files may have all components in a single loop.
+    const source =
+        \\data_all
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\ALA N  N
+        \\ALA CA C
+        \\GLY N  N
+        \\GLY CA C
+        \\GLY C  C
+        \\#
+    ;
+
+    var dict = try parseCcdData(std.testing.allocator, source, null);
+    defer dict.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), dict.count());
+
+    const ala = dict.get("ALA") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 2), ala.atoms.len);
+
+    const gly = dict.get("GLY") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 3), gly.atoms.len);
+}
+
+test "ComponentDict — empty source" {
+    var dict = try parseCcdData(std.testing.allocator, "", null);
+    defer dict.deinit();
+    try std.testing.expectEqual(@as(usize, 0), dict.count());
+}

--- a/src/classifier.zig
+++ b/src/classifier.zig
@@ -13,6 +13,7 @@
 //! - **NACCESS**: Default classifier, NACCESS-compatible radii (João Rodrigues)
 //! - **ProtOr**: Hybridization-based radii from Tsai et al. 1999
 //! - **OONS**: Ooi, Oobatake, Nemethy, Scheraga radii (older FreeSASA default)
+//! - **CCD**: Derives radii from CCD bond topology (ProtOr-compatible)
 //!
 //! ## Usage
 //!

--- a/src/classifier.zig
+++ b/src/classifier.zig
@@ -46,11 +46,16 @@ pub const ClassifierType = enum {
     /// Reference: Ooi, Oobatake, Nemethy, Scheraga
     oons,
 
+    /// CCD-based radii derived from bond topology
+    /// Uses hybridization analysis of Chemical Component Dictionary data
+    ccd,
+
     pub fn name(self: ClassifierType) []const u8 {
         return switch (self) {
             .naccess => "NACCESS",
             .protor => "ProtOr",
             .oons => "OONS",
+            .ccd => "CCD",
         };
     }
 
@@ -58,6 +63,7 @@ pub const ClassifierType = enum {
         if (std.ascii.eqlIgnoreCase(s, "naccess")) return .naccess;
         if (std.ascii.eqlIgnoreCase(s, "protor")) return .protor;
         if (std.ascii.eqlIgnoreCase(s, "oons")) return .oons;
+        if (std.ascii.eqlIgnoreCase(s, "ccd")) return .ccd;
         return null;
     }
 };
@@ -411,6 +417,22 @@ pub fn guessRadiusFromAtomName(atom_name: []const u8) ?f64 {
 // =============================================================================
 // Tests
 // =============================================================================
+
+test "ClassifierType fromString" {
+    try std.testing.expectEqual(ClassifierType.naccess, ClassifierType.fromString("naccess").?);
+    try std.testing.expectEqual(ClassifierType.protor, ClassifierType.fromString("protor").?);
+    try std.testing.expectEqual(ClassifierType.oons, ClassifierType.fromString("oons").?);
+    try std.testing.expectEqual(ClassifierType.ccd, ClassifierType.fromString("ccd").?);
+    try std.testing.expectEqual(ClassifierType.ccd, ClassifierType.fromString("CCD").?);
+    try std.testing.expectEqual(@as(?ClassifierType, null), ClassifierType.fromString("invalid"));
+}
+
+test "ClassifierType name" {
+    try std.testing.expectEqualStrings("NACCESS", ClassifierType.naccess.name());
+    try std.testing.expectEqualStrings("ProtOr", ClassifierType.protor.name());
+    try std.testing.expectEqualStrings("OONS", ClassifierType.oons.name());
+    try std.testing.expectEqualStrings("CCD", ClassifierType.ccd.name());
+}
 
 test "AtomClass fromString" {
     try std.testing.expectEqual(AtomClass.polar, AtomClass.fromString("polar"));

--- a/src/classifier_ccd.zig
+++ b/src/classifier_ccd.zig
@@ -864,6 +864,7 @@ pub const CcdClassifier = struct {
 
             // Allocate a persistent copy of the key on the heap
             const key_copy = try self.allocator.alloc(u8, 9);
+            errdefer self.allocator.free(key_copy);
             @memcpy(key_copy, &key);
 
             try self.runtime_components.put(key_copy, RuntimeEntry{ .props = entry.props });

--- a/src/classifier_ccd.zig
+++ b/src/classifier_ccd.zig
@@ -350,7 +350,7 @@ const hardcoded_table = std.StaticStringMap(AtomProperties).initComptime(.{
     .{ "SEP :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
     .{ "SEP :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
     .{ "SEP :OG  ", AtomProperties{ .radius = 1.46, .class = .polar } }, // sp3, 0H (bonded to P)
-    .{ "SEP :P   ", AtomProperties{ .radius = 1.80, .class = .apolar } },
+    .{ "SEP :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
     .{ "SEP :O1P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
     .{ "SEP :O2P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
     .{ "SEP :O3P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
@@ -364,7 +364,7 @@ const hardcoded_table = std.StaticStringMap(AtomProperties).initComptime(.{
     .{ "TPO :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
     .{ "TPO :CG2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
     .{ "TPO :OG1 ", AtomProperties{ .radius = 1.46, .class = .polar } }, // sp3, 0H (bonded to P)
-    .{ "TPO :P   ", AtomProperties{ .radius = 1.80, .class = .apolar } },
+    .{ "TPO :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
     .{ "TPO :O1P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
     .{ "TPO :O2P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
     .{ "TPO :O3P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
@@ -372,7 +372,7 @@ const hardcoded_table = std.StaticStringMap(AtomProperties).initComptime(.{
 
     // PSU (pseudouridine) — like U but C-glycosidic bond (C1'-C5 instead of N1)
     .{ "PSU :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
-    .{ "PSU :P   ", AtomProperties{ .radius = 1.80, .class = .apolar } },
+    .{ "PSU :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
     .{ "PSU :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
     .{ "PSU :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
     .{ "PSU :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },

--- a/src/classifier_ccd.zig
+++ b/src/classifier_ccd.zig
@@ -1,0 +1,1058 @@
+//! CCD-based classifier with hardcoded StaticStringMap for standard residues
+//! and runtime component support for non-standard residues.
+//!
+//! This classifier is the primary lookup for CCD-based SASA calculation.
+//! Standard residues use a compile-time StaticStringMap for O(1) lookup.
+//! Non-standard residues are added at runtime via `addComponent`.
+//!
+//! The hardcoded table produces the same radii as ProtOr for standard residues.
+//! Reference: Tsai et al. 1999, J. Mol. Biol. 290:253-266
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const classifier = @import("classifier.zig");
+const AtomClass = classifier.AtomClass;
+const AtomProperties = classifier.AtomProperties;
+const hybridization = @import("hybridization.zig");
+const Component = hybridization.Component;
+
+// =============================================================================
+// Hardcoded table (same entries and values as classifier_protor.zig)
+// =============================================================================
+
+/// Key format: "RES :ATOM" — 4 chars residue (space-padded) + ':' + 4 chars atom (space-padded) = 9 chars total
+const hardcoded_table = std.StaticStringMap(AtomProperties).initComptime(.{
+    // === Standard Amino Acids ===
+
+    // ALA
+    .{ "ALA :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ALA :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ALA :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ALA :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ALA :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ALA :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // ARG
+    .{ "ARG :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ARG :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ARG :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ARG :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ARG :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ARG :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ARG :CD  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ARG :NE  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ARG :CZ  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ARG :NH1 ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ARG :NH2 ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ARG :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // ASN
+    .{ "ASN :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ASN :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ASN :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ASN :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ASN :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ASN :CG  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ASN :OD1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ASN :ND2 ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ASN :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // ASP
+    .{ "ASP :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ASP :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ASP :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ASP :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ASP :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ASP :CG  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ASP :OD1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ASP :OD2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "ASP :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // CYS
+    .{ "CYS :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "CYS :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "CYS :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "CYS :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "CYS :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "CYS :SG  ", AtomProperties{ .radius = 1.77, .class = .polar } },
+    .{ "CYS :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // GLN
+    .{ "GLN :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "GLN :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLN :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "GLN :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "GLN :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLN :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLN :CD  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "GLN :OE1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "GLN :NE2 ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "GLN :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // GLU
+    .{ "GLU :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "GLU :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLU :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "GLU :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "GLU :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLU :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLU :CD  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "GLU :OE1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "GLU :OE2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "GLU :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // GLY
+    .{ "GLY :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "GLY :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLY :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "GLY :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "GLY :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // HIS
+    .{ "HIS :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "HIS :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "HIS :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "HIS :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "HIS :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "HIS :CG  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "HIS :ND1 ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "HIS :CD2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "HIS :CE1 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "HIS :NE2 ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "HIS :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // ILE
+    .{ "ILE :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ILE :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ILE :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ILE :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ILE :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ILE :CG1 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ILE :CG2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ILE :CD1 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ILE :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // LEU
+    .{ "LEU :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "LEU :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LEU :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "LEU :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "LEU :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LEU :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LEU :CD1 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LEU :CD2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LEU :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // LYS
+    .{ "LYS :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "LYS :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LYS :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "LYS :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "LYS :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LYS :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LYS :CD  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LYS :CE  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "LYS :NZ  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "LYS :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // MET
+    .{ "MET :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "MET :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MET :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "MET :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "MET :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MET :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MET :SD  ", AtomProperties{ .radius = 1.77, .class = .polar } },
+    .{ "MET :CE  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MET :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // PHE
+    .{ "PHE :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "PHE :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PHE :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "PHE :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "PHE :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PHE :CG  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "PHE :CD1 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "PHE :CD2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "PHE :CE1 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "PHE :CE2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "PHE :CZ  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "PHE :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // PRO
+    .{ "PRO :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "PRO :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PRO :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "PRO :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "PRO :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PRO :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PRO :CD  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PRO :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // SER
+    .{ "SER :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "SER :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "SER :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "SER :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "SER :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "SER :OG  ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "SER :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // THR
+    .{ "THR :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "THR :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "THR :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "THR :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "THR :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "THR :OG1 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "THR :CG2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "THR :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // TRP
+    .{ "TRP :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "TRP :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "TRP :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TRP :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "TRP :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "TRP :CG  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TRP :CD1 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TRP :CD2 ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TRP :NE1 ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "TRP :CE2 ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TRP :CE3 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TRP :CZ2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TRP :CZ3 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TRP :CH2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TRP :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // TYR
+    .{ "TYR :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "TYR :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "TYR :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TYR :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "TYR :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "TYR :CG  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TYR :CD1 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TYR :CD2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TYR :CE1 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TYR :CE2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "TYR :CZ  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TYR :OH  ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "TYR :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // VAL
+    .{ "VAL :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "VAL :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "VAL :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "VAL :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "VAL :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "VAL :CG1 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "VAL :CG2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "VAL :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // === Non-standard Amino Acids ===
+
+    // ASX (ambiguous ASN/ASP)
+    .{ "ASX :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "ASX :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ASX :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ASX :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "ASX :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "ASX :CG  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "ASX :XD1 ", AtomProperties{ .radius = 1.50, .class = .polar } },
+    .{ "ASX :XD2 ", AtomProperties{ .radius = 1.50, .class = .polar } },
+    .{ "ASX :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // GLX (ambiguous GLN/GLU)
+    .{ "GLX :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "GLX :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLX :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "GLX :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "GLX :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLX :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "GLX :CD  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "GLX :XE1 ", AtomProperties{ .radius = 1.50, .class = .polar } },
+    .{ "GLX :XE2 ", AtomProperties{ .radius = 1.50, .class = .polar } },
+    .{ "GLX :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // SEC (selenocysteine)
+    .{ "SEC :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "SEC :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "SEC :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "SEC :SE  ", AtomProperties{ .radius = 1.90, .class = .polar } },
+    .{ "SEC :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "SEC :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "SEC :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // MSE (selenomethionine)
+    .{ "MSE :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "MSE :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MSE :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "MSE :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "MSE :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "MSE :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MSE :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MSE :SE  ", AtomProperties{ .radius = 1.90, .class = .polar } },
+    .{ "MSE :CE  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+
+    // PYL (pyrrolysine)
+    .{ "PYL :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "PYL :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "PYL :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "PYL :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "PYL :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :CD  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :CE  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :NZ  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "PYL :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "PYL :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "PYL :CA2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :N2  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "PYL :CB2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :CG2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :CD2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PYL :CE2 ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+
+    // === New residues (not in ProtOr) ===
+
+    // HYP (hydroxyproline) — like PRO but with hydroxyl on CG
+    .{ "HYP :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "HYP :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "HYP :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "HYP :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "HYP :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } }, // sp3, 2H
+    .{ "HYP :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } }, // sp3, 1H
+    .{ "HYP :CD  ", AtomProperties{ .radius = 1.88, .class = .apolar } }, // sp3, 2H
+    .{ "HYP :OD1 ", AtomProperties{ .radius = 1.46, .class = .polar } }, // sp3, 1H (hydroxyl)
+    .{ "HYP :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // MLY (dimethyllysine) — like LYS but NZ has 0H (methylated)
+    .{ "MLY :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "MLY :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MLY :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "MLY :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "MLY :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MLY :CG  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MLY :CD  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MLY :CE  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "MLY :NZ  ", AtomProperties{ .radius = 1.64, .class = .polar } }, // sp3, 0H
+    .{ "MLY :CH1 ", AtomProperties{ .radius = 1.88, .class = .apolar } }, // methyl
+    .{ "MLY :CH2 ", AtomProperties{ .radius = 1.88, .class = .apolar } }, // methyl
+    .{ "MLY :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // SEP (phosphoserine) — like SER but OG bonded to phosphate
+    .{ "SEP :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "SEP :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "SEP :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "SEP :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "SEP :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "SEP :OG  ", AtomProperties{ .radius = 1.46, .class = .polar } }, // sp3, 0H (bonded to P)
+    .{ "SEP :P   ", AtomProperties{ .radius = 1.80, .class = .apolar } },
+    .{ "SEP :O1P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
+    .{ "SEP :O2P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
+    .{ "SEP :O3P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
+    .{ "SEP :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // TPO (phosphothreonine) — like THR but OG1 bonded to phosphate
+    .{ "TPO :N   ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "TPO :CA  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "TPO :C   ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "TPO :O   ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "TPO :CB  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "TPO :CG2 ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "TPO :OG1 ", AtomProperties{ .radius = 1.46, .class = .polar } }, // sp3, 0H (bonded to P)
+    .{ "TPO :P   ", AtomProperties{ .radius = 1.80, .class = .apolar } },
+    .{ "TPO :O1P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
+    .{ "TPO :O2P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
+    .{ "TPO :O3P ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
+    .{ "TPO :OXT ", AtomProperties{ .radius = 1.46, .class = .polar } },
+
+    // PSU (pseudouridine) — like U but C-glycosidic bond (C1'-C5 instead of N1)
+    .{ "PSU :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "PSU :P   ", AtomProperties{ .radius = 1.80, .class = .apolar } },
+    .{ "PSU :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "PSU :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "PSU :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "PSU :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PSU :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PSU :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "PSU :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PSU :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "PSU :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PSU :O2' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "PSU :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "PSU :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "PSU :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "PSU :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "PSU :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "PSU :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "PSU :O4  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "PSU :C5  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "PSU :C6  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+
+    // === Capping Groups ===
+
+    // ACE (acetyl cap) — CH3-C(=O)
+    .{ "ACE :C   ", AtomProperties{ .radius = 1.76, .class = .apolar } }, // sp2, 1H (C3H1 in ProtOr)
+    .{ "ACE :O   ", AtomProperties{ .radius = 1.42, .class = .polar } }, // sp2, 0H
+    .{ "ACE :CH3 ", AtomProperties{ .radius = 1.88, .class = .apolar } }, // sp3, 3H
+
+    // NH2 (amino cap)
+    .{ "NH2 :N   ", AtomProperties{ .radius = 1.64, .class = .polar } }, // sp3, 2H (N2H2 in ProtOr)
+
+    // HOH (water)
+    .{ "HOH :O   ", AtomProperties{ .radius = 1.46, .class = .polar } }, // sp3, 2H
+
+    // === RNA Nucleotides ===
+
+    // A (adenine)
+    .{ "A   :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "A   :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "A   :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "A   :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "A   :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "A   :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "A   :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "A   :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "A   :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "A   :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "A   :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "A   :O2' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "A   :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "A   :N9  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "A   :C8  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "A   :N7  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "A   :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "A   :C6  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "A   :N6  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "A   :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "A   :C2  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "A   :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "A   :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+
+    // C (cytosine)
+    .{ "C   :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "C   :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "C   :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "C   :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "C   :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "C   :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "C   :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "C   :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "C   :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "C   :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "C   :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "C   :O2' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "C   :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "C   :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "C   :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "C   :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "C   :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "C   :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "C   :N4  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "C   :C5  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "C   :C6  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+
+    // G (guanine)
+    .{ "G   :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "G   :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "G   :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "G   :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "G   :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "G   :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "G   :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "G   :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "G   :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "G   :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "G   :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "G   :O2' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "G   :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "G   :N9  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "G   :C8  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "G   :N7  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "G   :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "G   :C6  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "G   :O6  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "G   :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "G   :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "G   :N2  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "G   :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "G   :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+
+    // I (inosine)
+    .{ "I   :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "I   :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "I   :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "I   :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "I   :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "I   :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "I   :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "I   :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "I   :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "I   :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "I   :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "I   :O2' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "I   :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "I   :N9  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "I   :C8  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "I   :N7  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "I   :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "I   :C6  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "I   :O6  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "I   :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "I   :C2  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "I   :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "I   :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+
+    // T (thymine - for RNA)
+    .{ "T   :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "T   :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "T   :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "T   :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "T   :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "T   :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "T   :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "T   :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "T   :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "T   :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "T   :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "T   :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "T   :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "T   :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "T   :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "T   :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "T   :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "T   :O4  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "T   :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "T   :C7  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "T   :C6  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+
+    // U (uracil)
+    .{ "U   :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "U   :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "U   :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "U   :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "U   :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "U   :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "U   :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "U   :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "U   :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "U   :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "U   :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "U   :O2' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "U   :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "U   :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "U   :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "U   :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "U   :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "U   :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "U   :O4  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "U   :C5  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "U   :C6  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+
+    // === DNA Nucleotides ===
+
+    // DA (deoxyadenosine)
+    .{ "DA  :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DA  :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "DA  :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DA  :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DA  :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DA  :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DA  :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DA  :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DA  :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DA  :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DA  :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DA  :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DA  :N9  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DA  :C8  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "DA  :N7  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DA  :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DA  :C6  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DA  :N6  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DA  :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DA  :C2  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "DA  :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DA  :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+
+    // DC (deoxycytidine)
+    .{ "DC  :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DC  :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "DC  :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DC  :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DC  :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DC  :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DC  :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DC  :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DC  :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DC  :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DC  :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DC  :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DC  :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DC  :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DC  :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DC  :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DC  :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DC  :N4  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DC  :C5  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "DC  :C6  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+
+    // DG (deoxyguanosine)
+    .{ "DG  :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DG  :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "DG  :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DG  :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DG  :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DG  :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DG  :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DG  :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DG  :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DG  :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DG  :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DG  :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DG  :N9  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DG  :C8  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "DG  :N7  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DG  :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DG  :C6  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DG  :O6  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DG  :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DG  :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DG  :N2  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DG  :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DG  :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+
+    // DI (deoxyinosine)
+    .{ "DI  :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DI  :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "DI  :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DI  :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DI  :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DI  :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DI  :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DI  :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DI  :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DI  :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DI  :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DI  :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DI  :N9  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DI  :C8  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "DI  :N7  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DI  :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DI  :C6  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DI  :O6  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DI  :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DI  :C2  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "DI  :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DI  :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+
+    // DT (deoxythymidine)
+    .{ "DT  :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DT  :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "DT  :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DT  :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DT  :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DT  :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DT  :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DT  :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DT  :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DT  :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DT  :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DT  :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DT  :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DT  :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DT  :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DT  :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DT  :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DT  :O4  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DT  :C5  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DT  :C7  ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DT  :C6  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+
+    // DU (deoxyuridine)
+    .{ "DU  :OP3 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DU  :P   ", AtomProperties{ .radius = 1.80, .class = .polar } },
+    .{ "DU  :OP1 ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DU  :OP2 ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DU  :O5' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DU  :C5' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DU  :C4' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DU  :O4' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DU  :C3' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DU  :O3' ", AtomProperties{ .radius = 1.46, .class = .polar } },
+    .{ "DU  :C2' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DU  :C1' ", AtomProperties{ .radius = 1.88, .class = .apolar } },
+    .{ "DU  :N1  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DU  :C2  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DU  :O2  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DU  :N3  ", AtomProperties{ .radius = 1.64, .class = .polar } },
+    .{ "DU  :C4  ", AtomProperties{ .radius = 1.61, .class = .apolar } },
+    .{ "DU  :O4  ", AtomProperties{ .radius = 1.42, .class = .polar } },
+    .{ "DU  :C5  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+    .{ "DU  :C6  ", AtomProperties{ .radius = 1.76, .class = .apolar } },
+});
+
+/// List of hardcoded residue names for isHardcoded check
+const hardcoded_residues = std.StaticStringMap(void).initComptime(.{
+    // Standard amino acids
+    .{ "ALA", {} },
+    .{ "ARG", {} },
+    .{ "ASN", {} },
+    .{ "ASP", {} },
+    .{ "CYS", {} },
+    .{ "GLN", {} },
+    .{ "GLU", {} },
+    .{ "GLY", {} },
+    .{ "HIS", {} },
+    .{ "ILE", {} },
+    .{ "LEU", {} },
+    .{ "LYS", {} },
+    .{ "MET", {} },
+    .{ "PHE", {} },
+    .{ "PRO", {} },
+    .{ "SER", {} },
+    .{ "THR", {} },
+    .{ "TRP", {} },
+    .{ "TYR", {} },
+    .{ "VAL", {} },
+    // Non-standard amino acids
+    .{ "ASX", {} },
+    .{ "GLX", {} },
+    .{ "SEC", {} },
+    .{ "MSE", {} },
+    .{ "PYL", {} },
+    // New residues
+    .{ "HYP", {} },
+    .{ "MLY", {} },
+    .{ "SEP", {} },
+    .{ "TPO", {} },
+    .{ "PSU", {} },
+    // Capping groups
+    .{ "ACE", {} },
+    .{ "NH2", {} },
+    // Solvent
+    .{ "HOH", {} },
+    // Nucleic acids
+    .{ "A", {} },
+    .{ "C", {} },
+    .{ "G", {} },
+    .{ "I", {} },
+    .{ "T", {} },
+    .{ "U", {} },
+    .{ "DA", {} },
+    .{ "DC", {} },
+    .{ "DG", {} },
+    .{ "DI", {} },
+    .{ "DT", {} },
+    .{ "DU", {} },
+});
+
+// =============================================================================
+// Key formatting
+// =============================================================================
+
+/// Convert (residue, atom) to 9-char key for StaticStringMap lookup.
+/// Format: "RES :ATOM" — 4 chars residue (left-justified, space-padded) + ':' + 4 chars atom (left-justified, space-padded)
+pub fn formatKey(residue: []const u8, atom: []const u8) [9]u8 {
+    var key: [9]u8 = .{ ' ', ' ', ' ', ' ', ':', ' ', ' ', ' ', ' ' };
+
+    const res_len = @min(residue.len, 4);
+    for (residue[0..res_len], 0..) |c, i| {
+        key[i] = c;
+    }
+
+    const atom_len = @min(atom.len, 4);
+    for (atom[0..atom_len], 0..) |c, i| {
+        key[5 + i] = c;
+    }
+
+    return key;
+}
+
+// =============================================================================
+// Runtime entry for non-standard residues
+// =============================================================================
+
+/// Runtime entry stored per atom for a component added via addComponent.
+const RuntimeEntry = struct {
+    props: AtomProperties,
+};
+
+/// Runtime component storage: maps formatted 9-char keys to properties.
+const RuntimeMap = std.StringHashMap(RuntimeEntry);
+
+// =============================================================================
+// CcdClassifier
+// =============================================================================
+
+pub const CcdClassifier = struct {
+    runtime_components: RuntimeMap,
+    allocator: Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: Allocator) CcdClassifier {
+        return .{
+            .runtime_components = RuntimeMap.init(allocator),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *CcdClassifier) void {
+        // Free all allocated keys
+        var it = self.runtime_components.keyIterator();
+        while (it.next()) |key_ptr| {
+            self.allocator.free(key_ptr.*);
+        }
+        self.runtime_components.deinit();
+    }
+
+    /// Get radius for a (residue, atom) pair.
+    /// Lookup priority: hardcoded table -> runtime map -> null
+    pub fn getRadius(self: *const CcdClassifier, residue: []const u8, atom: []const u8) ?f64 {
+        const props = self.getProperties(residue, atom) orelse return null;
+        return props.radius;
+    }
+
+    /// Get polarity class for a (residue, atom) pair.
+    pub fn getClass(self: *const CcdClassifier, residue: []const u8, atom: []const u8) AtomClass {
+        const props = self.getProperties(residue, atom) orelse return .unknown;
+        return props.class;
+    }
+
+    /// Get both radius and class for a (residue, atom) pair.
+    /// Lookup priority:
+    /// 1. Hardcoded StaticStringMap (O(1), compile-time)
+    /// 2. Runtime HashMap (populated via addComponent)
+    /// 3. Return null (caller uses element fallback)
+    pub fn getProperties(self: *const CcdClassifier, residue: []const u8, atom: []const u8) ?AtomProperties {
+        // 1. Hardcoded lookup
+        const key = formatKey(residue, atom);
+        if (hardcoded_table.get(&key)) |props| {
+            return props;
+        }
+
+        // 2. Runtime lookup
+        if (self.runtime_components.get(&key)) |entry| {
+            return entry.props;
+        }
+
+        // 3. Not found
+        return null;
+    }
+
+    /// Check if a residue name has hardcoded entries.
+    pub fn isHardcoded(residue: []const u8) bool {
+        return hardcoded_residues.get(residue) != null;
+    }
+
+    /// Add a component from hybridization analysis to the runtime map.
+    /// Calls deriveComponentProperties and stores results keyed by (comp_id, atom_id).
+    pub fn addComponent(self: *CcdClassifier, component: *const Component) !void {
+        const entries = try hybridization.deriveComponentProperties(self.allocator, component);
+        defer self.allocator.free(entries);
+
+        const comp_id = component.compIdSlice();
+
+        for (entries) |entry| {
+            const atom_id = entry.atomIdSlice();
+            const key = formatKey(comp_id, atom_id);
+
+            // Allocate a persistent copy of the key on the heap
+            const key_copy = try self.allocator.alloc(u8, 9);
+            @memcpy(key_copy, &key);
+
+            try self.runtime_components.put(key_copy, RuntimeEntry{ .props = entry.props });
+        }
+    }
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const protor = @import("classifier_protor.zig");
+const CompAtom = hybridization.CompAtom;
+const CompBond = hybridization.CompBond;
+
+test "CCD hardcoded ALA lookup — getRadius and getClass" {
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    // N
+    try std.testing.expectApproxEqAbs(@as(f64, 1.64), ccd.getRadius("ALA", "N").?, 0.001);
+    try std.testing.expectEqual(AtomClass.polar, ccd.getClass("ALA", "N"));
+
+    // CA
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), ccd.getRadius("ALA", "CA").?, 0.001);
+    try std.testing.expectEqual(AtomClass.apolar, ccd.getClass("ALA", "CA"));
+
+    // C
+    try std.testing.expectApproxEqAbs(@as(f64, 1.61), ccd.getRadius("ALA", "C").?, 0.001);
+    try std.testing.expectEqual(AtomClass.apolar, ccd.getClass("ALA", "C"));
+
+    // O
+    try std.testing.expectApproxEqAbs(@as(f64, 1.42), ccd.getRadius("ALA", "O").?, 0.001);
+    try std.testing.expectEqual(AtomClass.polar, ccd.getClass("ALA", "O"));
+
+    // CB
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), ccd.getRadius("ALA", "CB").?, 0.001);
+    try std.testing.expectEqual(AtomClass.apolar, ccd.getClass("ALA", "CB"));
+}
+
+test "CCD unknown residue returns null" {
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    try std.testing.expectEqual(@as(?f64, null), ccd.getRadius("ZZZ", "N"));
+    try std.testing.expectEqual(@as(?f64, null), ccd.getRadius("ZZZ", "CA"));
+    try std.testing.expectEqual(AtomClass.unknown, ccd.getClass("ZZZ", "N"));
+    try std.testing.expectEqual(@as(?AtomProperties, null), ccd.getProperties("ZZZ", "N"));
+}
+
+test "CCD isHardcoded" {
+    try std.testing.expect(CcdClassifier.isHardcoded("ALA"));
+    try std.testing.expect(CcdClassifier.isHardcoded("GLY"));
+    try std.testing.expect(CcdClassifier.isHardcoded("PHE"));
+    try std.testing.expect(CcdClassifier.isHardcoded("HOH"));
+    try std.testing.expect(CcdClassifier.isHardcoded("MSE"));
+    try std.testing.expect(CcdClassifier.isHardcoded("A"));
+    try std.testing.expect(CcdClassifier.isHardcoded("DA"));
+    try std.testing.expect(CcdClassifier.isHardcoded("HYP"));
+    try std.testing.expect(CcdClassifier.isHardcoded("SEP"));
+
+    try std.testing.expect(!CcdClassifier.isHardcoded("ZZZ"));
+    try std.testing.expect(!CcdClassifier.isHardcoded("LIG"));
+    try std.testing.expect(!CcdClassifier.isHardcoded(""));
+}
+
+test "CCD runtime component via addComponent" {
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    // Create a fake ligand "LIG" with 2 atoms: C1(C) and N1(N)
+    const atoms = [_]CompAtom{
+        CompAtom.init("C1", "C"), // 0
+        CompAtom.init("N1", "N"), // 1
+        CompAtom.init("H1", "H"), // 2 (hydrogen)
+    };
+    const bonds = [_]CompBond{
+        .{ .atom_idx_1 = 0, .atom_idx_2 = 1, .order = .single, .aromatic = false },
+        .{ .atom_idx_1 = 0, .atom_idx_2 = 2, .order = .single, .aromatic = false },
+    };
+    const comp = Component{
+        .comp_id = .{ 'L', 'I', 'G', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = &atoms,
+        .bonds = &bonds,
+    };
+
+    // Before adding, should return null
+    try std.testing.expectEqual(@as(?f64, null), ccd.getRadius("LIG", "C1"));
+
+    try ccd.addComponent(&comp);
+
+    // After adding, should find it
+    const c1_radius = ccd.getRadius("LIG", "C1");
+    try std.testing.expect(c1_radius != null);
+
+    const n1_radius = ccd.getRadius("LIG", "N1");
+    try std.testing.expect(n1_radius != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.64), n1_radius.?, 0.001); // N always 1.64
+
+    // H1 should not be added (hydrogen is skipped)
+    try std.testing.expectEqual(@as(?f64, null), ccd.getRadius("LIG", "H1"));
+}
+
+test "CCD ProtOr compatibility — backbone atoms for all 20 standard amino acids" {
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    const residues = [_][]const u8{
+        "ALA", "ARG", "ASN", "ASP", "CYS",
+        "GLN", "GLU", "GLY", "HIS", "ILE",
+        "LEU", "LYS", "MET", "PHE", "PRO",
+        "SER", "THR", "TRP", "TYR", "VAL",
+    };
+
+    const backbone_atoms = [_][]const u8{ "N", "CA", "C", "O" };
+
+    for (residues) |res| {
+        for (backbone_atoms) |atom| {
+            const ccd_radius = ccd.getRadius(res, atom);
+            const protor_radius = protor.getRadius(res, atom);
+
+            // Both must return a value
+            try std.testing.expect(ccd_radius != null);
+            try std.testing.expect(protor_radius != null);
+
+            // Values must match
+            try std.testing.expectApproxEqAbs(protor_radius.?, ccd_radius.?, 0.001);
+        }
+    }
+}
+
+test "CCD HOH lookup" {
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    try std.testing.expectApproxEqAbs(@as(f64, 1.46), ccd.getRadius("HOH", "O").?, 0.001);
+    try std.testing.expectEqual(AtomClass.polar, ccd.getClass("HOH", "O"));
+}
+
+test "CCD formatKey" {
+    // Standard 3-letter residue + short atom name
+    const key1 = formatKey("ALA", "N");
+    try std.testing.expectEqualStrings("ALA :N   ", &key1);
+
+    // 3-letter residue + 2-char atom
+    const key2 = formatKey("ALA", "CA");
+    try std.testing.expectEqualStrings("ALA :CA  ", &key2);
+
+    // 1-letter residue (nucleic acid)
+    const key3 = formatKey("A", "P");
+    try std.testing.expectEqualStrings("A   :P   ", &key3);
+
+    // 2-letter residue (DNA)
+    const key4 = formatKey("DA", "C1'");
+    try std.testing.expectEqualStrings("DA  :C1' ", &key4);
+
+    // 4-char atom name
+    const key5 = formatKey("ALA", "OXT");
+    try std.testing.expectEqualStrings("ALA :OXT ", &key5);
+}
+
+test "CCD new residues — HYP, SEP, TPO, HOH" {
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    // HYP backbone matches standard AA
+    try std.testing.expectApproxEqAbs(@as(f64, 1.64), ccd.getRadius("HYP", "N").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), ccd.getRadius("HYP", "CA").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.61), ccd.getRadius("HYP", "C").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.42), ccd.getRadius("HYP", "O").?, 0.001);
+    // HYP specific: OD1 hydroxyl
+    try std.testing.expectApproxEqAbs(@as(f64, 1.46), ccd.getRadius("HYP", "OD1").?, 0.001);
+
+    // SEP phosphate
+    try std.testing.expectApproxEqAbs(@as(f64, 1.80), ccd.getRadius("SEP", "P").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.42), ccd.getRadius("SEP", "O1P").?, 0.001);
+
+    // TPO phosphate
+    try std.testing.expectApproxEqAbs(@as(f64, 1.80), ccd.getRadius("TPO", "P").?, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.42), ccd.getRadius("TPO", "O1P").?, 0.001);
+}
+
+test "CCD getProperties returns correct struct" {
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    const props = ccd.getProperties("ALA", "CB");
+    try std.testing.expect(props != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.88), props.?.radius, 0.001);
+    try std.testing.expectEqual(AtomClass.apolar, props.?.class);
+}

--- a/src/classifier_ccd.zig
+++ b/src/classifier_ccd.zig
@@ -1056,3 +1056,77 @@ test "CCD getProperties returns correct struct" {
     try std.testing.expectApproxEqAbs(@as(f64, 1.88), props.?.radius, 0.001);
     try std.testing.expectEqual(AtomClass.apolar, props.?.class);
 }
+
+// =============================================================================
+// E2E tests with real structure files
+// =============================================================================
+
+const mmcif = @import("mmcif_parser.zig");
+
+test "E2E: CCD classifier matches ProtOr on 1ubq.cif" {
+    // Parse the real 1ubq structure
+    var parser = mmcif.MmcifParser.init(std.testing.allocator);
+    var input = try parser.parseFile("examples/1ubq.cif");
+    defer input.deinit();
+    defer parser.deinitCcd();
+
+    const residues = input.residue.?;
+    const atom_names = input.atom_name.?;
+    const n = input.atomCount();
+
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    // 1ubq contains only standard amino acids, so CCD and ProtOr must agree on all atoms
+    var mismatches: usize = 0;
+    for (0..n) |i| {
+        const res = residues[i].slice();
+        const atm = atom_names[i].slice();
+
+        const ccd_r = ccd.getRadius(res, atm);
+        const protor_r = protor.getRadius(res, atm);
+
+        // Both classifiers should return a value for standard AAs
+        if (ccd_r != null and protor_r != null) {
+            if (@abs(ccd_r.? - protor_r.?) > 0.01) {
+                mismatches += 1;
+            }
+        } else if (ccd_r == null and protor_r != null) {
+            // CCD missing an atom that ProtOr knows — counts as mismatch
+            mismatches += 1;
+        } else if (ccd_r != null and protor_r == null) {
+            // CCD has an atom that ProtOr doesn't — counts as mismatch
+            mismatches += 1;
+        }
+        // Both null: neither classifier knows this atom, not a mismatch
+    }
+    try std.testing.expectEqual(@as(usize, 0), mismatches);
+}
+
+test "E2E: CCD classifier classifies all 1ubq atoms without fallback" {
+    // Parse the real 1ubq structure
+    var parser = mmcif.MmcifParser.init(std.testing.allocator);
+    var input = try parser.parseFile("examples/1ubq.cif");
+    defer input.deinit();
+    defer parser.deinitCcd();
+
+    const residues = input.residue.?;
+    const atom_names = input.atom_name.?;
+    const n = input.atomCount();
+
+    var ccd = CcdClassifier.init(std.testing.allocator);
+    defer ccd.deinit();
+
+    // For standard amino acids (which 1ubq exclusively contains),
+    // CCD classifier should never return null — no fallback needed
+    var null_count: usize = 0;
+    for (0..n) |i| {
+        const res = residues[i].slice();
+        const atm = atom_names[i].slice();
+
+        if (ccd.getRadius(res, atm) == null) {
+            null_count += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 0), null_count);
+}

--- a/src/hybridization.zig
+++ b/src/hybridization.zig
@@ -123,6 +123,7 @@ pub const Component = struct {
 pub const BondAnalysis = struct {
     hybridization: Hybridization,
     heavy_bond_count: u8,
+    heavy_valence_sum: u8,
     h_bond_count: u8,
     has_double: bool,
     has_triple: bool,
@@ -163,6 +164,18 @@ fn normalizeElement(type_symbol: []const u8, buf: *[4]u8) u3 {
     return @intCast(len);
 }
 
+/// Convert a BondOrder to its valence contribution (number of valence units consumed).
+fn bondValence(order: BondOrder) u8 {
+    return switch (order) {
+        .single => 1,
+        .double => 2,
+        .triple => 3,
+        .aromatic => 2, // simplified; CCD uses aromatic for ring bonds
+        .delocalized => 2,
+        .unknown => 1,
+    };
+}
+
 /// Analyze bonds around a given atom in a component.
 ///
 /// Iterates all bonds in the component to find those involving `atom_idx`,
@@ -172,6 +185,7 @@ pub fn analyzeBonds(component: *const Component, atom_idx: u16) BondAnalysis {
     var result = BondAnalysis{
         .hybridization = .unknown,
         .heavy_bond_count = 0,
+        .heavy_valence_sum = 0,
         .h_bond_count = 0,
         .has_double = false,
         .has_triple = false,
@@ -194,6 +208,7 @@ pub fn analyzeBonds(component: *const Component, atom_idx: u16) BondAnalysis {
                 result.h_bond_count += 1;
             } else {
                 result.heavy_bond_count += 1;
+                result.heavy_valence_sum += bondValence(bond.order);
             }
 
             switch (bond.order) {
@@ -265,17 +280,20 @@ pub fn deriveRadius(type_symbol: []const u8, hybridization: Hybridization, impli
 
 /// Derive polarity class from element symbol.
 ///
-/// N, O -> polar; C, S, P, SE -> apolar; others -> unknown.
+/// N, O, S, P, SE -> polar (matching ProtOr convention);
+/// C -> apolar; others -> unknown.
 pub fn deriveClass(type_symbol: []const u8) AtomClass {
     var buf: [4]u8 = undefined;
     const len = normalizeElement(type_symbol, &buf);
     const elem = buf[0..len];
 
-    if (std.mem.eql(u8, elem, "N") or std.mem.eql(u8, elem, "O")) return .polar;
-    if (std.mem.eql(u8, elem, "C") or
+    // N, O, S, P, SE -> polar (matching ProtOr convention)
+    if (std.mem.eql(u8, elem, "N") or
+        std.mem.eql(u8, elem, "O") or
         std.mem.eql(u8, elem, "S") or
         std.mem.eql(u8, elem, "P") or
-        std.mem.eql(u8, elem, "SE")) return .apolar;
+        std.mem.eql(u8, elem, "SE")) return .polar;
+    if (std.mem.eql(u8, elem, "C")) return .apolar;
 
     return .unknown;
 }
@@ -302,13 +320,14 @@ fn typicalValence(type_symbol: []const u8) ?u8 {
 
 /// Compute the number of implicit hydrogens for an atom.
 ///
-/// implicit_h = typical_valence - (heavy_bond_count + explicit_h_count),
-/// clamped to 0. Returns 0 if the element has no known typical valence.
-pub fn implicitHCount(type_symbol: []const u8, heavy_bond_count: u8, explicit_h_count: u8) u8 {
+/// implicit_h = typical_valence - (heavy_valence_sum + explicit_h_count),
+/// where heavy_valence_sum accounts for bond orders (double=2, triple=3, etc.).
+/// Clamped to 0. Returns 0 if the element has no known typical valence.
+pub fn implicitHCount(type_symbol: []const u8, heavy_valence_sum: u8, explicit_h_count: u8) u8 {
     const valence = typicalValence(type_symbol) orelse return 0;
-    const total_bonds = @as(u16, heavy_bond_count) + @as(u16, explicit_h_count);
-    if (total_bonds >= valence) return 0;
-    return @intCast(valence - total_bonds);
+    const total_valence = @as(u16, heavy_valence_sum) + @as(u16, explicit_h_count);
+    if (total_valence >= valence) return 0;
+    return @intCast(valence - total_valence);
 }
 
 // =============================================================================
@@ -341,7 +360,7 @@ pub fn deriveComponentProperties(
 
         const implicit_h = implicitHCount(
             atom.typeSymbolSlice(),
-            analysis.heavy_bond_count,
+            analysis.heavy_valence_sum,
             analysis.h_bond_count,
         );
 
@@ -535,13 +554,15 @@ test "deriveClass — all elements" {
     try std.testing.expectEqual(AtomClass.polar, deriveClass("n"));
     try std.testing.expectEqual(AtomClass.polar, deriveClass("o"));
 
+    // Polar (S, P, SE match ProtOr convention)
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("S"));
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("P"));
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("SE"));
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("Se"));
+
     // Apolar
     try std.testing.expectEqual(AtomClass.apolar, deriveClass("C"));
-    try std.testing.expectEqual(AtomClass.apolar, deriveClass("S"));
-    try std.testing.expectEqual(AtomClass.apolar, deriveClass("P"));
-    try std.testing.expectEqual(AtomClass.apolar, deriveClass("SE"));
     try std.testing.expectEqual(AtomClass.apolar, deriveClass("c"));
-    try std.testing.expectEqual(AtomClass.apolar, deriveClass("Se"));
 
     // Unknown
     try std.testing.expectEqual(AtomClass.unknown, deriveClass("FE"));
@@ -549,23 +570,30 @@ test "deriveClass — all elements" {
     try std.testing.expectEqual(AtomClass.unknown, deriveClass("H"));
 }
 
-test "implicitHCount — C with 3 heavy bonds" {
-    // C valence=4, 3 heavy bonds, 0 explicit H => 1 implicit H
+test "implicitHCount — C with valence sum 3" {
+    // C valence=4, heavy_valence_sum=3 (e.g. 3 single bonds), 0 explicit H => 1 implicit H
     try std.testing.expectEqual(@as(u8, 1), implicitHCount("C", 3, 0));
 }
 
-test "implicitHCount — N with 1 heavy bond" {
-    // N valence=3, 1 heavy bond, 0 explicit H => 2 implicit H
+test "implicitHCount — C with double bond" {
+    // C valence=4, heavy_valence_sum=2 (one double bond), 0 explicit H => 2 implicit H
+    try std.testing.expectEqual(@as(u8, 2), implicitHCount("C", 2, 0));
+    // C valence=4, heavy_valence_sum=4 (1 double + 2 single), 0 explicit H => 0 implicit H
+    try std.testing.expectEqual(@as(u8, 0), implicitHCount("C", 4, 0));
+}
+
+test "implicitHCount — N with valence sum 1" {
+    // N valence=3, heavy_valence_sum=1 (1 single bond), 0 explicit H => 2 implicit H
     try std.testing.expectEqual(@as(u8, 2), implicitHCount("N", 1, 0));
 }
 
 test "implicitHCount — with explicit H (=0)" {
-    // N valence=3, 1 heavy bond, 2 explicit H => 0 implicit H
+    // N valence=3, heavy_valence_sum=1, 2 explicit H => 0 implicit H
     try std.testing.expectEqual(@as(u8, 0), implicitHCount("N", 1, 2));
 }
 
 test "implicitHCount — clamped to zero" {
-    // If bonds exceed valence, result is 0
+    // If valence sum exceeds typical valence, result is 0
     try std.testing.expectEqual(@as(u8, 0), implicitHCount("C", 5, 0));
     try std.testing.expectEqual(@as(u8, 0), implicitHCount("O", 3, 0));
 }
@@ -615,14 +643,14 @@ test "deriveComponentProperties — simplified ALA" {
     for (results) |entry| {
         const name = entry.atomIdSlice();
         if (std.mem.eql(u8, name, "N")) {
-            // N: 1 heavy bond (CA), 0 H bonds
+            // N: 1 heavy bond (CA, single), heavy_valence_sum=1, 0 H bonds
             // implicit_h = 3 - (1+0) = 2
             // radius = 1.64 (N always 1.64)
             try std.testing.expectEqual(@as(f64, 1.64), entry.props.radius);
             try std.testing.expectEqual(AtomClass.polar, entry.props.class);
             found_n = true;
         } else if (std.mem.eql(u8, name, "CA")) {
-            // CA: 3 heavy bonds (N, C, CB), 0 H bonds
+            // CA: 3 heavy bonds (N, C, CB, all single), heavy_valence_sum=3, 0 H bonds
             // implicit_h = 4 - (3+0) = 1
             // hybridization = sp3 (all single bonds)
             // radius = sp3/H1+ = 1.88
@@ -630,23 +658,23 @@ test "deriveComponentProperties — simplified ALA" {
             try std.testing.expectEqual(AtomClass.apolar, entry.props.class);
             found_ca = true;
         } else if (std.mem.eql(u8, name, "C")) {
-            // C (carbonyl): 2 heavy bonds (CA, O), 0 H bonds
-            // implicit_h = 4 - (2+0) = 2
+            // C (carbonyl): 2 heavy bonds (CA single, O double), heavy_valence_sum=3, 0 H bonds
+            // implicit_h = 4 - (3+0) = 1
             // hybridization = sp2 (has double bond C=O)
             // radius = sp2/H1+ = 1.76
             try std.testing.expectEqual(@as(f64, 1.76), entry.props.radius);
             try std.testing.expectEqual(AtomClass.apolar, entry.props.class);
             found_c = true;
         } else if (std.mem.eql(u8, name, "O")) {
-            // O: 1 heavy bond (C), 0 H bonds
-            // implicit_h = 2 - (1+0) = 1
+            // O: 1 heavy bond (C, double), heavy_valence_sum=2, 0 H bonds
+            // implicit_h = 2 - (2+0) = 0
             // hybridization = sp2 (double bond C=O)
             // radius = sp2 = 1.42
             try std.testing.expectEqual(@as(f64, 1.42), entry.props.radius);
             try std.testing.expectEqual(AtomClass.polar, entry.props.class);
             found_o = true;
         } else if (std.mem.eql(u8, name, "CB")) {
-            // CB: 1 heavy bond (CA), 0 H bonds
+            // CB: 1 heavy bond (CA, single), heavy_valence_sum=1, 0 H bonds
             // implicit_h = 4 - (1+0) = 3
             // hybridization = sp3 (single bonds only)
             // radius = sp3/H1+ = 1.88

--- a/src/hybridization.zig
+++ b/src/hybridization.zig
@@ -1,0 +1,713 @@
+//! Hybridization derivation module for CCD-based atom classification.
+//!
+//! Provides pure functions for deriving ProtOr-compatible VdW radii from
+//! CCD (Chemical Component Dictionary) bond topology. Given a component's
+//! atom and bond tables, this module analyzes bond orders to determine
+//! hybridization states, then maps those to ProtOr radii and polarity classes.
+//!
+//! Reference: Tsai et al. 1999, J. Mol. Biol. 290:253-266
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const classifier = @import("classifier.zig");
+const AtomClass = classifier.AtomClass;
+const AtomProperties = classifier.AtomProperties;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/// Bond order parsed from CCD `_chem_comp_bond.value_order` strings.
+pub const BondOrder = enum {
+    single,
+    double,
+    triple,
+    aromatic,
+    delocalized,
+    unknown,
+
+    /// Parse a CCD value_order string (case-insensitive).
+    /// "SING" -> single, "DOUB" -> double, "TRIP" -> triple,
+    /// "AROM" -> aromatic, "DELO" / "POLY" -> delocalized,
+    /// anything else -> unknown.
+    pub fn fromString(s: []const u8) BondOrder {
+        if (s.len == 4) {
+            var buf: [4]u8 = undefined;
+            for (s[0..4], 0..) |c, i| {
+                buf[i] = std.ascii.toUpper(c);
+            }
+            if (std.mem.eql(u8, &buf, "SING")) return .single;
+            if (std.mem.eql(u8, &buf, "DOUB")) return .double;
+            if (std.mem.eql(u8, &buf, "TRIP")) return .triple;
+            if (std.mem.eql(u8, &buf, "AROM")) return .aromatic;
+            if (std.mem.eql(u8, &buf, "DELO")) return .delocalized;
+            if (std.mem.eql(u8, &buf, "POLY")) return .delocalized;
+        }
+        return .unknown;
+    }
+};
+
+/// Hybridization state of an atom.
+pub const Hybridization = enum {
+    sp3,
+    sp2,
+    sp,
+    unknown,
+};
+
+/// Fixed-size atom representation from a CCD component.
+pub const CompAtom = struct {
+    atom_id: [4]u8,
+    atom_id_len: u3,
+    type_symbol: [4]u8,
+    type_symbol_len: u3,
+    aromatic: bool,
+    leaving: bool,
+
+    /// Construct a CompAtom from slices (truncates to max field sizes).
+    pub fn init(atom_id: []const u8, type_symbol: []const u8) CompAtom {
+        var self: CompAtom = undefined;
+        self.aromatic = false;
+        self.leaving = false;
+
+        const aid_len: usize = @min(atom_id.len, 4);
+        self.atom_id = .{ 0, 0, 0, 0 };
+        self.atom_id_len = @intCast(aid_len);
+        for (atom_id[0..aid_len], 0..) |c, i| {
+            self.atom_id[i] = c;
+        }
+
+        const ts_len: usize = @min(type_symbol.len, 4);
+        self.type_symbol = .{ 0, 0, 0, 0 };
+        self.type_symbol_len = @intCast(ts_len);
+        for (type_symbol[0..ts_len], 0..) |c, i| {
+            self.type_symbol[i] = c;
+        }
+
+        return self;
+    }
+
+    /// Get the atom_id as a slice.
+    pub fn atomIdSlice(self: *const CompAtom) []const u8 {
+        return self.atom_id[0..self.atom_id_len];
+    }
+
+    /// Get the type_symbol as a slice.
+    pub fn typeSymbolSlice(self: *const CompAtom) []const u8 {
+        return self.type_symbol[0..self.type_symbol_len];
+    }
+};
+
+/// Bond between two atoms in a CCD component.
+pub const CompBond = struct {
+    atom_idx_1: u16,
+    atom_idx_2: u16,
+    order: BondOrder,
+    aromatic: bool,
+};
+
+/// A CCD component (residue/ligand) with atoms and bonds.
+pub const Component = struct {
+    comp_id: [5]u8,
+    comp_id_len: u3,
+    atoms: []const CompAtom,
+    bonds: []const CompBond,
+
+    /// Get the comp_id as a slice.
+    pub fn compIdSlice(self: *const Component) []const u8 {
+        return self.comp_id[0..self.comp_id_len];
+    }
+};
+
+/// Result of analyzing bonds around a single atom.
+pub const BondAnalysis = struct {
+    hybridization: Hybridization,
+    heavy_bond_count: u8,
+    h_bond_count: u8,
+    has_double: bool,
+    has_triple: bool,
+    has_aromatic: bool,
+};
+
+/// Result entry from deriveComponentProperties.
+pub const DerivedAtomEntry = struct {
+    atom_id: [4]u8,
+    atom_id_len: u3,
+    props: AtomProperties,
+
+    pub fn atomIdSlice(self: *const DerivedAtomEntry) []const u8 {
+        return self.atom_id[0..self.atom_id_len];
+    }
+};
+
+// =============================================================================
+// Bond Analysis
+// =============================================================================
+
+/// Check if a type_symbol represents hydrogen (case-insensitive).
+fn isHydrogen(type_symbol: []const u8) bool {
+    if (type_symbol.len == 1) {
+        return type_symbol[0] == 'H' or type_symbol[0] == 'h';
+    }
+    return false;
+}
+
+/// Normalize an element symbol to uppercase into a fixed buffer.
+/// Returns the length of the normalized symbol.
+fn normalizeElement(type_symbol: []const u8, buf: *[4]u8) u3 {
+    const trimmed = std.mem.trim(u8, type_symbol, " ");
+    const len: usize = @min(trimmed.len, 4);
+    for (trimmed[0..len], 0..) |c, i| {
+        buf[i] = std.ascii.toUpper(c);
+    }
+    return @intCast(len);
+}
+
+/// Analyze bonds around a given atom in a component.
+///
+/// Iterates all bonds in the component to find those involving `atom_idx`,
+/// counts heavy-atom vs hydrogen neighbors, and detects double/triple/aromatic
+/// bonds to determine hybridization.
+pub fn analyzeBonds(component: *const Component, atom_idx: u16) BondAnalysis {
+    var result = BondAnalysis{
+        .hybridization = .unknown,
+        .heavy_bond_count = 0,
+        .h_bond_count = 0,
+        .has_double = false,
+        .has_triple = false,
+        .has_aromatic = false,
+    };
+
+    for (component.bonds) |bond| {
+        const neighbor_idx: ?u16 = if (bond.atom_idx_1 == atom_idx)
+            bond.atom_idx_2
+        else if (bond.atom_idx_2 == atom_idx)
+            bond.atom_idx_1
+        else
+            null;
+
+        if (neighbor_idx) |nidx| {
+            if (nidx >= component.atoms.len) continue;
+
+            const neighbor = &component.atoms[nidx];
+            if (isHydrogen(neighbor.typeSymbolSlice())) {
+                result.h_bond_count += 1;
+            } else {
+                result.heavy_bond_count += 1;
+            }
+
+            switch (bond.order) {
+                .double => result.has_double = true,
+                .triple => result.has_triple = true,
+                .aromatic => result.has_aromatic = true,
+                .delocalized => result.has_double = true,
+                else => {},
+            }
+
+            if (bond.aromatic) {
+                result.has_aromatic = true;
+            }
+        }
+    }
+
+    // Determine hybridization from bond analysis
+    if (result.has_triple) {
+        result.hybridization = .sp;
+    } else if (result.has_double or result.has_aromatic) {
+        result.hybridization = .sp2;
+    } else if (result.heavy_bond_count > 0 or result.h_bond_count > 0) {
+        result.hybridization = .sp3;
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Radius Derivation (ProtOr table)
+// =============================================================================
+
+/// Derive ProtOr-compatible VdW radius from element, hybridization, and
+/// implicit hydrogen count.
+///
+/// Returns null for elements not in the ProtOr table.
+pub fn deriveRadius(type_symbol: []const u8, hybridization: Hybridization, implicit_h: u8) ?f64 {
+    var buf: [4]u8 = undefined;
+    const len = normalizeElement(type_symbol, &buf);
+    const elem = buf[0..len];
+
+    if (std.mem.eql(u8, elem, "C")) {
+        return switch (hybridization) {
+            .sp2 => if (implicit_h == 0) 1.61 else 1.76,
+            .sp3 => if (implicit_h == 0) 1.61 else 1.88,
+            .sp => 1.61,
+            .unknown => 1.88,
+        };
+    }
+    if (std.mem.eql(u8, elem, "N")) return 1.64;
+    if (std.mem.eql(u8, elem, "O")) {
+        return switch (hybridization) {
+            .sp2 => 1.42,
+            .sp3 => 1.46,
+            .sp => 1.42,
+            .unknown => 1.42,
+        };
+    }
+    if (std.mem.eql(u8, elem, "S")) return 1.77;
+    if (std.mem.eql(u8, elem, "P")) return 1.80;
+    if (std.mem.eql(u8, elem, "SE")) return 1.90;
+
+    return null;
+}
+
+// =============================================================================
+// Atom Class Derivation
+// =============================================================================
+
+/// Derive polarity class from element symbol.
+///
+/// N, O -> polar; C, S, P, SE -> apolar; others -> unknown.
+pub fn deriveClass(type_symbol: []const u8) AtomClass {
+    var buf: [4]u8 = undefined;
+    const len = normalizeElement(type_symbol, &buf);
+    const elem = buf[0..len];
+
+    if (std.mem.eql(u8, elem, "N") or std.mem.eql(u8, elem, "O")) return .polar;
+    if (std.mem.eql(u8, elem, "C") or
+        std.mem.eql(u8, elem, "S") or
+        std.mem.eql(u8, elem, "P") or
+        std.mem.eql(u8, elem, "SE")) return .apolar;
+
+    return .unknown;
+}
+
+// =============================================================================
+// Valence / Implicit Hydrogen
+// =============================================================================
+
+/// Typical valence for common biological elements.
+fn typicalValence(type_symbol: []const u8) ?u8 {
+    var buf: [4]u8 = undefined;
+    const len = normalizeElement(type_symbol, &buf);
+    const elem = buf[0..len];
+
+    if (std.mem.eql(u8, elem, "C")) return 4;
+    if (std.mem.eql(u8, elem, "N")) return 3;
+    if (std.mem.eql(u8, elem, "O")) return 2;
+    if (std.mem.eql(u8, elem, "S")) return 2;
+    if (std.mem.eql(u8, elem, "P")) return 5;
+    if (std.mem.eql(u8, elem, "SE")) return 2;
+
+    return null;
+}
+
+/// Compute the number of implicit hydrogens for an atom.
+///
+/// implicit_h = typical_valence - (heavy_bond_count + explicit_h_count),
+/// clamped to 0. Returns 0 if the element has no known typical valence.
+pub fn implicitHCount(type_symbol: []const u8, heavy_bond_count: u8, explicit_h_count: u8) u8 {
+    const valence = typicalValence(type_symbol) orelse return 0;
+    const total_bonds = @as(u16, heavy_bond_count) + @as(u16, explicit_h_count);
+    if (total_bonds >= valence) return 0;
+    return @intCast(valence - total_bonds);
+}
+
+// =============================================================================
+// Component-Level Derivation
+// =============================================================================
+
+/// Derive ProtOr-compatible atom properties for all non-hydrogen atoms
+/// in a component.
+///
+/// For each non-hydrogen atom:
+/// 1. Analyze bonds to determine hybridization
+/// 2. Compute implicit hydrogen count
+/// 3. Derive ProtOr radius and polarity class
+/// 4. Skip atoms where deriveRadius returns null (unsupported elements)
+///
+/// Returns an owned slice that the caller must free with the same allocator.
+pub fn deriveComponentProperties(
+    allocator: Allocator,
+    component: *const Component,
+) ![]const DerivedAtomEntry {
+    var results = std.ArrayListUnmanaged(DerivedAtomEntry){};
+    errdefer results.deinit(allocator);
+
+    for (component.atoms, 0..) |atom, idx| {
+        // Skip hydrogen atoms
+        if (isHydrogen(atom.typeSymbolSlice())) continue;
+
+        const atom_idx: u16 = @intCast(idx);
+        const analysis = analyzeBonds(component, atom_idx);
+
+        const implicit_h = implicitHCount(
+            atom.typeSymbolSlice(),
+            analysis.heavy_bond_count,
+            analysis.h_bond_count,
+        );
+
+        const radius = deriveRadius(
+            atom.typeSymbolSlice(),
+            analysis.hybridization,
+            implicit_h,
+        ) orelse continue; // skip unsupported elements
+
+        const class = deriveClass(atom.typeSymbolSlice());
+
+        try results.append(allocator, .{
+            .atom_id = atom.atom_id,
+            .atom_id_len = atom.atom_id_len,
+            .props = .{
+                .radius = radius,
+                .class = class,
+            },
+        });
+    }
+
+    return results.toOwnedSlice(allocator);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "BondOrder.fromString — all variants and case insensitivity" {
+    // Standard uppercase
+    try std.testing.expectEqual(BondOrder.single, BondOrder.fromString("SING"));
+    try std.testing.expectEqual(BondOrder.double, BondOrder.fromString("DOUB"));
+    try std.testing.expectEqual(BondOrder.triple, BondOrder.fromString("TRIP"));
+    try std.testing.expectEqual(BondOrder.aromatic, BondOrder.fromString("AROM"));
+    try std.testing.expectEqual(BondOrder.delocalized, BondOrder.fromString("DELO"));
+    try std.testing.expectEqual(BondOrder.delocalized, BondOrder.fromString("POLY"));
+
+    // Case insensitivity
+    try std.testing.expectEqual(BondOrder.single, BondOrder.fromString("sing"));
+    try std.testing.expectEqual(BondOrder.double, BondOrder.fromString("Doub"));
+    try std.testing.expectEqual(BondOrder.triple, BondOrder.fromString("tRiP"));
+    try std.testing.expectEqual(BondOrder.aromatic, BondOrder.fromString("arom"));
+
+    // Unknown
+    try std.testing.expectEqual(BondOrder.unknown, BondOrder.fromString("XXXX"));
+    try std.testing.expectEqual(BondOrder.unknown, BondOrder.fromString(""));
+    try std.testing.expectEqual(BondOrder.unknown, BondOrder.fromString("SI"));
+}
+
+test "analyzeBonds — sp3 atom (ALA CA)" {
+    // ALA CA: bonded to N(single), C(single), CB(single), HA(single)
+    // => sp3, 3 heavy, 1 H, no double/triple/aromatic
+    const atoms = [_]CompAtom{
+        CompAtom.init("N", "N"), // 0
+        CompAtom.init("CA", "C"), // 1
+        CompAtom.init("C", "C"), // 2
+        CompAtom.init("CB", "C"), // 3
+        CompAtom.init("HA", "H"), // 4
+    };
+    const bonds = [_]CompBond{
+        .{ .atom_idx_1 = 0, .atom_idx_2 = 1, .order = .single, .aromatic = false }, // N-CA
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 2, .order = .single, .aromatic = false }, // CA-C
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 3, .order = .single, .aromatic = false }, // CA-CB
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 4, .order = .single, .aromatic = false }, // CA-HA
+    };
+    const comp = Component{
+        .comp_id = .{ 'A', 'L', 'A', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = &atoms,
+        .bonds = &bonds,
+    };
+
+    const result = analyzeBonds(&comp, 1); // CA
+    try std.testing.expectEqual(Hybridization.sp3, result.hybridization);
+    try std.testing.expectEqual(@as(u8, 3), result.heavy_bond_count);
+    try std.testing.expectEqual(@as(u8, 1), result.h_bond_count);
+    try std.testing.expect(!result.has_double);
+    try std.testing.expect(!result.has_triple);
+    try std.testing.expect(!result.has_aromatic);
+}
+
+test "analyzeBonds — sp2 atom (carbonyl C)" {
+    // Carbonyl C: bonded to CA(single), O(double), N_next(single)
+    // => sp2, 3 heavy, 0 H, has_double=true
+    const atoms = [_]CompAtom{
+        CompAtom.init("CA", "C"), // 0
+        CompAtom.init("C", "C"), // 1
+        CompAtom.init("O", "O"), // 2
+        CompAtom.init("N", "N"), // 3 (next residue's N, modeled in same component)
+    };
+    const bonds = [_]CompBond{
+        .{ .atom_idx_1 = 0, .atom_idx_2 = 1, .order = .single, .aromatic = false }, // CA-C
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 2, .order = .double, .aromatic = false }, // C=O
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 3, .order = .single, .aromatic = false }, // C-N
+    };
+    const comp = Component{
+        .comp_id = .{ 'A', 'L', 'A', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = &atoms,
+        .bonds = &bonds,
+    };
+
+    const result = analyzeBonds(&comp, 1); // C
+    try std.testing.expectEqual(Hybridization.sp2, result.hybridization);
+    try std.testing.expectEqual(@as(u8, 3), result.heavy_bond_count);
+    try std.testing.expectEqual(@as(u8, 0), result.h_bond_count);
+    try std.testing.expect(result.has_double);
+    try std.testing.expect(!result.has_triple);
+    try std.testing.expect(!result.has_aromatic);
+}
+
+test "analyzeBonds — aromatic atom" {
+    // PHE CG: aromatic ring atom bonded to CB(single), CD1(arom), CD2(arom)
+    const atoms = [_]CompAtom{
+        CompAtom.init("CB", "C"), // 0
+        CompAtom.init("CG", "C"), // 1
+        CompAtom.init("CD1", "C"), // 2
+        CompAtom.init("CD2", "C"), // 3
+    };
+    const bonds = [_]CompBond{
+        .{ .atom_idx_1 = 0, .atom_idx_2 = 1, .order = .single, .aromatic = false }, // CB-CG
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 2, .order = .aromatic, .aromatic = true }, // CG-CD1
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 3, .order = .aromatic, .aromatic = true }, // CG-CD2
+    };
+    const comp = Component{
+        .comp_id = .{ 'P', 'H', 'E', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = &atoms,
+        .bonds = &bonds,
+    };
+
+    const result = analyzeBonds(&comp, 1); // CG
+    try std.testing.expectEqual(Hybridization.sp2, result.hybridization);
+    try std.testing.expectEqual(@as(u8, 3), result.heavy_bond_count);
+    try std.testing.expectEqual(@as(u8, 0), result.h_bond_count);
+    try std.testing.expect(!result.has_double);
+    try std.testing.expect(!result.has_triple);
+    try std.testing.expect(result.has_aromatic);
+}
+
+test "deriveRadius — all element/hybridization combos" {
+    // Carbon
+    try std.testing.expectEqual(@as(?f64, 1.61), deriveRadius("C", .sp2, 0));
+    try std.testing.expectEqual(@as(?f64, 1.76), deriveRadius("C", .sp2, 1));
+    try std.testing.expectEqual(@as(?f64, 1.76), deriveRadius("C", .sp2, 2));
+    try std.testing.expectEqual(@as(?f64, 1.61), deriveRadius("C", .sp3, 0));
+    try std.testing.expectEqual(@as(?f64, 1.88), deriveRadius("C", .sp3, 1));
+    try std.testing.expectEqual(@as(?f64, 1.88), deriveRadius("C", .sp3, 2));
+    try std.testing.expectEqual(@as(?f64, 1.88), deriveRadius("C", .sp3, 3));
+    try std.testing.expectEqual(@as(?f64, 1.61), deriveRadius("C", .sp, 0));
+    try std.testing.expectEqual(@as(?f64, 1.88), deriveRadius("C", .unknown, 0));
+
+    // Nitrogen (always 1.64)
+    try std.testing.expectEqual(@as(?f64, 1.64), deriveRadius("N", .sp2, 0));
+    try std.testing.expectEqual(@as(?f64, 1.64), deriveRadius("N", .sp3, 1));
+    try std.testing.expectEqual(@as(?f64, 1.64), deriveRadius("N", .sp, 0));
+    try std.testing.expectEqual(@as(?f64, 1.64), deriveRadius("N", .unknown, 0));
+
+    // Oxygen
+    try std.testing.expectEqual(@as(?f64, 1.42), deriveRadius("O", .sp2, 0));
+    try std.testing.expectEqual(@as(?f64, 1.46), deriveRadius("O", .sp3, 0));
+    try std.testing.expectEqual(@as(?f64, 1.42), deriveRadius("O", .sp, 0));
+    try std.testing.expectEqual(@as(?f64, 1.42), deriveRadius("O", .unknown, 0));
+
+    // Sulfur (always 1.77)
+    try std.testing.expectEqual(@as(?f64, 1.77), deriveRadius("S", .sp3, 0));
+    try std.testing.expectEqual(@as(?f64, 1.77), deriveRadius("S", .sp2, 0));
+
+    // Phosphorus (always 1.80)
+    try std.testing.expectEqual(@as(?f64, 1.80), deriveRadius("P", .sp3, 0));
+
+    // Selenium (always 1.90)
+    try std.testing.expectEqual(@as(?f64, 1.90), deriveRadius("SE", .sp3, 0));
+
+    // Case insensitivity
+    try std.testing.expectEqual(@as(?f64, 1.61), deriveRadius("c", .sp2, 0));
+    try std.testing.expectEqual(@as(?f64, 1.64), deriveRadius("n", .sp3, 0));
+    try std.testing.expectEqual(@as(?f64, 1.90), deriveRadius("Se", .sp3, 0));
+}
+
+test "deriveRadius — unknown element returns null" {
+    try std.testing.expectEqual(@as(?f64, null), deriveRadius("FE", .sp3, 0));
+    try std.testing.expectEqual(@as(?f64, null), deriveRadius("ZN", .sp3, 0));
+    try std.testing.expectEqual(@as(?f64, null), deriveRadius("XX", .sp3, 0));
+}
+
+test "deriveClass — all elements" {
+    // Polar
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("N"));
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("O"));
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("n"));
+    try std.testing.expectEqual(AtomClass.polar, deriveClass("o"));
+
+    // Apolar
+    try std.testing.expectEqual(AtomClass.apolar, deriveClass("C"));
+    try std.testing.expectEqual(AtomClass.apolar, deriveClass("S"));
+    try std.testing.expectEqual(AtomClass.apolar, deriveClass("P"));
+    try std.testing.expectEqual(AtomClass.apolar, deriveClass("SE"));
+    try std.testing.expectEqual(AtomClass.apolar, deriveClass("c"));
+    try std.testing.expectEqual(AtomClass.apolar, deriveClass("Se"));
+
+    // Unknown
+    try std.testing.expectEqual(AtomClass.unknown, deriveClass("FE"));
+    try std.testing.expectEqual(AtomClass.unknown, deriveClass("ZN"));
+    try std.testing.expectEqual(AtomClass.unknown, deriveClass("H"));
+}
+
+test "implicitHCount — C with 3 heavy bonds" {
+    // C valence=4, 3 heavy bonds, 0 explicit H => 1 implicit H
+    try std.testing.expectEqual(@as(u8, 1), implicitHCount("C", 3, 0));
+}
+
+test "implicitHCount — N with 1 heavy bond" {
+    // N valence=3, 1 heavy bond, 0 explicit H => 2 implicit H
+    try std.testing.expectEqual(@as(u8, 2), implicitHCount("N", 1, 0));
+}
+
+test "implicitHCount — with explicit H (=0)" {
+    // N valence=3, 1 heavy bond, 2 explicit H => 0 implicit H
+    try std.testing.expectEqual(@as(u8, 0), implicitHCount("N", 1, 2));
+}
+
+test "implicitHCount — clamped to zero" {
+    // If bonds exceed valence, result is 0
+    try std.testing.expectEqual(@as(u8, 0), implicitHCount("C", 5, 0));
+    try std.testing.expectEqual(@as(u8, 0), implicitHCount("O", 3, 0));
+}
+
+test "implicitHCount — unknown element returns 0" {
+    try std.testing.expectEqual(@as(u8, 0), implicitHCount("FE", 2, 0));
+}
+
+test "deriveComponentProperties — simplified ALA" {
+    // Simplified ALA without H atoms: N, CA, C, O, CB
+    // Bonds: N-CA(single), CA-C(single), C=O(double), CA-CB(single)
+    // Plus backbone N-C bond for completeness: not included since
+    // this is intra-residue only.
+    const atoms = [_]CompAtom{
+        CompAtom.init("N", "N"), // 0: N
+        CompAtom.init("CA", "C"), // 1: CA
+        CompAtom.init("C", "C"), // 2: C (carbonyl)
+        CompAtom.init("O", "O"), // 3: O
+        CompAtom.init("CB", "C"), // 4: CB
+    };
+    const bonds = [_]CompBond{
+        .{ .atom_idx_1 = 0, .atom_idx_2 = 1, .order = .single, .aromatic = false }, // N-CA
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 2, .order = .single, .aromatic = false }, // CA-C
+        .{ .atom_idx_1 = 2, .atom_idx_2 = 3, .order = .double, .aromatic = false }, // C=O
+        .{ .atom_idx_1 = 1, .atom_idx_2 = 4, .order = .single, .aromatic = false }, // CA-CB
+    };
+    const comp = Component{
+        .comp_id = .{ 'A', 'L', 'A', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = &atoms,
+        .bonds = &bonds,
+    };
+
+    const results = try deriveComponentProperties(std.testing.allocator, &comp);
+    defer std.testing.allocator.free(results);
+
+    // Should have 5 non-hydrogen atoms, all with known radii
+    try std.testing.expectEqual(@as(usize, 5), results.len);
+
+    // Build a lookup by atom_id for easier assertions
+    var found_n = false;
+    var found_ca = false;
+    var found_c = false;
+    var found_o = false;
+    var found_cb = false;
+
+    for (results) |entry| {
+        const name = entry.atomIdSlice();
+        if (std.mem.eql(u8, name, "N")) {
+            // N: 1 heavy bond (CA), 0 H bonds
+            // implicit_h = 3 - (1+0) = 2
+            // radius = 1.64 (N always 1.64)
+            try std.testing.expectEqual(@as(f64, 1.64), entry.props.radius);
+            try std.testing.expectEqual(AtomClass.polar, entry.props.class);
+            found_n = true;
+        } else if (std.mem.eql(u8, name, "CA")) {
+            // CA: 3 heavy bonds (N, C, CB), 0 H bonds
+            // implicit_h = 4 - (3+0) = 1
+            // hybridization = sp3 (all single bonds)
+            // radius = sp3/H1+ = 1.88
+            try std.testing.expectEqual(@as(f64, 1.88), entry.props.radius);
+            try std.testing.expectEqual(AtomClass.apolar, entry.props.class);
+            found_ca = true;
+        } else if (std.mem.eql(u8, name, "C")) {
+            // C (carbonyl): 2 heavy bonds (CA, O), 0 H bonds
+            // implicit_h = 4 - (2+0) = 2
+            // hybridization = sp2 (has double bond C=O)
+            // radius = sp2/H1+ = 1.76
+            try std.testing.expectEqual(@as(f64, 1.76), entry.props.radius);
+            try std.testing.expectEqual(AtomClass.apolar, entry.props.class);
+            found_c = true;
+        } else if (std.mem.eql(u8, name, "O")) {
+            // O: 1 heavy bond (C), 0 H bonds
+            // implicit_h = 2 - (1+0) = 1
+            // hybridization = sp2 (double bond C=O)
+            // radius = sp2 = 1.42
+            try std.testing.expectEqual(@as(f64, 1.42), entry.props.radius);
+            try std.testing.expectEqual(AtomClass.polar, entry.props.class);
+            found_o = true;
+        } else if (std.mem.eql(u8, name, "CB")) {
+            // CB: 1 heavy bond (CA), 0 H bonds
+            // implicit_h = 4 - (1+0) = 3
+            // hybridization = sp3 (single bonds only)
+            // radius = sp3/H1+ = 1.88
+            try std.testing.expectEqual(@as(f64, 1.88), entry.props.radius);
+            try std.testing.expectEqual(AtomClass.apolar, entry.props.class);
+            found_cb = true;
+        }
+    }
+
+    try std.testing.expect(found_n);
+    try std.testing.expect(found_ca);
+    try std.testing.expect(found_c);
+    try std.testing.expect(found_o);
+    try std.testing.expect(found_cb);
+}
+
+test "deriveComponentProperties — skips hydrogen atoms and unknown elements" {
+    const atoms = [_]CompAtom{
+        CompAtom.init("C1", "C"), // 0
+        CompAtom.init("H1", "H"), // 1 (hydrogen, should be skipped)
+        CompAtom.init("FE", "FE"), // 2 (unknown element, should be skipped)
+    };
+    const bonds = [_]CompBond{
+        .{ .atom_idx_1 = 0, .atom_idx_2 = 1, .order = .single, .aromatic = false },
+    };
+    const comp = Component{
+        .comp_id = .{ 'T', 'S', 'T', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = &atoms,
+        .bonds = &bonds,
+    };
+
+    const results = try deriveComponentProperties(std.testing.allocator, &comp);
+    defer std.testing.allocator.free(results);
+
+    // Only C1 should appear (H1 is hydrogen, FE has no ProtOr radius)
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqualStrings("C1", results[0].atomIdSlice());
+}
+
+test "CompAtom init and accessors" {
+    const atom = CompAtom.init("CA", "C");
+    try std.testing.expectEqualStrings("CA", atom.atomIdSlice());
+    try std.testing.expectEqualStrings("C", atom.typeSymbolSlice());
+    try std.testing.expect(!atom.aromatic);
+    try std.testing.expect(!atom.leaving);
+}
+
+test "CompAtom truncation" {
+    // atom_id max is 4, type_symbol max is 4
+    const atom = CompAtom.init("TOOLONG", "VERYLONGELEMENT");
+    try std.testing.expectEqualStrings("TOOL", atom.atomIdSlice());
+    try std.testing.expectEqualStrings("VERY", atom.typeSymbolSlice());
+}
+
+test "Component compIdSlice" {
+    const comp = Component{
+        .comp_id = .{ 'A', 'L', 'A', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = &.{},
+        .bonds = &.{},
+    };
+    try std.testing.expectEqualStrings("ALA", comp.compIdSlice());
+}

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -35,6 +35,7 @@ const mmap_reader = @import("mmap_reader.zig");
 const gzip = @import("gzip.zig");
 const types = @import("types.zig");
 const AtomInput = types.AtomInput;
+const ccd_parser = @import("ccd_parser.zig");
 
 /// Error types for mmCIF parsing
 pub const ParseError = error{
@@ -116,24 +117,59 @@ pub const MmcifParser = struct {
     chain_filter: ?[]const []const u8 = null,
     /// Use auth_asym_id instead of label_asym_id for chain
     use_auth_chain: bool = false,
+    /// Inline CCD data parsed from `_chem_comp_atom`/`_chem_comp_bond` loops
+    inline_ccd: ?ccd_parser.ComponentDict = null,
 
     pub fn init(allocator: Allocator) MmcifParser {
         return .{ .allocator = allocator };
     }
 
+    /// Return a pointer to the inline CCD data, or null if none was parsed.
+    pub fn getInlineCcd(self: *MmcifParser) ?*ccd_parser.ComponentDict {
+        if (self.inline_ccd != null) return &self.inline_ccd.?;
+        return null;
+    }
+
+    /// Clean up inline CCD data. Must be called before the parser goes out of
+    /// scope when `parse()` has been called and `getInlineCcd()` is non-null.
+    pub fn deinitCcd(self: *MmcifParser) void {
+        if (self.inline_ccd) |*dict| {
+            dict.deinit();
+            self.inline_ccd = null;
+        }
+    }
+
     /// Parse mmCIF from a string
     pub fn parse(self: *MmcifParser, source: []const u8) !AtomInput {
+        // First pass: extract any inline CCD data (_chem_comp_atom / _chem_comp_bond)
+        var ccd_dict = try ccd_parser.parseCcdData(self.allocator, source, null);
+        if (ccd_dict.count() == 0) {
+            ccd_dict.deinit();
+            self.inline_ccd = null;
+        } else {
+            self.inline_ccd = ccd_dict;
+        }
+
+        // Second pass: parse _atom_site loop for coordinates
         var tokenizer = cif.Tokenizer.init(source);
 
         // Skip to atom_site loop
-        const loop_info = try self.findAtomSiteLoop(&tokenizer);
+        const loop_info = self.findAtomSiteLoop(&tokenizer) catch |err| {
+            // Clean up CCD data on failure
+            self.deinitCcd();
+            return err;
+        };
 
         if (!loop_info.columns.hasRequiredFields()) {
+            self.deinitCcd();
             return ParseError.MissingCoordinateField;
         }
 
         // Parse atom data
-        return try self.parseAtomData(&tokenizer, loop_info.columns, loop_info.num_cols);
+        return self.parseAtomData(&tokenizer, loop_info.columns, loop_info.num_cols) catch |err| {
+            self.deinitCcd();
+            return err;
+        };
     }
 
     /// Parse mmCIF from a file (handles both plain and .gz compressed)
@@ -831,6 +867,7 @@ test "fuzz mmcif parser" {
     try std.testing.fuzz({}, struct {
         fn testOne(_: void, input: []const u8) !void {
             var parser = MmcifParser.init(std.testing.allocator);
+            defer parser.deinitCcd();
             var result = parser.parse(input) catch return;
             result.deinit();
         }
@@ -841,4 +878,164 @@ test "fuzz mmcif parser" {
             "data_TEST\nloop_\n_cell.length_a\n_cell.length_b\n10.0 20.0\n#\n",
         },
     });
+}
+
+test "parse mmCIF with inline CCD data" {
+    // A mmCIF file containing both _chem_comp_atom/_chem_comp_bond AND _atom_site loops
+    const source =
+        \\data_TEST
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\_chem_comp_atom.pdbx_aromatic_flag
+        \\_chem_comp_atom.pdbx_leaving_atom_flag
+        \\ALA N   N N N
+        \\ALA CA  C N N
+        \\ALA C   C N N
+        \\ALA O   O N N
+        \\ALA CB  C N N
+        \\ALA OXT O N Y
+        \\#
+        \\loop_
+        \\_chem_comp_bond.comp_id
+        \\_chem_comp_bond.atom_id_1
+        \\_chem_comp_bond.atom_id_2
+        \\_chem_comp_bond.value_order
+        \\ALA N   CA  SING
+        \\ALA CA  C   SING
+        \\ALA CA  CB  SING
+        \\ALA C   O   DOUB
+        \\ALA C   OXT SING
+        \\#
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.group_PDB
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 N N  ALA ATOM 10.0 20.0 30.0
+        \\2 C CA ALA ATOM 11.0 21.0 31.0
+        \\3 C C  ALA ATOM 12.0 22.0 32.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    defer parser.deinitCcd();
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    // Verify atom_site parsing works as normal
+    try std.testing.expectEqual(@as(usize, 3), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+
+    // Verify inline CCD was parsed
+    const ccd = parser.getInlineCcd();
+    try std.testing.expect(ccd != null);
+    try std.testing.expectEqual(@as(usize, 1), ccd.?.count());
+
+    const comp = ccd.?.get("ALA");
+    try std.testing.expect(comp != null);
+    try std.testing.expectEqual(@as(usize, 6), comp.?.atoms.len);
+    try std.testing.expectEqual(@as(usize, 5), comp.?.bonds.len);
+
+    // Verify OXT is a leaving atom
+    var found_oxt = false;
+    for (comp.?.atoms) |atom| {
+        if (std.mem.eql(u8, atom.atomIdSlice(), "OXT")) {
+            try std.testing.expect(atom.leaving);
+            found_oxt = true;
+        }
+    }
+    try std.testing.expect(found_oxt);
+}
+
+test "parse mmCIF without inline CCD — getInlineCcd returns null" {
+    const source =
+        \\data_TEST
+        \\#
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CA ALA 10.0 20.0 30.0
+        \\2 N N  ALA 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    defer parser.deinitCcd();
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    // No CCD loops present, so inline_ccd should be null
+    try std.testing.expect(parser.getInlineCcd() == null);
+
+    // Normal parsing still works
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+}
+
+test "parse mmCIF with inline CCD after atom_site" {
+    // CCD loops come AFTER the _atom_site loop
+    const source =
+        \\data_TEST
+        \\#
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.group_PDB
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 N N  GLY ATOM 10.0 20.0 30.0
+        \\2 C CA GLY ATOM 11.0 21.0 31.0
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\GLY N  N
+        \\GLY CA C
+        \\GLY C  C
+        \\GLY O  O
+        \\#
+        \\loop_
+        \\_chem_comp_bond.comp_id
+        \\_chem_comp_bond.atom_id_1
+        \\_chem_comp_bond.atom_id_2
+        \\_chem_comp_bond.value_order
+        \\GLY N  CA SING
+        \\GLY CA C  SING
+        \\GLY C  O  DOUB
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    defer parser.deinitCcd();
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    // Atom coordinates parsed correctly
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+
+    // CCD data parsed even though it was after atom_site
+    const ccd = parser.getInlineCcd();
+    try std.testing.expect(ccd != null);
+    try std.testing.expectEqual(@as(usize, 1), ccd.?.count());
+
+    const comp = ccd.?.get("GLY");
+    try std.testing.expect(comp != null);
+    try std.testing.expectEqual(@as(usize, 4), comp.?.atoms.len);
+    try std.testing.expectEqual(@as(usize, 3), comp.?.bonds.len);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -38,6 +38,7 @@ pub const bitmask_lut = @import("bitmask_lut.zig");
 pub const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
 pub const gzip = @import("gzip.zig");
 pub const hybridization = @import("hybridization.zig");
+pub const ccd_parser = @import("ccd_parser.zig");
 
 test {
     _ = shrake_rupley;
@@ -55,4 +56,5 @@ test {
     _ = shrake_rupley_bitmask;
     _ = gzip;
     _ = hybridization;
+    _ = ccd_parser;
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -39,6 +39,7 @@ pub const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
 pub const gzip = @import("gzip.zig");
 pub const hybridization = @import("hybridization.zig");
 pub const ccd_parser = @import("ccd_parser.zig");
+pub const classifier_ccd = @import("classifier_ccd.zig");
 
 test {
     _ = shrake_rupley;
@@ -57,4 +58,5 @@ test {
     _ = gzip;
     _ = hybridization;
     _ = ccd_parser;
+    _ = classifier_ccd;
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -37,6 +37,7 @@ pub const dcd = @import("dcd.zig");
 pub const bitmask_lut = @import("bitmask_lut.zig");
 pub const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
 pub const gzip = @import("gzip.zig");
+pub const hybridization = @import("hybridization.zig");
 
 test {
     _ = shrake_rupley;
@@ -53,4 +54,5 @@ test {
     _ = bitmask_lut;
     _ = shrake_rupley_bitmask;
     _ = gzip;
+    _ = hybridization;
 }

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -19,6 +19,7 @@ const classifier = @import("classifier.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_protor = @import("classifier_protor.zig");
 const classifier_oons = @import("classifier_oons.zig");
+const classifier_ccd = @import("classifier_ccd.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -310,7 +311,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\OPTIONS:
         \\    --algorithm=ALGO   Algorithm: sr (shrake-rupley), lr (lee-richards)
         \\                       Default: sr
-        \\    --classifier=TYPE  Built-in classifier: naccess, protor, oons
+        \\    --classifier=TYPE  Built-in classifier: naccess, protor, oons, ccd
         \\    --threads=N        Number of threads (default: auto-detect)
         \\    --probe-radius=R   Probe radius in Angstroms (default: 1.4)
         \\    --n-points=N       Test points per atom (default: 100, for sr)
@@ -1031,6 +1032,10 @@ fn applyBuiltinClassifier(
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
+    // For CCD: create classifier instance (hardcoded table is compile-time, no setup cost)
+    var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd) classifier_ccd.CcdClassifier.init(input.allocator) else null;
+    defer if (ccd_clf) |*c| c.deinit();
+
     var classified_count: usize = 0;
     var fallback_count: usize = 0;
 
@@ -1039,6 +1044,7 @@ fn applyBuiltinClassifier(
             .naccess => classifier_naccess.getRadius(residues[i].slice(), atom_names[i].slice()),
             .protor => classifier_protor.getRadius(residues[i].slice(), atom_names[i].slice()),
             .oons => classifier_oons.getRadius(residues[i].slice(), atom_names[i].slice()),
+            .ccd => if (ccd_clf) |*c| c.getRadius(residues[i].slice(), atom_names[i].slice()) else null,
         };
         if (radius_opt) |r| {
             input.r[i] = r;


### PR DESCRIPTION
## Summary

- Add new `CcdClassifier` that derives ProtOr-compatible VdW radii from CCD (Chemical Component Dictionary) bond topology
- Enables accurate radius assignment for any chemical component, not just standard amino acids
- Accessible via `zsasa calc -c ccd` or `ZSASA_CLASSIFIER_CCD` in C API

## Architecture

4-level lookup priority:
1. **Hardcoded table** (StaticStringMap) — stdAA, nucleic acids, modified residues (MSE, SEC, HYP, SEP, TPO, etc.)
2. **Inline CCD** — `_chem_comp_atom`/`_chem_comp_bond` from mmCIF files
3. **External CCD** — CLI option (future)
4. **Element fallback** — existing VdW radii

Derivation pipeline: CCD bond orders → hybridization (sp/sp2/sp3) → implicit H count → ProtOr radius table

## New files

| File | Purpose |
|---|---|
| `src/hybridization.zig` | Bond analysis, hybridization inference, radius derivation |
| `src/ccd_parser.zig` | Streaming CCD `_chem_comp_atom`/`_chem_comp_bond` parser |
| `src/classifier_ccd.zig` | CcdClassifier struct with hardcoded + runtime lookup |

## Verification

- CCD classifier produces identical SASA to ProtOr on 1ubq.cif (4834.72 Å²)
- 602/602 atoms classified, 0 fallback on standard amino acid structures
- E2E tests confirm per-atom radius match against ProtOr

## Test plan

- [x] Unit tests for hybridization derivation (17 tests)
- [x] Unit tests for CCD streaming parser (7 tests)
- [x] Unit tests for CcdClassifier (9 tests)
- [x] Inline CCD parsing tests (3 tests)
- [x] ProtOr compatibility test (all 20 AA backbone atoms)
- [x] E2E test on real structure (1ubq.cif)
- [x] CLI smoke test (`zsasa calc -c ccd`)
- [x] Full test suite passes (450/451, 1 pre-existing skip)