### PR TITLE
fix: revert gzip to native std.compress.flate

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,11 +41,16 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
 
-    // Shared library for C API / Python bindings
+    // Shared library for C API / Python bindings.
+    // libc is required because c_api.zig uses std.heap.c_allocator (so the
+    // FFI surface uses C's malloc/free rather than a per-call GeneralPurposeAllocator,
+    // matching Python ctypes' lifetime expectations). On macOS the dylib auto-links
+    // libSystem so this is implicit, but Linux needs the explicit flag.
     const lib_module = b.createModule(.{
         .root_source_file = b.path("src/c_api.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
         .imports = &.{
             .{ .name = "zxdrfile", .module = zxdrfile_mod },
         },

--- a/build.zig
+++ b/build.zig
@@ -6,27 +6,11 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // zlib dependency (built from source via allyourcodebase/zlib)
-    const zlib_dep = b.dependency("zlib", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const zlib_artifact = zlib_dep.artifact("z");
-
-    // PIC-enabled zlib for shared library builds
-    const zlib_pic_dep = b.dependency("zlib", .{
-        .target = target,
-        .optimize = optimize,
-        .pie = true,
-    });
-    const zlib_pic_artifact = zlib_pic_dep.artifact("z");
-
     // Library module (exposed to package consumers via zig fetch)
     const mod = b.addModule("zsasa", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
     });
-    mod.linkLibrary(zlib_artifact);
 
     const zxdrfile_dep = b.dependency("zxdrfile", .{
         .target = target,
@@ -50,7 +34,6 @@ pub fn build(b: *std.Build) void {
             .{ .name = "zxdrfile", .module = zxdrfile_mod },
         },
     });
-    exe_module.linkLibrary(zlib_artifact);
 
     const exe = b.addExecutable(.{
         .name = "zsasa",
@@ -58,36 +41,15 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
 
-    // Translate zlib.h to a Zig module via addTranslateC (preferred over @cImport
-    // in 0.16). The wrapper header (src/c/zlib_wrapper.h) exists because
-    // addTranslateC requires a build-rooted b.path() as root_source_file; lazy
-    // paths returned from dependencies (e.g. zlib_dep.path("zlib.h")) cannot
-    // serve as the root — only as include paths.
-    const zlib_c = b.addTranslateC(.{
-        .root_source_file = b.path("src/c/zlib_wrapper.h"),
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
-    });
-    zlib_c.addIncludePath(zlib_dep.path("."));
-    const zlib_c_mod = zlib_c.createModule();
-
-    // Wire zlib_c into the modules that need it
-    mod.addImport("zlib_c", zlib_c_mod);
-    exe_module.addImport("zlib_c", zlib_c_mod);
-
     // Shared library for C API / Python bindings
     const lib_module = b.createModule(.{
         .root_source_file = b.path("src/c_api.zig"),
         .target = target,
         .optimize = optimize,
-        .link_libc = true,
         .imports = &.{
             .{ .name = "zxdrfile", .module = zxdrfile_mod },
         },
     });
-    lib_module.linkLibrary(zlib_pic_artifact);
-    lib_module.addImport("zlib_c", zlib_c_mod);
 
     const lib = b.addLibrary(.{
         .linkage = .dynamic,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,10 +36,6 @@
             .url = "git+https://github.com/N283T/zxdrfile.git?ref=v0.4.0#47d8c42cff9b098febd1990cc50438c26987f85c",
             .hash = "zxdrfile-0.4.0-JIaQ9mIfAgAHB9bW-_p9g6_gfd0tyG3-MmA0LYJKB8rb",
         },
-        .zlib = .{
-            .url = "git+https://github.com/allyourcodebase/zlib.git?ref=v1.3.1.1-2#c5115f4b69ef660f72a835c6638f80508ef284c7",
-            .hash = "zlib-1.3.1-1-ZZQ7ldENAAA7qJjUXP6E6xnRuV-jDL9dyoJFc_eb3zQ6",
-        },
     },
     .paths = .{
         "build.zig",

--- a/src/c/zlib_wrapper.h
+++ b/src/c/zlib_wrapper.h
@@ -1,2 +1,0 @@
-/* Wrapper consumed by build.zig addTranslateC; see build.zig comment for rationale. */
-#include <zlib.h>

--- a/src/gzip.zig
+++ b/src/gzip.zig
@@ -1,58 +1,99 @@
-//! Gzip decompression using C zlib.
+//! Gzip decompression using native std.compress.flate.
 //!
-//! Workaround for Zig 0.15 flate bug (unreachable in Writer.rebase).
-//! See: https://github.com/ziglang/zig/issues/25035
-//!
-//! TODO(PR2): revert to std.compress.flate now that ziglang/zig#25035 is fixed
-//! in Zig 0.16. Verify regression with 2oxd.cif.gz (the original reproducer).
+//! Restored after #320's C-zlib workaround. The upstream panic
+//! (https://github.com/ziglang/zig/issues/25035) is fixed in Zig 0.16.
 
 const std = @import("std");
-const c = @import("zlib_c");
 
 pub const GzipError = error{ GzipOpenFailed, GzipReadFailed, FileTooLarge, OutOfMemory };
 
 const CHUNK_SIZE = 64 * 1024; // 64 KB read chunks
 
-/// Default max decompressed size: 4 GB
+/// Default max decompressed size: 4 GB.
 pub const DEFAULT_MAX_SIZE: usize = 4 * 1024 * 1024 * 1024;
 
-/// Decompress a gzip file using C zlib. Caller owns the returned slice.
+/// Decompress a gzip file. Caller owns the returned slice.
 pub fn readGzip(allocator: std.mem.Allocator, path: []const u8) GzipError![]u8 {
     return readGzipLimited(allocator, path, DEFAULT_MAX_SIZE);
 }
 
 /// Decompress a gzip file with a custom size limit. Caller owns the returned slice.
+/// The size limit is checked before each chunk read so a malicious file cannot
+/// allocate more than `max_size` bytes before the cap is detected.
 pub fn readGzipLimited(allocator: std.mem.Allocator, path: []const u8, max_size: usize) GzipError![]u8 {
-    const c_path = try allocator.dupeZ(u8, path);
-    defer allocator.free(c_path);
+    // NOTE: gzip.zig deliberately does not take an `io: std.Io` parameter to
+    // preserve the existing public API used by all callers (mmcif/pdb/json/sdf
+    // parsers + batch + compile_dict + the FFI surface in c_api.zig). The
+    // function-local single-threaded Threaded is sufficient for the synchronous
+    // file-read + decompress pipeline used here. We use a function-local
+    // instance (rather than std.Io.Threaded.global_single_threaded) so the
+    // threading guarantee is statically obvious — gzip.zig is reachable from
+    // batch.zig worker threads spawned via std.Thread.spawn.
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io = threaded.io();
 
-    const gz = c.gzopen(c_path.ptr, "rb") orelse return error.GzipOpenFailed;
-    var gz_closed = false;
-    errdefer if (!gz_closed) {
-        _ = c.gzclose(gz);
-    };
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch return error.GzipOpenFailed;
+    defer file.close(io);
+
+    var file_buf: [CHUNK_SIZE]u8 = undefined;
+    var file_reader = file.reader(io, &file_buf);
+
+    // Native gzip decompressor. The window buffer must be at least
+    // flate.max_window_len (64 KB) to support generic reads that go through
+    // the indirect (buffered) vtable used by readSliceShort/readVec.
+    // 64 KB on stack — required by the indirect (buffered) Decompress vtable
+    // path used by readSliceShort/readVec; see flate.history_len.
+    var window_buf: [std.compress.flate.max_window_len]u8 = undefined;
+    var decompress: std.compress.flate.Decompress = .init(&file_reader.interface, .gzip, &window_buf);
+    const reader: *std.Io.Reader = &decompress.reader;
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer buf.deinit(allocator);
 
+    // Compute CRC32 over the decompressed bytes so we can verify the gzip
+    // trailer ourselves. std.compress.flate parses the trailer fields into
+    // decompress.container_metadata.gzip.{crc,count} but does NOT compare them
+    // against the actual decoded bytes. Without this verification, a corrupt
+    // .cif.gz with a valid frame structure but a bad checksum would silently
+    // return wrong bytes — a real correctness regression for the SASA pipeline
+    // (the previous C-zlib version verified CRC via gzclose).
+    var crc = std.hash.Crc32.init();
+
     while (true) {
         if (buf.items.len >= max_size) return error.FileTooLarge;
-        const to_read = @min(CHUNK_SIZE, max_size - buf.items.len);
-        try buf.ensureUnusedCapacity(allocator, to_read);
-        const dest = buf.unusedCapacitySlice()[0..to_read];
-        const n = c.gzread(gz, dest.ptr, @intCast(dest.len));
-        if (n < 0) return error.GzipReadFailed;
+        const room = max_size - buf.items.len;
+        const want = @min(CHUNK_SIZE, room);
+        try buf.ensureUnusedCapacity(allocator, want);
+        const dest = buf.unusedCapacitySlice()[0..want];
+        const n = reader.readSliceShort(dest) catch {
+            // The underlying decompressor parks the real cause (BadGzipHeader,
+            // InvalidCode, WrongStoredBlockNlen, raw I/O error, etc.) on
+            // decompress.err. Surface it via the log so debugging corrupt
+            // archives doesn't require a debugger.
+            if (decompress.err) |inner| {
+                std.log.warn("gzip decode failed for {s}: {s}", .{ path, @errorName(inner) });
+            }
+            return error.GzipReadFailed;
+        };
         if (n == 0) break;
-        buf.items.len += @intCast(n);
+        crc.update(dest[0..n]);
+        buf.items.len += n;
     }
 
-    // gzclose checks CRC — detect corrupt data before returning
-    const close_result = c.gzclose(gz);
-    gz_closed = true;
-    if (close_result != c.Z_OK) {
-        buf.deinit(allocator);
+    // Verify gzip trailer: std.compress.flate does not check CRC / ISIZE for
+    // us. Without this, a corrupt .cif.gz can decompress silently to wrong
+    // bytes. See the comment above the Crc32.init() for context.
+    const meta = decompress.container_metadata.gzip;
+    if (crc.final() != meta.crc) {
+        std.log.warn("gzip CRC mismatch for {s}", .{path});
         return error.GzipReadFailed;
     }
+    const truncated_size: u32 = @truncate(buf.items.len);
+    if (truncated_size != meta.count) {
+        std.log.warn("gzip ISIZE mismatch for {s}", .{path});
+        return error.GzipReadFailed;
+    }
+
     return buf.toOwnedSlice(allocator);
 }
 
@@ -109,4 +150,27 @@ test "readGzipLimited returns FileTooLarge when limit exceeded" {
     // Limit to 5 bytes — "Hello world\n" is 12 bytes, should fail
     const result = readGzipLimited(allocator, tmp_path, 5);
     try std.testing.expectError(error.FileTooLarge, result);
+}
+
+test "readGzip rejects gzip with corrupted CRC" {
+    const allocator = std.testing.allocator;
+
+    // Same "Hello world\n" gzip as above, but with one byte of the CRC32 flipped.
+    var gz_data = [_]u8{
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+        0x01, 0x0c, 0x00, 0xf3, 0xff, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
+        0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a, 0xd5, 0xe0, 0x39,
+        0xb7, 0x0c, 0x00, 0x00, 0x00,
+    };
+    gz_data[27] ^= 0xff; // corrupt first byte of CRC32 trailer
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "test.gz", .data = &gz_data });
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "test.gz", allocator);
+    defer allocator.free(tmp_path);
+
+    const result = readGzip(allocator, tmp_path);
+    try std.testing.expectError(error.GzipReadFailed, result);
 }


### PR DESCRIPTION
## Summary
- Rewrite `src/gzip.zig` on top of `std.compress.flate.Decompress` with `Container.gzip`. Public API (`readGzip` / `readGzipLimited` / `DEFAULT_MAX_SIZE` / `GzipError`) and the 4 GB decompression-bomb cap unchanged.
- Drop the `zlib` dependency, the `b.addTranslateC` step, the `linkLibrary` calls, and `src/c/zlib_wrapper.h` from `build.zig` and `build.zig.zon`.
- Reverts the C-zlib workaround introduced in #320; the upstream panic ziglang/zig#25035 is fixed in Zig 0.16.

Callers (`mmcif_parser.zig`, `pdb_parser.zig`, `json_parser.zig`, `sdf_parser.zig`, `calc.zig`, `batch.zig`, `compile_dict.zig`) are not touched.

## Notable behavior change

`std.compress.flate` parses the gzip trailer (CRC32 + ISIZE) but does **not** verify it against the decompressed bytes. The previous C-zlib version verified CRC via `gzclose`. To preserve that correctness guarantee, this PR adds explicit CRC32 + ISIZE verification after the decompress loop and surfaces the underlying decompressor error via `std.log.warn`. A new test (`readGzip rejects gzip with corrupted CRC`) exercises the regression case.

Refs: #342

## 2oxd.cif.gz headline check (PR2 raison d'être)

```
Classifier 'CCD': 2713 atoms classified, 0 fallback
Calculated SASA for 2713 atoms
Total area: 15546.61 Å²

Per-chain SASA:
  A: 15546.61 Å² (2713 atoms)
Output written to output.json
```

## 9-way smoke matrix
```
## 9-way smoke matrix
=== ccd × examples/1ubq.pdb ===
Classifier 'CCD': 660 atoms classified, 0 fallback
Calculated SASA for 660 atoms
Total area: 5656.65 Å²
=== ccd × examples/1ubq.cif ===
Classifier 'CCD': 660 atoms classified, 0 fallback
Calculated SASA for 660 atoms
Total area: 5656.65 Å²
=== ccd × test_data/ethanol_v2000.sdf ===
Classifier 'CCD': 3 atoms classified, 0 fallback
Calculated SASA for 3 atoms
Total area: 164.80 Å²
=== naccess × examples/1ubq.pdb ===
Classifier 'NACCESS': 602 atoms classified, 0 fallback
Calculated SASA for 602 atoms
Total area: 4823.29 Å²
=== naccess × examples/1ubq.cif ===
Classifier 'NACCESS': 602 atoms classified, 0 fallback
Calculated SASA for 602 atoms
Total area: 4823.29 Å²
=== naccess × test_data/ethanol_v2000.sdf ===
Classifier 'NACCESS': 3 atoms classified, 0 fallback
Calculated SASA for 3 atoms
Total area: 169.51 Å²
=== oons × examples/1ubq.pdb ===
Classifier 'OONS': 602 atoms classified, 0 fallback
Calculated SASA for 602 atoms
Total area: 4779.51 Å²
=== oons × examples/1ubq.cif ===
Classifier 'OONS': 602 atoms classified, 0 fallback
Calculated SASA for 602 atoms
Total area: 4779.51 Å²
=== oons × test_data/ethanol_v2000.sdf ===
Classifier 'OONS': 3 atoms classified, 0 fallback
Calculated SASA for 3 atoms
Total area: 166.58 Å²
```

## Batch smoke (also exercises gzip via 1crn/3hhb .cif.gz)
```

Processing: 0/5Processing: 5/5

Batch Results:
  Total files:     5
  Successful:      5
  Failed:          0
  Total SASA time: 16.28 ms
  Total time:      60.62 ms (includes I/O)
  Throughput:      82.5 files/sec
```

## Traj smoke
```
Reading topology: test_data/1l2y.pdb
Topology: 304 atoms
Classifier 'NACCESS': 304 atoms classified, 0 fallback
Opening trajectory (DCD): test_data/1l2y.dcd
Algorithm: Shrake-Rupley, Threads: 10, Precision: f32
Processing frames...

Batch size: 20 frames
  Processed 38 frames in 6ms (6333.3 frames/sec)
Output written to: traj_sasa.csv
```

## Python bindings
```
tests/test_xtc.py::TestRepr::test_trajectory_sasa_result_repr PASSED     [100%]

======================= 145 passed, 16 skipped in 1.24s ========================
```

## Test plan
- [x] `zig build` clean
- [x] `zig build test` 531/532 pass (1 skip), +1 new bad-CRC regression test
- [x] `zig build -Doptimize=ReleaseFast` clean
- [x] `zsasa calc 2oxd.cif.gz` → 2713 atoms, 15546.61 Å² (native flate)
- [x] 9-way classifier × format smoke matrix
- [x] `zsasa batch examples/` smoke (5/5, includes gzip via 1crn/3hhb .cif.gz)
- [x] `zsasa traj` smoke (38 frames)
- [x] `python pytest` 145 pass / 16 skip