### PR TITLE
feat: add CCD classifier to Python bindings

### DIFF
--- a/python/tests/test_sasa.py
+++ b/python/tests/test_sasa.py
@@ -222,6 +222,7 @@ class TestClassifierTypes:
         assert ClassifierType.NACCESS == 0
         assert ClassifierType.PROTOR == 1
         assert ClassifierType.OONS == 2
+        assert ClassifierType.CCD == 3
 
     def test_classifier_type_is_int(self):
         """Classifier types should be usable as integers."""
@@ -296,7 +297,12 @@ class TestGetAtomClass:
 
     def test_different_classifiers(self):
         """Different classifiers should give consistent polarity."""
-        for classifier in [ClassifierType.NACCESS, ClassifierType.PROTOR, ClassifierType.OONS]:
+        for classifier in [
+            ClassifierType.NACCESS,
+            ClassifierType.PROTOR,
+            ClassifierType.OONS,
+            ClassifierType.CCD,
+        ]:
             assert get_atom_class("ALA", "CA", classifier) == AtomClass.APOLAR
             assert get_atom_class("ALA", "O", classifier) == AtomClass.POLAR
 
@@ -408,11 +414,13 @@ class TestClassifyAtoms:
         result_naccess = classify_atoms(["ALA"], ["CA"], ClassifierType.NACCESS)
         result_protor = classify_atoms(["ALA"], ["CA"], ClassifierType.PROTOR)
         result_oons = classify_atoms(["ALA"], ["CA"], ClassifierType.OONS)
+        result_ccd = classify_atoms(["ALA"], ["CA"], ClassifierType.CCD)
 
         # All should return valid radii
         assert not np.isnan(result_naccess.radii[0])
         assert not np.isnan(result_protor.radii[0])
         assert not np.isnan(result_oons.radii[0])
+        assert not np.isnan(result_ccd.radii[0])
 
     def test_classification_result_repr(self):
         """ClassificationResult should have a clean repr."""

--- a/python/zsasa/core.py
+++ b/python/zsasa/core.py
@@ -56,6 +56,7 @@ ZSASA_ALGORITHM_LR = 1
 ZSASA_CLASSIFIER_NACCESS = 0
 ZSASA_CLASSIFIER_PROTOR = 1
 ZSASA_CLASSIFIER_OONS = 2
+ZSASA_CLASSIFIER_CCD = 3
 
 # Atom classes
 ZSASA_ATOM_CLASS_POLAR = 0
@@ -449,11 +450,13 @@ class ClassifierType(IntEnum):
         NACCESS: NACCESS-compatible radii (default, most commonly used).
         PROTOR: ProtOr radii based on hybridization state.
         OONS: Ooi, Oobatake, Nemethy, Scheraga radii (older FreeSASA default).
+        CCD: CCD-based radii derived from bond topology (ProtOr-compatible).
     """
 
     NACCESS = ZSASA_CLASSIFIER_NACCESS
     PROTOR = ZSASA_CLASSIFIER_PROTOR
     OONS = ZSASA_CLASSIFIER_OONS
+    CCD = ZSASA_CLASSIFIER_CCD
 
 
 class AtomClass(IntEnum):


### PR DESCRIPTION
## Summary

- Add `ClassifierType.CCD = 3` to Python API
- Update tests to cover CCD classifier in polarity and radius tests

## Usage

```python
from zsasa import ClassifierType, get_radius, get_atom_class

radius = get_radius("ALA", "CA", ClassifierType.CCD)
cls = get_atom_class("ALA", "O", ClassifierType.CCD)
```

## Test plan

- [x] `test_classifier_type_values` — CCD == 3
- [x] `test_different_classifiers` — CCD returns correct polarity
- [x] `test_different_classifiers` (classify_atoms) — CCD returns valid radii