### PR TITLE
feat: auto-include HETATM when using CCD classifier

### DIFF
--- a/src/batch.zig
+++ b/src/batch.zig
@@ -1430,7 +1430,7 @@ pub fn run(allocator: Allocator, args: BatchArgs) !void {
         .quiet = args.quiet,
         .classifier_type = args.classifier_type,
         .include_hydrogens = args.include_hydrogens,
-        .include_hetatm = args.include_hetatm,
+        .include_hetatm = args.include_hetatm or (args.classifier_type == .ccd),
         .use_bitmask = args.use_bitmask,
         .store_atom_areas = (args.output_format == .jsonl),
         .external_ccd = if (ext_ccd != null) &ext_ccd.? else null,

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -807,9 +807,17 @@ pub fn run(allocator: std.mem.Allocator, args: CalcArgs) !void {
         return error.MissingArgument;
     };
 
+    // CCD classifier implies HETATM inclusion (the whole point is classifying non-standard residues)
+    var effective_args = args;
+    if (effective_args.classifier_type) |ct| {
+        if (ct == .ccd and !effective_args.include_hetatm) {
+            effective_args.include_hetatm = true;
+        }
+    }
+
     // Read input file (JSON, PDB, or mmCIF)
     timer.reset();
-    var read_result = readInputFile(allocator, input_path, args) catch |err| {
+    var read_result = readInputFile(allocator, input_path, effective_args) catch |err| {
         std.debug.print("Error reading input file '{s}': {s}\n", .{ input_path, @errorName(err) });
         std.process.exit(1);
     };


### PR DESCRIPTION
## Summary

- `-c ccd` now automatically includes HETATM records without needing `--include-hetatm`
- CCD classifier's primary purpose is classifying non-standard residues, so excluding HETATM by default was inconsistent

## Changes

- `calc.zig`: Override `include_hetatm = true` when classifier is `.ccd`
- `batch.zig`: Same logic when building `BatchConfig`

## Test plan

- [x] `zsasa calc -c ccd 3hhb.cif.gz` now includes HEM atoms (4612 atoms, was 4379 without HETATM)
- [x] All tests pass