### PR TITLE
feat: add external CCD support with --ccd option and compile-dict subcommand

### DIFF
--- a/src/batch.zig
+++ b/src/batch.zig
@@ -343,12 +343,13 @@ fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType, external_ccd: ?
 
     if (ccd_clf != null) {
         if (external_ccd) |dict| {
-            var it = dict.components.iterator();
-            while (it.next()) |entry| {
-                const comp_id = entry.key_ptr.*;
-                if (!classifier_ccd.CcdClassifier.isHardcoded(comp_id)) {
-                    const comp = entry.value_ptr.view();
-                    ccd_clf.?.addComponent(&comp) catch {};
+            // Only load components present in input and not hardcoded
+            for (0..n) |i| {
+                const res = residues[i].slice();
+                if (!classifier_ccd.CcdClassifier.isHardcoded(res)) {
+                    if (dict.get(res)) |comp| {
+                        ccd_clf.?.addComponent(&comp) catch {};
+                    }
                 }
             }
         }

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -343,13 +343,21 @@ fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType, external_ccd: ?
 
     if (ccd_clf != null) {
         if (external_ccd) |dict| {
-            // Only load components present in input and not hardcoded
+            // Deduplicate: collect unique non-hardcoded residues
+            var needed = std.StringHashMap(void).init(input.allocator);
+            defer needed.deinit();
             for (0..n) |i| {
                 const res = residues[i].slice();
                 if (!classifier_ccd.CcdClassifier.isHardcoded(res)) {
-                    if (dict.get(res)) |comp| {
-                        ccd_clf.?.addComponent(&comp) catch {};
-                    }
+                    try needed.put(res, {});
+                }
+            }
+            var it = needed.keyIterator();
+            while (it.next()) |key_ptr| {
+                if (dict.get(key_ptr.*)) |comp| {
+                    ccd_clf.?.addComponent(&comp) catch |err| {
+                        std.debug.print("Warning: Could not derive CCD properties for '{s}': {s}\n", .{ key_ptr.*, @errorName(err) });
+                    };
                 }
             }
         }

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -14,6 +14,9 @@ const classifier_protor = @import("classifier_protor.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
+const ccd_parser = @import("ccd_parser.zig");
+const ccd_binary = @import("ccd_binary.zig");
+const gzip = @import("gzip.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -59,6 +62,7 @@ pub const BatchConfig = struct {
     include_hetatm: bool = false, // Include HETATM records (default: exclude)
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
     store_atom_areas: bool = false, // When true, copy atom_areas to result_allocator for jsonl
+    external_ccd: ?*const ccd_parser.ComponentDict = null, // External CCD dictionary
 };
 
 /// Helper to build and hold bitmask LUTs for batch processing.
@@ -328,14 +332,27 @@ fn readInputFile(allocator: Allocator, path: []const u8, config: BatchConfig) !A
 }
 
 /// Apply built-in classifier to replace radii based on residue/atom names
-fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType) !void {
+fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType, external_ccd: ?*const ccd_parser.ComponentDict) !void {
     const n = input.atomCount();
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
-    // For CCD: create classifier instance (hardcoded table is compile-time, no setup cost)
+    // For CCD: create classifier instance and feed external CCD components
     var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd) classifier_ccd.CcdClassifier.init(input.allocator) else null;
     defer if (ccd_clf) |*c| c.deinit();
+
+    if (ccd_clf != null) {
+        if (external_ccd) |dict| {
+            var it = dict.components.iterator();
+            while (it.next()) |entry| {
+                const comp_id = entry.key_ptr.*;
+                if (!classifier_ccd.CcdClassifier.isHardcoded(comp_id)) {
+                    const comp = entry.value_ptr.view();
+                    ccd_clf.?.addComponent(&comp) catch {};
+                }
+            }
+        }
+    }
 
     const new_radii = try input.allocator.alloc(f64, n);
     errdefer input.allocator.free(new_radii);
@@ -448,7 +465,7 @@ fn processOneFile(
     if (config.classifier_type) |ct| {
         const format = format_detect.detectInputFormat(input_path);
         if (format != .json and input.hasClassificationInfo()) {
-            applyBuiltinClassifier(&input, ct) catch |err| {
+            applyBuiltinClassifier(&input, ct, config.external_ccd) catch |err| {
                 result.status = .err;
                 result.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return result;
@@ -1011,6 +1028,7 @@ pub const BatchArgs = struct {
     include_hydrogens: bool = false,
     include_hetatm: bool = false,
     use_bitmask: bool = false,
+    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz])
     quiet: bool = false,
     show_timing: bool = false,
     show_help: bool = false,
@@ -1232,6 +1250,18 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         else if (std.mem.eql(u8, arg, "--use-bitmask")) {
             result.use_bitmask = true;
         }
+        // --ccd=PATH or --ccd PATH (external CCD dictionary)
+        else if (std.mem.startsWith(u8, arg, "--ccd=")) {
+            const value = arg["--ccd=".len..];
+            result.ccd_path = value;
+        } else if (std.mem.eql(u8, arg, "--ccd")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --ccd\n", .{});
+                std.process.exit(1);
+            }
+            result.ccd_path = args[i];
+        }
         // --quiet or -q
         else if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
             result.quiet = true;
@@ -1308,6 +1338,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\                        Default: sr
         \\    --classifier=TYPE   Built-in classifier: naccess, protor, oons, ccd
         \\                        Default: protor
+        \\    --ccd=PATH          External CCD dictionary file (.zsdc or .cif[.gz])
+        \\                        Used with --classifier=ccd for non-standard residues
         \\    --threads=N         Number of threads (default: auto-detect)
         \\    --probe-radius=R    Probe radius in Angstroms (default: 1.4)
         \\    --n-points=N        Test points per atom (default: 100, for sr)
@@ -1342,6 +1374,37 @@ pub fn run(allocator: Allocator, args: BatchArgs) !void {
         return error.MissingArgument;
     };
 
+    // Load external CCD dictionary if specified
+    var ext_ccd: ?ccd_parser.ComponentDict = null;
+    if (args.ccd_path) |ccd_path| {
+        const ccd_data = if (std.mem.endsWith(u8, ccd_path, ".gz"))
+            gzip.readGzip(allocator, ccd_path) catch |err| {
+                std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                std.process.exit(1);
+            }
+        else blk: {
+            const f = std.fs.cwd().openFile(ccd_path, .{}) catch |err| {
+                std.debug.print("Error opening CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                std.process.exit(1);
+            };
+            defer f.close();
+            break :blk f.readToEndAlloc(allocator, 4 * 1024 * 1024 * 1024) catch |err| {
+                std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                std.process.exit(1);
+            };
+        };
+        defer allocator.free(ccd_data);
+
+        ext_ccd = ccd_binary.loadDict(allocator, ccd_data) catch |err| {
+            std.debug.print("Error loading CCD dictionary '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+            std.process.exit(1);
+        };
+        if (!args.quiet) {
+            std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), ccd_path });
+        }
+    }
+    defer if (ext_ccd) |*d| d.deinit();
+
     // For jsonl, don't pass output_dir to runBatch (no per-file I/O during computation)
     const output_dir: ?[]const u8 = if (args.output_format == .jsonl) null else args.output_path;
 
@@ -1361,6 +1424,7 @@ pub fn run(allocator: Allocator, args: BatchArgs) !void {
         .include_hetatm = args.include_hetatm,
         .use_bitmask = args.use_bitmask,
         .store_atom_areas = (args.output_format == .jsonl),
+        .external_ccd = if (ext_ccd != null) &ext_ccd.? else null,
     };
 
     if (!args.quiet) {

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -653,7 +653,7 @@ fn applyBuiltinClassifier(
         for (0..n) |i| {
             const res = residues[i].slice();
             if (!classifier_ccd.CcdClassifier.isHardcoded(res)) {
-                needed.put(res, {}) catch {};
+                try needed.put(res, {});
             }
         }
 

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -20,6 +20,8 @@ const classifier_protor = @import("classifier_protor.zig");
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
 const ccd_parser = @import("ccd_parser.zig");
+const ccd_binary = @import("ccd_binary.zig");
+const gzip = @import("gzip.zig");
 
 const Config = types.Config;
 const Configf32 = types.Configf32;
@@ -58,6 +60,7 @@ pub const CalcArgs = struct {
     rsa: bool = false, // Show RSA (Relative Solvent Accessibility)
     polar: bool = false, // Show polar/nonpolar SASA summary
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
+    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz])
     quiet: bool = false,
     validate_only: bool = false,
     show_timing: bool = false, // Show timing breakdown for benchmarking
@@ -377,6 +380,18 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) CalcArgs {
         else if (std.mem.eql(u8, arg, "--timing")) {
             result.show_timing = true;
         }
+        // --ccd=PATH or --ccd PATH (external CCD dictionary)
+        else if (std.mem.startsWith(u8, arg, "--ccd=")) {
+            const value = arg["--ccd=".len..];
+            result.ccd_path = value;
+        } else if (std.mem.eql(u8, arg, "--ccd")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --ccd\n", .{});
+                std.process.exit(1);
+            }
+            result.ccd_path = args[i];
+        }
         // --use-bitmask (bitmask LUT optimization for SR, n-points must be 1..1024)
         else if (std.mem.eql(u8, arg, "--use-bitmask")) {
             result.use_bitmask = true;
@@ -447,6 +462,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\                       Default: sr
         \\    --classifier=TYPE  Built-in classifier: naccess, protor, oons, ccd
         \\                       Default: protor for PDB/mmCIF, none for JSON
+        \\    --ccd=PATH         External CCD dictionary file (.zsdc or .cif[.gz])
+        \\                       Used with --classifier=ccd for non-standard residues
         \\    --config=FILE      Custom classifier config file (FreeSASA format)
         \\    --chain=ID         Filter by chain ID (e.g., --chain=A or --chain=A,B,C)
         \\                       Default: label_asym_id (mmCIF standard)
@@ -616,36 +633,41 @@ fn applyBuiltinClassifier(
     input: *types.AtomInput,
     ct: ClassifierType,
     inline_ccd: ?*const ccd_parser.ComponentDict,
+    external_ccd: ?*const ccd_parser.ComponentDict,
     quiet: bool,
 ) !void {
     const n = input.atomCount();
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
-    // For CCD: create classifier instance and feed inline CCD components
+    // For CCD: create classifier instance and feed inline/external CCD components
     var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd) classifier_ccd.CcdClassifier.init(input.allocator) else null;
     defer if (ccd_clf) |*c| c.deinit();
 
-    // Feed inline CCD components for non-standard residues
+    // Feed CCD components for non-standard residues from both sources
     if (ccd_clf != null) {
-        if (inline_ccd) |dict| {
-            var it = dict.components.iterator();
-            while (it.next()) |entry| {
-                const comp_id = entry.key_ptr.*;
-                if (!classifier_ccd.CcdClassifier.isHardcoded(comp_id)) {
-                    const comp = entry.value_ptr.view();
-                    ccd_clf.?.addComponent(&comp) catch |err| {
-                        if (!quiet) {
-                            std.debug.print("Warning: Could not derive CCD properties for '{s}': {s}\n", .{ comp_id, @errorName(err) });
-                        }
-                    };
+        const dicts: [2]?*const ccd_parser.ComponentDict = .{ inline_ccd, external_ccd };
+        const labels: [2][]const u8 = .{ "inline", "external" };
+        for (dicts, labels) |maybe_dict, label| {
+            if (maybe_dict) |dict| {
+                var it = dict.components.iterator();
+                while (it.next()) |entry| {
+                    const comp_id = entry.key_ptr.*;
+                    if (!classifier_ccd.CcdClassifier.isHardcoded(comp_id)) {
+                        const comp = entry.value_ptr.view();
+                        ccd_clf.?.addComponent(&comp) catch |err| {
+                            if (!quiet) {
+                                std.debug.print("Warning: Could not derive CCD properties for '{s}': {s}\n", .{ comp_id, @errorName(err) });
+                            }
+                        };
+                    }
                 }
-            }
-            if (!quiet) {
-                const total = dict.components.count();
-                const runtime = ccd_clf.?.runtime_components.count();
-                if (runtime > 0) {
-                    std.debug.print("CCD: {d} inline components loaded ({d} runtime-derived)\n", .{ total, runtime });
+                if (!quiet) {
+                    const total = dict.components.count();
+                    const runtime = ccd_clf.?.runtime_components.count();
+                    if (runtime > 0) {
+                        std.debug.print("CCD: {d} {s} components loaded ({d} runtime-derived)\n", .{ total, label, runtime });
+                    }
                 }
             }
         }
@@ -862,7 +884,40 @@ pub fn run(allocator: std.mem.Allocator, args: CalcArgs) !void {
         } else if (effective_classifier) |ct| {
             // Use built-in classifier
             const inline_ccd: ?*const ccd_parser.ComponentDict = if (read_result.mmcif) |*p| p.getInlineCcd() else null;
-            applyBuiltinClassifier(&input, ct, inline_ccd, args.quiet) catch |err| {
+
+            // Load external CCD dictionary if specified
+            var ext_ccd: ?ccd_parser.ComponentDict = null;
+            if (args.ccd_path) |ccd_path| {
+                const ccd_data = if (std.mem.endsWith(u8, ccd_path, ".gz"))
+                    gzip.readGzip(allocator, ccd_path) catch |err| {
+                        std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                        std.process.exit(1);
+                    }
+                else blk: {
+                    const f = std.fs.cwd().openFile(ccd_path, .{}) catch |err| {
+                        std.debug.print("Error opening CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                        std.process.exit(1);
+                    };
+                    defer f.close();
+                    break :blk f.readToEndAlloc(allocator, 4 * 1024 * 1024 * 1024) catch |err| {
+                        std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                        std.process.exit(1);
+                    };
+                };
+                defer allocator.free(ccd_data);
+
+                ext_ccd = ccd_binary.loadDict(allocator, ccd_data) catch |err| {
+                    std.debug.print("Error loading CCD dictionary '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                    std.process.exit(1);
+                };
+                if (!args.quiet) {
+                    std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), ccd_path });
+                }
+            }
+            defer if (ext_ccd) |*d| d.deinit();
+
+            const ext_ccd_ptr: ?*const ccd_parser.ComponentDict = if (ext_ccd != null) &ext_ccd.? else null;
+            applyBuiltinClassifier(&input, ct, inline_ccd, ext_ccd_ptr, args.quiet) catch |err| {
                 std.debug.print("Error applying classifier: {s}\n", .{@errorName(err)});
                 std.process.exit(1);
             };

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -644,31 +644,41 @@ fn applyBuiltinClassifier(
     var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd) classifier_ccd.CcdClassifier.init(input.allocator) else null;
     defer if (ccd_clf) |*c| c.deinit();
 
-    // Feed CCD components for non-standard residues from both sources
+    // Feed CCD components for non-standard residues
+    // Only load components that are actually present in the input structure
     if (ccd_clf != null) {
-        const dicts: [2]?*const ccd_parser.ComponentDict = .{ inline_ccd, external_ccd };
-        const labels: [2][]const u8 = .{ "inline", "external" };
-        for (dicts, labels) |maybe_dict, label| {
-            if (maybe_dict) |dict| {
-                var it = dict.components.iterator();
-                while (it.next()) |entry| {
-                    const comp_id = entry.key_ptr.*;
-                    if (!classifier_ccd.CcdClassifier.isHardcoded(comp_id)) {
-                        const comp = entry.value_ptr.view();
-                        ccd_clf.?.addComponent(&comp) catch |err| {
-                            if (!quiet) {
-                                std.debug.print("Warning: Could not derive CCD properties for '{s}': {s}\n", .{ comp_id, @errorName(err) });
-                            }
-                        };
+        // Collect unique non-hardcoded residue names from input
+        var needed = std.StringHashMap(void).init(input.allocator);
+        defer needed.deinit();
+        for (0..n) |i| {
+            const res = residues[i].slice();
+            if (!classifier_ccd.CcdClassifier.isHardcoded(res)) {
+                needed.put(res, {}) catch {};
+            }
+        }
+
+        if (needed.count() > 0) {
+            var loaded: usize = 0;
+            const dicts: [2]?*const ccd_parser.ComponentDict = .{ inline_ccd, external_ccd };
+            for (dicts) |maybe_dict| {
+                if (maybe_dict) |dict| {
+                    var it = needed.keyIterator();
+                    while (it.next()) |key_ptr| {
+                        const comp_id = key_ptr.*;
+                        if (dict.get(comp_id)) |comp| {
+                            ccd_clf.?.addComponent(&comp) catch |err| {
+                                if (!quiet) {
+                                    std.debug.print("Warning: Could not derive CCD properties for '{s}': {s}\n", .{ comp_id, @errorName(err) });
+                                }
+                                continue;
+                            };
+                            loaded += 1;
+                        }
                     }
                 }
-                if (!quiet) {
-                    const total = dict.components.count();
-                    const runtime = ccd_clf.?.runtime_components.count();
-                    if (runtime > 0) {
-                        std.debug.print("CCD: {d} {s} components loaded ({d} runtime-derived)\n", .{ total, label, runtime });
-                    }
-                }
+            }
+            if (!quiet and loaded > 0) {
+                std.debug.print("CCD: {d} non-standard components derived from CCD data\n", .{loaded});
             }
         }
     }

--- a/src/ccd_binary.zig
+++ b/src/ccd_binary.zig
@@ -1,0 +1,422 @@
+//! Binary CCD dictionary format (ZSDC = Z-SASA Dictionary Compiled).
+//!
+//! A compact binary format for storing CCD component data needed for SASA
+//! classification. This is a freesasa-zig original format, containing only
+//! the fields required for ProtOr-compatible VdW radius assignment.
+//!
+//! ## Format Layout
+//!
+//! Header (12 bytes):
+//!   [4B magic "ZSDC"] [1B version] [3B reserved] [4B component count LE]
+//!
+//! Component Record (variable length):
+//!   [1B comp_id_len] [N bytes comp_id]
+//!   [2B atom_count LE] [12B x atom_count packed atoms]
+//!   [2B bond_count LE] [6B x bond_count packed bonds]
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ccd_parser = @import("ccd_parser.zig");
+const hyb = @import("hybridization.zig");
+const CompAtom = hyb.CompAtom;
+const CompBond = hyb.CompBond;
+const BondOrder = hyb.BondOrder;
+
+pub const MAGIC: [4]u8 = .{ 'Z', 'S', 'D', 'C' };
+pub const FORMAT_VERSION: u8 = 1;
+const HEADER_SIZE: usize = 12;
+
+pub const ReadError = error{
+    InvalidMagic,
+    UnsupportedVersion,
+    UnexpectedEof,
+    OutOfMemory,
+    CountTooLarge,
+};
+
+// =============================================================================
+// Packed binary representations
+// =============================================================================
+
+/// Packed atom record (12 bytes, extern struct for stable layout).
+pub const PackedAtom = extern struct {
+    atom_id: [4]u8,
+    atom_id_len: u8,
+    type_symbol: [4]u8,
+    type_symbol_len: u8,
+    flags: u8, // bit0 = leaving, bit1 = aromatic
+    _pad: u8,
+
+    comptime {
+        std.debug.assert(@sizeOf(PackedAtom) == 12);
+    }
+
+    pub fn fromCompAtom(a: CompAtom) PackedAtom {
+        var flags: u8 = 0;
+        if (a.leaving) flags |= 0x01;
+        if (a.aromatic) flags |= 0x02;
+        return .{
+            .atom_id = a.atom_id,
+            .atom_id_len = @intCast(a.atom_id_len),
+            .type_symbol = a.type_symbol,
+            .type_symbol_len = @intCast(a.type_symbol_len),
+            .flags = flags,
+            ._pad = 0,
+        };
+    }
+
+    pub fn toCompAtom(self: PackedAtom) CompAtom {
+        const aid_len: u3 = @intCast(self.atom_id_len & 0x07);
+        const ts_len: u3 = @intCast(self.type_symbol_len & 0x07);
+        return .{
+            .atom_id = self.atom_id,
+            .atom_id_len = aid_len,
+            .type_symbol = self.type_symbol,
+            .type_symbol_len = ts_len,
+            .leaving = (self.flags & 0x01) != 0,
+            .aromatic = (self.flags & 0x02) != 0,
+        };
+    }
+};
+
+/// Packed bond record (6 bytes, extern struct for stable layout).
+pub const PackedBond = extern struct {
+    atom_idx_1: u16,
+    atom_idx_2: u16,
+    order: u8,
+    flags: u8, // bit0 = aromatic
+
+    comptime {
+        std.debug.assert(@sizeOf(PackedBond) == 6);
+    }
+
+    pub fn fromCompBond(b: CompBond) PackedBond {
+        var flags: u8 = 0;
+        if (b.aromatic) flags |= 0x01;
+        return .{
+            .atom_idx_1 = std.mem.nativeToLittle(u16, b.atom_idx_1),
+            .atom_idx_2 = std.mem.nativeToLittle(u16, b.atom_idx_2),
+            .order = @intFromEnum(b.order),
+            .flags = flags,
+        };
+    }
+
+    pub fn toCompBond(self: PackedBond) CompBond {
+        return .{
+            .atom_idx_1 = std.mem.littleToNative(u16, self.atom_idx_1),
+            .atom_idx_2 = std.mem.littleToNative(u16, self.atom_idx_2),
+            .order = @enumFromInt(self.order),
+            .aromatic = (self.flags & 0x01) != 0,
+        };
+    }
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Check if data starts with ZSDC magic bytes.
+pub fn isBinaryDict(data: []const u8) bool {
+    if (data.len < 4) return false;
+    return std.mem.eql(u8, data[0..4], &MAGIC);
+}
+
+/// Write a ComponentDict to binary ZSDC format.
+pub fn writeDict(writer: anytype, dict: *const ccd_parser.ComponentDict) !void {
+    // Count components
+    const comp_count: u32 = @intCast(dict.components.count());
+
+    // Write header
+    try writer.writeAll(&MAGIC);
+    try writer.writeByte(FORMAT_VERSION);
+    try writer.writeAll(&[3]u8{ 0, 0, 0 }); // reserved
+    try writer.writeAll(&std.mem.toBytes(std.mem.nativeToLittle(u32, comp_count)));
+
+    // Write each component
+    var it = dict.components.iterator();
+    while (it.next()) |entry| {
+        const comp_id = entry.key_ptr.*;
+        const stored = entry.value_ptr;
+
+        // Component ID
+        const cid_len: u8 = @intCast(@min(comp_id.len, 255));
+        try writer.writeByte(cid_len);
+        try writer.writeAll(comp_id[0..cid_len]);
+
+        // Atom count and atoms
+        const atom_count: u16 = @intCast(stored.atoms.len);
+        try writer.writeAll(&std.mem.toBytes(std.mem.nativeToLittle(u16, atom_count)));
+        for (stored.atoms) |atom| {
+            const pa = PackedAtom.fromCompAtom(atom);
+            try writer.writeAll(std.mem.asBytes(&pa));
+        }
+
+        // Bond count and bonds
+        const bond_count: u16 = @intCast(stored.bonds.len);
+        try writer.writeAll(&std.mem.toBytes(std.mem.nativeToLittle(u16, bond_count)));
+        for (stored.bonds) |bond| {
+            const pb = PackedBond.fromCompBond(bond);
+            try writer.writeAll(std.mem.asBytes(&pb));
+        }
+    }
+}
+
+/// Read a ComponentDict from binary ZSDC format.
+pub fn readDict(allocator: Allocator, reader: anytype) ReadError!ccd_parser.ComponentDict {
+    var dict = ccd_parser.ComponentDict.init(allocator);
+    errdefer dict.deinit();
+
+    // Read header
+    var header: [HEADER_SIZE]u8 = undefined;
+    reader.readNoEof(&header) catch return error.UnexpectedEof;
+
+    if (!std.mem.eql(u8, header[0..4], &MAGIC)) return error.InvalidMagic;
+    if (header[4] != FORMAT_VERSION) return error.UnsupportedVersion;
+
+    const comp_count = std.mem.littleToNative(u32, std.mem.bytesToValue(u32, header[8..12]));
+    if (comp_count > 1_000_000) return error.CountTooLarge;
+
+    // Read components
+    for (0..comp_count) |_| {
+        // Read comp_id
+        const cid_len_byte = reader.readByte() catch return error.UnexpectedEof;
+        const cid_len: usize = cid_len_byte;
+        if (cid_len == 0 or cid_len > 255) return error.UnexpectedEof;
+        var cid_buf: [255]u8 = undefined;
+        reader.readNoEof(cid_buf[0..cid_len]) catch return error.UnexpectedEof;
+
+        // Read atom count
+        var atom_count_buf: [2]u8 = undefined;
+        reader.readNoEof(&atom_count_buf) catch return error.UnexpectedEof;
+        const atom_count: u16 = std.mem.littleToNative(u16, std.mem.bytesToValue(u16, &atom_count_buf));
+
+        // Read atoms
+        const atoms = allocator.alloc(CompAtom, atom_count) catch return error.OutOfMemory;
+        errdefer allocator.free(atoms);
+        for (0..atom_count) |i| {
+            var packed_buf: [@sizeOf(PackedAtom)]u8 = undefined;
+            reader.readNoEof(&packed_buf) catch {
+                allocator.free(atoms);
+                return error.UnexpectedEof;
+            };
+            const pa: PackedAtom = @bitCast(packed_buf);
+            atoms[i] = pa.toCompAtom();
+        }
+
+        // Read bond count
+        var bond_count_buf: [2]u8 = undefined;
+        reader.readNoEof(&bond_count_buf) catch return error.UnexpectedEof;
+        const bond_count: u16 = std.mem.littleToNative(u16, std.mem.bytesToValue(u16, &bond_count_buf));
+
+        // Read bonds
+        const bonds = allocator.alloc(CompBond, bond_count) catch {
+            allocator.free(atoms);
+            return error.OutOfMemory;
+        };
+        errdefer allocator.free(bonds);
+        for (0..bond_count) |i| {
+            var packed_buf: [@sizeOf(PackedBond)]u8 = undefined;
+            reader.readNoEof(&packed_buf) catch {
+                allocator.free(atoms);
+                allocator.free(bonds);
+                return error.UnexpectedEof;
+            };
+            const pb: PackedBond = @bitCast(packed_buf);
+            bonds[i] = pb.toCompBond();
+        }
+
+        // Build comp_id key
+        const key = allocator.dupe(u8, cid_buf[0..cid_len]) catch {
+            allocator.free(atoms);
+            allocator.free(bonds);
+            return error.OutOfMemory;
+        };
+        errdefer allocator.free(key);
+
+        // Build stored component
+        var comp_id_fixed: [5]u8 = .{ 0, 0, 0, 0, 0 };
+        const fixed_len: usize = @min(cid_len, 5);
+        @memcpy(comp_id_fixed[0..fixed_len], cid_buf[0..fixed_len]);
+
+        const stored = ccd_parser.StoredComponent{
+            .comp_id = comp_id_fixed,
+            .comp_id_len = @intCast(fixed_len),
+            .atoms = atoms,
+            .bonds = bonds,
+            .allocator = allocator,
+        };
+
+        dict.components.put(key, stored) catch {
+            allocator.free(key);
+            allocator.free(atoms);
+            allocator.free(bonds);
+            return error.OutOfMemory;
+        };
+        dict.owned_keys.append(allocator, key) catch {
+            // Key is already in the map, so we should not free it here;
+            // dict.deinit() via errdefer will handle cleanup.
+            return error.OutOfMemory;
+        };
+    }
+
+    return dict;
+}
+
+/// Auto-detect format and load a ComponentDict from raw data.
+/// If data starts with ZSDC magic, decode as binary; otherwise parse as CIF text.
+pub fn loadDict(allocator: Allocator, data: []const u8) !ccd_parser.ComponentDict {
+    if (isBinaryDict(data)) {
+        var fbs = std.io.fixedBufferStream(data);
+        return readDict(allocator, fbs.reader());
+    } else {
+        return ccd_parser.parseCcdData(allocator, data, null);
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "isBinaryDict — valid magic" {
+    const data = [_]u8{ 'Z', 'S', 'D', 'C', 1, 0, 0, 0, 0, 0, 0, 0 };
+    try std.testing.expect(isBinaryDict(&data));
+}
+
+test "isBinaryDict — wrong magic" {
+    const data = [_]u8{ 'Z', 'S', 'D', 'X', 1, 0, 0, 0, 0, 0, 0, 0 };
+    try std.testing.expect(!isBinaryDict(&data));
+}
+
+test "isBinaryDict — empty" {
+    const data = [_]u8{};
+    try std.testing.expect(!isBinaryDict(&data));
+}
+
+test "isBinaryDict — too short" {
+    const data = [_]u8{ 'Z', 'S', 'D' };
+    try std.testing.expect(!isBinaryDict(&data));
+}
+
+test "round-trip: create ComponentDict -> writeDict -> readDict -> verify" {
+    const allocator = std.testing.allocator;
+
+    // Build a synthetic ComponentDict
+    var dict = ccd_parser.ComponentDict.init(allocator);
+    defer dict.deinit();
+
+    // Create atoms for component "ALA"
+    const atoms = try allocator.alloc(CompAtom, 2);
+    atoms[0] = CompAtom.init("CA", "C");
+    atoms[1] = CompAtom.init("N", "N");
+    atoms[1].leaving = true;
+    atoms[0].aromatic = true;
+
+    // Create bonds
+    const bonds = try allocator.alloc(CompBond, 1);
+    bonds[0] = .{
+        .atom_idx_1 = 0,
+        .atom_idx_2 = 1,
+        .order = .single,
+        .aromatic = false,
+    };
+
+    const key = try allocator.dupe(u8, "ALA");
+    const stored = ccd_parser.StoredComponent{
+        .comp_id = .{ 'A', 'L', 'A', 0, 0 },
+        .comp_id_len = 3,
+        .atoms = atoms,
+        .bonds = bonds,
+        .allocator = allocator,
+    };
+    try dict.components.put(key, stored);
+    try dict.owned_keys.append(allocator, key);
+
+    // Write to buffer
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeDict(fbs.writer(), &dict);
+
+    // Read back
+    const written = fbs.getWritten();
+    var read_fbs = std.io.fixedBufferStream(written);
+    var read_dict = try readDict(allocator, read_fbs.reader());
+    defer read_dict.deinit();
+
+    // Verify
+    try std.testing.expectEqual(@as(usize, 1), read_dict.components.count());
+
+    const comp = read_dict.get("ALA") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 2), comp.atoms.len);
+    try std.testing.expectEqual(@as(usize, 1), comp.bonds.len);
+
+    // Verify atom fields
+    try std.testing.expectEqualSlices(u8, "CA", comp.atoms[0].atomIdSlice());
+    try std.testing.expectEqualSlices(u8, "C", comp.atoms[0].typeSymbolSlice());
+    try std.testing.expect(comp.atoms[0].aromatic);
+    try std.testing.expect(!comp.atoms[0].leaving);
+
+    try std.testing.expectEqualSlices(u8, "N", comp.atoms[1].atomIdSlice());
+    try std.testing.expectEqualSlices(u8, "N", comp.atoms[1].typeSymbolSlice());
+    try std.testing.expect(!comp.atoms[1].aromatic);
+    try std.testing.expect(comp.atoms[1].leaving);
+
+    // Verify bond fields
+    try std.testing.expectEqual(@as(u16, 0), comp.bonds[0].atom_idx_1);
+    try std.testing.expectEqual(@as(u16, 1), comp.bonds[0].atom_idx_2);
+    try std.testing.expectEqual(BondOrder.single, comp.bonds[0].order);
+    try std.testing.expect(!comp.bonds[0].aromatic);
+}
+
+test "round-trip: empty dictionary" {
+    const allocator = std.testing.allocator;
+
+    var dict = ccd_parser.ComponentDict.init(allocator);
+    defer dict.deinit();
+
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeDict(fbs.writer(), &dict);
+
+    var read_fbs = std.io.fixedBufferStream(fbs.getWritten());
+    var read_dict = try readDict(allocator, read_fbs.reader());
+    defer read_dict.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), read_dict.components.count());
+}
+
+test "loadDict — auto-detect binary" {
+    const allocator = std.testing.allocator;
+
+    // Build a minimal binary dict in memory
+    var dict = ccd_parser.ComponentDict.init(allocator);
+    defer dict.deinit();
+
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeDict(fbs.writer(), &dict);
+
+    const data = fbs.getWritten();
+    var loaded = try loadDict(allocator, data);
+    defer loaded.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), loaded.components.count());
+}
+
+test "loadDict — auto-detect CIF text" {
+    const allocator = std.testing.allocator;
+
+    // Minimal CIF data with no actual loops (just enough to parse)
+    const cif_text = "data_test\n";
+    var loaded = try loadDict(allocator, cif_text);
+    defer loaded.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), loaded.components.count());
+}
+
+test "PackedAtom size is 12 bytes" {
+    try std.testing.expectEqual(@as(usize, 12), @sizeOf(PackedAtom));
+}
+
+test "PackedBond size is 6 bytes" {
+    try std.testing.expectEqual(@as(usize, 6), @sizeOf(PackedBond));
+}

--- a/src/ccd_binary.zig
+++ b/src/ccd_binary.zig
@@ -192,13 +192,11 @@ pub fn readDict(allocator: Allocator, reader: anytype) ReadError!ccd_parser.Comp
 
         // Read atoms
         const atoms = allocator.alloc(CompAtom, atom_count) catch return error.OutOfMemory;
-        errdefer allocator.free(atoms);
+        var atoms_owned = true;
+        defer if (atoms_owned) allocator.free(atoms);
         for (0..atom_count) |i| {
             var packed_buf: [@sizeOf(PackedAtom)]u8 = undefined;
-            reader.readNoEof(&packed_buf) catch {
-                allocator.free(atoms);
-                return error.UnexpectedEof;
-            };
+            reader.readNoEof(&packed_buf) catch return error.UnexpectedEof;
             const pa: PackedAtom = @bitCast(packed_buf);
             atoms[i] = pa.toCompAtom();
         }
@@ -209,29 +207,20 @@ pub fn readDict(allocator: Allocator, reader: anytype) ReadError!ccd_parser.Comp
         const bond_count: u16 = std.mem.littleToNative(u16, std.mem.bytesToValue(u16, &bond_count_buf));
 
         // Read bonds
-        const bonds = allocator.alloc(CompBond, bond_count) catch {
-            allocator.free(atoms);
-            return error.OutOfMemory;
-        };
-        errdefer allocator.free(bonds);
+        const bonds = allocator.alloc(CompBond, bond_count) catch return error.OutOfMemory;
+        var bonds_owned = true;
+        defer if (bonds_owned) allocator.free(bonds);
         for (0..bond_count) |i| {
             var packed_buf: [@sizeOf(PackedBond)]u8 = undefined;
-            reader.readNoEof(&packed_buf) catch {
-                allocator.free(atoms);
-                allocator.free(bonds);
-                return error.UnexpectedEof;
-            };
+            reader.readNoEof(&packed_buf) catch return error.UnexpectedEof;
             const pb: PackedBond = @bitCast(packed_buf);
             bonds[i] = pb.toCompBond();
         }
 
         // Build comp_id key
-        const key = allocator.dupe(u8, cid_buf[0..cid_len]) catch {
-            allocator.free(atoms);
-            allocator.free(bonds);
-            return error.OutOfMemory;
-        };
-        errdefer allocator.free(key);
+        const key = allocator.dupe(u8, cid_buf[0..cid_len]) catch return error.OutOfMemory;
+        var key_owned = true;
+        defer if (key_owned) allocator.free(key);
 
         // Build stored component
         var comp_id_fixed: [5]u8 = .{ 0, 0, 0, 0, 0 };
@@ -246,17 +235,17 @@ pub fn readDict(allocator: Allocator, reader: anytype) ReadError!ccd_parser.Comp
             .allocator = allocator,
         };
 
-        dict.components.put(key, stored) catch {
-            allocator.free(key);
-            allocator.free(atoms);
-            allocator.free(bonds);
-            return error.OutOfMemory;
-        };
+        // Transfer ownership to dict
+        dict.components.put(key, stored) catch return error.OutOfMemory;
         dict.owned_keys.append(allocator, key) catch {
             // Key is already in the map, so we should not free it here;
             // dict.deinit() via errdefer will handle cleanup.
             return error.OutOfMemory;
         };
+        // Ownership successfully transferred to dict
+        atoms_owned = false;
+        bonds_owned = false;
+        key_owned = false;
     }
 
     return dict;

--- a/src/classifier_ccd.zig
+++ b/src/classifier_ccd.zig
@@ -862,17 +862,17 @@ pub const CcdClassifier = struct {
             const atom_id = entry.atomIdSlice();
             const key = formatKey(comp_id, atom_id);
 
-            // Use getOrPut to avoid leaking keys on duplicate entries
-            const gop = try self.runtime_components.getOrPut(&key);
-            if (gop.found_existing) {
-                // Update value, key already allocated
-                gop.value_ptr.* = RuntimeEntry{ .props = entry.props };
+            // Use getPtr to update existing entries in place (avoids key reallocation).
+            // For new entries, allocate key on heap first to avoid dangling stack pointers.
+            if (self.runtime_components.getPtr(&key)) |value_ptr| {
+                value_ptr.* = RuntimeEntry{ .props = entry.props };
             } else {
-                // Allocate a persistent copy of the key on the heap
                 const key_copy = try self.allocator.alloc(u8, 9);
                 @memcpy(key_copy, &key);
-                gop.key_ptr.* = key_copy;
-                gop.value_ptr.* = RuntimeEntry{ .props = entry.props };
+                self.runtime_components.put(key_copy, RuntimeEntry{ .props = entry.props }) catch |err| {
+                    self.allocator.free(key_copy);
+                    return err;
+                };
             }
         }
     }

--- a/src/classifier_ccd.zig
+++ b/src/classifier_ccd.zig
@@ -862,12 +862,18 @@ pub const CcdClassifier = struct {
             const atom_id = entry.atomIdSlice();
             const key = formatKey(comp_id, atom_id);
 
-            // Allocate a persistent copy of the key on the heap
-            const key_copy = try self.allocator.alloc(u8, 9);
-            errdefer self.allocator.free(key_copy);
-            @memcpy(key_copy, &key);
-
-            try self.runtime_components.put(key_copy, RuntimeEntry{ .props = entry.props });
+            // Use getOrPut to avoid leaking keys on duplicate entries
+            const gop = try self.runtime_components.getOrPut(&key);
+            if (gop.found_existing) {
+                // Update value, key already allocated
+                gop.value_ptr.* = RuntimeEntry{ .props = entry.props };
+            } else {
+                // Allocate a persistent copy of the key on the heap
+                const key_copy = try self.allocator.alloc(u8, 9);
+                @memcpy(key_copy, &key);
+                gop.key_ptr.* = key_copy;
+                gop.value_ptr.* = RuntimeEntry{ .props = entry.props };
+            }
         }
     }
 };

--- a/src/compile_dict.zig
+++ b/src/compile_dict.zig
@@ -1,0 +1,131 @@
+//! compile-dict subcommand: convert CIF text CCD data to ZSDC binary format.
+//!
+//! Usage:
+//!   zsasa compile-dict <input.cif[.gz]> -o <output.zsdc>
+//!
+//! Reads a CIF (Chemical Component Dictionary) file, parses all components,
+//! and writes a compact binary dictionary suitable for use with `--ccd`.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ccd_parser = @import("ccd_parser.zig");
+const ccd_binary = @import("ccd_binary.zig");
+const gzip = @import("gzip.zig");
+
+pub fn printHelp(program_name: []const u8) void {
+    std.debug.print(
+        \\zsasa compile-dict - Compile CIF dictionary to binary ZSDC format
+        \\
+        \\USAGE:
+        \\    {s} compile-dict <input.cif[.gz]> -o <output.zsdc>
+        \\
+        \\ARGUMENTS:
+        \\    <input>          Input CIF file (supports .gz compression)
+        \\
+        \\OPTIONS:
+        \\    -o, --output PATH  Output binary dictionary file (required)
+        \\    -h, --help         Show this help message
+        \\
+        \\EXAMPLES:
+        \\    {s} compile-dict components.cif -o components.zsdc
+        \\    {s} compile-dict components.cif.gz -o components.zsdc
+        \\
+    , .{ program_name, program_name, program_name });
+}
+
+pub fn run(allocator: Allocator, args: []const []const u8) !void {
+    var input_path: ?[]const u8 = null;
+    var output_path: ?[]const u8 = null;
+    var show_help = false;
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            show_help = true;
+        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--output")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for {s}\n", .{arg});
+                std.process.exit(1);
+            }
+            output_path = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--output=")) {
+            output_path = arg["--output=".len..];
+        } else if (std.mem.startsWith(u8, arg, "-")) {
+            std.debug.print("Error: Unknown option: {s}\n", .{arg});
+            std.process.exit(1);
+        } else if (input_path == null) {
+            input_path = arg;
+        } else {
+            std.debug.print("Error: Unexpected argument: {s}\n", .{arg});
+            std.process.exit(1);
+        }
+    }
+
+    if (show_help) {
+        // Caller handles this; but just in case:
+        printHelp("zsasa");
+        return;
+    }
+
+    const in_path = input_path orelse {
+        std.debug.print("Error: Missing input file\n", .{});
+        std.debug.print("Usage: zsasa compile-dict <input.cif[.gz]> -o <output.zsdc>\n", .{});
+        return error.MissingArgument;
+    };
+
+    const out_path = output_path orelse {
+        std.debug.print("Error: Missing output file. Use -o <output.zsdc>\n", .{});
+        return error.MissingArgument;
+    };
+
+    // Read input file (handle .gz)
+    std.debug.print("Reading '{s}'...\n", .{in_path});
+    const source = if (std.mem.endsWith(u8, in_path, ".gz"))
+        try gzip.readGzip(allocator, in_path)
+    else blk: {
+        const file = std.fs.cwd().openFile(in_path, .{}) catch |err| {
+            std.debug.print("Error: Could not open '{s}': {s}\n", .{ in_path, @errorName(err) });
+            std.process.exit(1);
+        };
+        defer file.close();
+        break :blk file.readToEndAlloc(allocator, 4 * 1024 * 1024 * 1024) catch |err| {
+            std.debug.print("Error: Could not read '{s}': {s}\n", .{ in_path, @errorName(err) });
+            std.process.exit(1);
+        };
+    };
+    defer allocator.free(source);
+
+    // Parse CIF
+    std.debug.print("Parsing CIF data ({d} bytes)...\n", .{source.len});
+    var dict = ccd_parser.parseCcdData(allocator, source, null) catch |err| {
+        std.debug.print("Error: Failed to parse CIF data: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+    defer dict.deinit();
+
+    const comp_count = dict.components.count();
+    std.debug.print("Parsed {d} components\n", .{comp_count});
+
+    // Write binary output
+    const out_file = std.fs.cwd().createFile(out_path, .{}) catch |err| {
+        std.debug.print("Error: Could not create '{s}': {s}\n", .{ out_path, @errorName(err) });
+        std.process.exit(1);
+    };
+    defer out_file.close();
+
+    var write_buf: [64 * 1024]u8 = undefined;
+    var buffered = out_file.writer(&write_buf);
+    ccd_binary.writeDict(&buffered.interface, &dict) catch |err| {
+        std.debug.print("Error: Failed to write binary dict: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+    buffered.interface.flush() catch |err| {
+        std.debug.print("Error: Failed to flush output: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
+    std.debug.print("Compiled {d} components to '{s}'\n", .{ comp_count, out_path });
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const build_options = @import("build_options");
 const batch = @import("batch.zig");
 const calc = @import("calc.zig");
+const compile_dict = @import("compile_dict.zig");
 const traj = @import("traj.zig");
 
 const version = build_options.version;
@@ -9,7 +10,8 @@ const version = build_options.version;
 fn isSubcommand(arg: []const u8) bool {
     return std.mem.eql(u8, arg, "calc") or
         std.mem.eql(u8, arg, "batch") or
-        std.mem.eql(u8, arg, "traj");
+        std.mem.eql(u8, arg, "traj") or
+        std.mem.eql(u8, arg, "compile-dict");
 }
 
 fn printUsage(program_name: []const u8) void {
@@ -20,9 +22,10 @@ fn printUsage(program_name: []const u8) void {
         \\    {s} <command> [OPTIONS] <args>
         \\
         \\COMMANDS:
-        \\    calc    Calculate SASA for a single structure file
-        \\    batch   Calculate SASA for all files in a directory
-        \\    traj    Calculate SASA across trajectory frames
+        \\    calc          Calculate SASA for a single structure file
+        \\    batch         Calculate SASA for all files in a directory
+        \\    traj          Calculate SASA across trajectory frames
+        \\    compile-dict  Compile CIF dictionary to binary ZSDC format
         \\
         \\GLOBAL OPTIONS:
         \\    -h, --help       Show this help message
@@ -93,6 +96,18 @@ pub fn main() !void {
             std.debug.print("Error in trajectory mode: {s}\n", .{@errorName(err)});
             std.process.exit(1);
         };
+    } else if (std.mem.eql(u8, subcmd, "compile-dict")) {
+        // Check for --help before running
+        for (args[2..]) |a| {
+            if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
+                compile_dict.printHelp(args[0]);
+                return;
+            }
+        }
+        compile_dict.run(allocator, args[2..]) catch |err| {
+            std.debug.print("Error: {s}\n", .{@errorName(err)});
+            std.process.exit(1);
+        };
     } else {
         std.debug.print("Error: unknown subcommand '{s}'\n", .{subcmd});
         printUsage(args[0]);
@@ -106,12 +121,14 @@ test {
     _ = calc;
     _ = batch;
     _ = traj;
+    _ = compile_dict;
 }
 
 test "isSubcommand" {
     try std.testing.expect(isSubcommand("calc"));
     try std.testing.expect(isSubcommand("batch"));
     try std.testing.expect(isSubcommand("traj"));
+    try std.testing.expect(isSubcommand("compile-dict"));
     try std.testing.expect(!isSubcommand("unknown"));
     try std.testing.expect(!isSubcommand("--help"));
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -40,6 +40,8 @@ pub const gzip = @import("gzip.zig");
 pub const hybridization = @import("hybridization.zig");
 pub const ccd_parser = @import("ccd_parser.zig");
 pub const classifier_ccd = @import("classifier_ccd.zig");
+pub const ccd_binary = @import("ccd_binary.zig");
+pub const compile_dict = @import("compile_dict.zig");
 
 test {
     _ = shrake_rupley;
@@ -59,4 +61,6 @@ test {
     _ = hybridization;
     _ = ccd_parser;
     _ = classifier_ccd;
+    _ = ccd_binary;
+    _ = compile_dict;
 }

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -1075,14 +1075,26 @@ fn applyBuiltinClassifier(
 
     if (ccd_clf != null) {
         if (external_ccd) |dict| {
-            var loaded: usize = 0;
+            // Deduplicate: collect unique non-hardcoded residues
+            var needed = std.StringHashMap(void).init(input.allocator);
+            defer needed.deinit();
             for (0..n) |i| {
                 const res = residues[i].slice();
                 if (!classifier_ccd.CcdClassifier.isHardcoded(res)) {
-                    if (dict.get(res)) |comp| {
-                        ccd_clf.?.addComponent(&comp) catch continue;
-                        loaded += 1;
-                    }
+                    try needed.put(res, {});
+                }
+            }
+            var loaded: usize = 0;
+            var it = needed.keyIterator();
+            while (it.next()) |key_ptr| {
+                if (dict.get(key_ptr.*)) |comp| {
+                    ccd_clf.?.addComponent(&comp) catch |err| {
+                        if (!quiet) {
+                            std.debug.print("Warning: Could not derive CCD properties for '{s}': {s}\n", .{ key_ptr.*, @errorName(err) });
+                        }
+                        continue;
+                    };
+                    loaded += 1;
                 }
             }
             if (!quiet and loaded > 0) {

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -1075,20 +1075,18 @@ fn applyBuiltinClassifier(
 
     if (ccd_clf != null) {
         if (external_ccd) |dict| {
-            var it = dict.components.iterator();
-            while (it.next()) |entry| {
-                const comp_id = entry.key_ptr.*;
-                if (!classifier_ccd.CcdClassifier.isHardcoded(comp_id)) {
-                    const comp = entry.value_ptr.view();
-                    ccd_clf.?.addComponent(&comp) catch {};
+            var loaded: usize = 0;
+            for (0..n) |i| {
+                const res = residues[i].slice();
+                if (!classifier_ccd.CcdClassifier.isHardcoded(res)) {
+                    if (dict.get(res)) |comp| {
+                        ccd_clf.?.addComponent(&comp) catch continue;
+                        loaded += 1;
+                    }
                 }
             }
-            if (!quiet) {
-                const total = dict.components.count();
-                const runtime = ccd_clf.?.runtime_components.count();
-                if (runtime > 0) {
-                    std.debug.print("CCD: {d} external components loaded ({d} runtime-derived)\n", .{ total, runtime });
-                }
+            if (!quiet and loaded > 0) {
+                std.debug.print("CCD: {d} non-standard components derived from external CCD\n", .{loaded});
             }
         }
     }

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -20,6 +20,9 @@ const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_protor = @import("classifier_protor.zig");
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
+const ccd_parser = @import("ccd_parser.zig");
+const ccd_binary = @import("ccd_binary.zig");
+const gzip = @import("gzip.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -126,6 +129,7 @@ pub const TrajArgs = struct {
     n_slices: u32 = 20,
     precision: Precision = .f32, // Default f32 for trajectory (speed)
     classifier_type: ?ClassifierType = null,
+    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz])
     stride: u32 = 1, // Process every Nth frame
     start_frame: u32 = 0, // Start frame
     end_frame: ?u32 = null, // End frame (null = all)
@@ -182,6 +186,16 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
             } else if (std.mem.startsWith(u8, arg, "--classifier=")) {
                 const value = arg["--classifier=".len..];
                 result.classifier_type = parseClassifierType(value);
+            } else if (std.mem.startsWith(u8, arg, "--ccd=")) {
+                const value = arg["--ccd=".len..];
+                result.ccd_path = value;
+            } else if (std.mem.eql(u8, arg, "--ccd")) {
+                i += 1;
+                if (i >= args.len) {
+                    std.debug.print("Error: Missing value for --ccd\n", .{});
+                    std.process.exit(1);
+                }
+                result.ccd_path = args[i];
             } else if (std.mem.startsWith(u8, arg, "--stride=")) {
                 const value = arg["--stride=".len..];
                 result.stride = std.fmt.parseInt(u32, value, 10) catch {
@@ -312,6 +326,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --algorithm=ALGO   Algorithm: sr (shrake-rupley), lr (lee-richards)
         \\                       Default: sr
         \\    --classifier=TYPE  Built-in classifier: naccess, protor, oons, ccd
+        \\    --ccd=PATH         External CCD dictionary file (.zsdc or .cif[.gz])
+        \\                       Used with --classifier=ccd for non-standard residues
         \\    --threads=N        Number of threads (default: auto-detect)
         \\    --probe-radius=R   Probe radius in Angstroms (default: 1.4)
         \\    --n-points=N       Test points per atom (default: 100, for sr)
@@ -654,9 +670,29 @@ pub fn run(allocator: Allocator, args: TrajArgs) !void {
         std.debug.print("Topology: {d} atoms\n", .{natoms});
     }
 
+    // Load external CCD dictionary if specified
+    var ext_ccd: ?ccd_parser.ComponentDict = null;
+    if (args.ccd_path) |ccd_path| {
+        const ccd_data = if (std.mem.endsWith(u8, ccd_path, ".gz"))
+            try gzip.readGzip(allocator, ccd_path)
+        else blk: {
+            const f = try std.fs.cwd().openFile(ccd_path, .{});
+            defer f.close();
+            break :blk try f.readToEndAlloc(allocator, 4 * 1024 * 1024 * 1024);
+        };
+        defer allocator.free(ccd_data);
+
+        ext_ccd = try ccd_binary.loadDict(allocator, ccd_data);
+        if (!args.quiet) {
+            std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), ccd_path });
+        }
+    }
+    defer if (ext_ccd) |*d| d.deinit();
+
     // Apply classifier if specified
     if (args.classifier_type) |ct| {
-        try applyBuiltinClassifier(allocator, &topology, ct, args.quiet);
+        const ext_ccd_ptr: ?*const ccd_parser.ComponentDict = if (ext_ccd != null) &ext_ccd.? else null;
+        try applyBuiltinClassifier(allocator, &topology, ct, ext_ccd_ptr, args.quiet);
     }
 
     // Open trajectory file
@@ -1026,15 +1062,36 @@ fn applyBuiltinClassifier(
     _: Allocator,
     input: *AtomInput,
     ct: ClassifierType,
+    external_ccd: ?*const ccd_parser.ComponentDict,
     quiet: bool,
 ) !void {
     const n = input.atomCount();
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
-    // For CCD: create classifier instance (hardcoded table is compile-time, no setup cost)
+    // For CCD: create classifier instance and feed external CCD components
     var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd) classifier_ccd.CcdClassifier.init(input.allocator) else null;
     defer if (ccd_clf) |*c| c.deinit();
+
+    if (ccd_clf != null) {
+        if (external_ccd) |dict| {
+            var it = dict.components.iterator();
+            while (it.next()) |entry| {
+                const comp_id = entry.key_ptr.*;
+                if (!classifier_ccd.CcdClassifier.isHardcoded(comp_id)) {
+                    const comp = entry.value_ptr.view();
+                    ccd_clf.?.addComponent(&comp) catch {};
+                }
+            }
+            if (!quiet) {
+                const total = dict.components.count();
+                const runtime = ccd_clf.?.runtime_components.count();
+                if (runtime > 0) {
+                    std.debug.print("CCD: {d} external components loaded ({d} runtime-derived)\n", .{ total, runtime });
+                }
+            }
+        }
+    }
 
     var classified_count: usize = 0;
     var fallback_count: usize = 0;


### PR DESCRIPTION
## Summary

- Add `--ccd <path>` CLI option for external CCD dictionary files
- Add `compile-dict` subcommand to convert CIF to binary ZSDC format
- Add `src/ccd_binary.zig` for binary CCD format (read/write/auto-detect)
- Support both CIF text (.cif/.cif.gz) and binary (.zsdc) formats

## Usage

```bash
# One-time: compile CCD to binary (49790 components in ~30s)
zsasa compile-dict components.cif.gz -o components.zsdc

# Use with CCD classifier
zsasa calc -c ccd --ccd components.zsdc --include-hetatm structure.cif.gz
```

## Key design decisions

- **ZSDC format** — freesasa-zig original, stores only atom_id/type_symbol/bonds (no coordinates/charges). 42MB vs 110MB for gzip CIF
- **Filtered loading** — only derives CCD properties for residues present in the input structure (not all 49K components)
- **Auto-detection** — `loadDict()` checks ZSDC magic bytes, falls back to CIF text parsing

## Verified

- 3hhb (hemoglobin + HEM): 4608/4612 classified, 4 fallback (Fe ions)
- components.cif.gz (49790 compounds) → components.zsdc (42MB) in 30s
- No memory leaks (fixed key duplication in addComponent)

## Test plan

- [x] Binary format: round-trip, magic detection, empty dict, auto-detect (8 tests)
- [x] All existing tests pass
- [x] CLI smoke test with real PDB data