### PR TITLE
fix: bump python/pyproject.toml to 0.2.8

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zsasa"
-version = "0.2.7"
+version = "0.2.8"
 description = "Fast SASA calculation using Zig"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `python/pyproject.toml` version from 0.2.7 to 0.2.8
- Was missed in the v0.2.8 release, causing PyPI publish to fail (wheels built as 0.2.7 which already exists)

## After merge

Need to re-tag v0.2.8 (delete + recreate) or create v0.2.8.1 to trigger publish workflow.