### PR TITLE
fix: clean up Zig 0.15.2 pins and Windows mmap reader regression

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Zig Version
       description: Output of `zig version`
-      placeholder: "0.15.2"
+      placeholder: "0.16.0"
     validations:
       required: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to zsasa!
 
 ### Prerequisites
 
-- **Zig 0.15.2+** - Required for building the project
+- **Zig 0.16.0+** - Required for building the project
 - **Python 3.11+** - Required for benchmarks and Python bindings
 - **FreeSASA C** (optional) - For benchmark comparisons
 
@@ -43,7 +43,7 @@ pip install -e ".[dev]"
 pytest tests/ -v
 ```
 
-Note: Requires Zig 0.15.2+ to be installed. The build hook compiles the library with ReleaseFast optimization.
+Note: Requires Zig 0.16.0+ to be installed. The build hook compiles the library with ReleaseFast optimization.
 
 For benchmark scripts:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM alpine:3.21 AS builder
 # Install Zig
 RUN apk add --no-cache curl xz git && \
     ARCH=$(uname -m) && \
-    curl -fsSL "https://ziglang.org/download/0.15.2/zig-${ARCH}-linux-0.15.2.tar.xz" | \
+    curl -fsSL "https://ziglang.org/download/0.16.0/zig-${ARCH}-linux-0.16.0.tar.xz" | \
     tar -xJ -C /usr/local && \
-    ln -s /usr/local/zig-${ARCH}-linux-0.15.2/zig /usr/local/bin/zig
+    ln -s /usr/local/zig-${ARCH}-linux-0.16.0/zig /usr/local/bin/zig
 
 # Copy source and build
 WORKDIR /src

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 set -eu
 
 REPO="N283T/zsasa"
-REQUIRED_ZIG_VERSION="0.15.2"
+REQUIRED_ZIG_VERSION="0.16.0"
 DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
 
 # ---------------------------------------------------------------------------

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -110,7 +110,7 @@ class ZigBuildHook(BuildHookInterface):
         zig_cmd = self._find_zig()
         if not zig_cmd:
             msg = (
-                "Zig compiler not found. Install Zig 0.15.2+ from "
+                "Zig compiler not found. Install Zig 0.16.0+ from "
                 "https://ziglang.org/download/ or run: pip install ziglang"
             )
             raise RuntimeError(msg)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -73,11 +73,14 @@ test-command = "pytest {project}/python/tests/test_sasa.py {project}/python/test
 [tool.cibuildwheel.linux]
 # Use manylinux_2_28 (glibc 2.28) containers to match Zig glibc target.
 # Default manylinux2014 (glibc 2.17) is too old for our glibc 2.28 target.
-manylinux-x86_64-image = "manylinux_2_28"
-manylinux-aarch64-image = "manylinux_2_28"
+# Pin to an explicit quay.io tag because the short alias resolves to a
+# tag baked into cibuildwheel that has been retired upstream
+# (e.g. 2026.03.01-1 disappeared from quay.io and broke v0.2.10's wheel build).
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:2026.04.25-0"
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64:2026.04.25-0"
 # Download Zig directly from official release (avoids PyPI rate limits).
 # $(uname -m) resolves to x86_64 or aarch64 depending on the runner.
-before-all = "curl -sSfL https://ziglang.org/download/0.15.2/zig-$(uname -m)-linux-0.15.2.tar.xz | tar -xJ -C /usr/local && ln -sf /usr/local/zig-$(uname -m)-linux-0.15.2/zig /usr/local/bin/zig && zig build -Doptimize=ReleaseFast -Dtarget=$(uname -m)-linux-gnu.2.28"
+before-all = "curl -sSfL https://ziglang.org/download/0.16.0/zig-$(uname -m)-linux-0.16.0.tar.xz | tar -xJ -C /usr/local && ln -sf /usr/local/zig-$(uname -m)-linux-0.16.0/zig /usr/local/bin/zig && zig build -Doptimize=ReleaseFast -Dtarget=$(uname -m)-linux-gnu.2.28"
 
 [tool.cibuildwheel.macos]
 # Zig installed by setup-zig action in workflow (not via PyPI).

--- a/python/zsasa/_ffi.py
+++ b/python/zsasa/_ffi.py
@@ -224,7 +224,7 @@ def _find_library() -> Path:
     msg = (
         f"Could not find {lib_name}. "
         f"Please install with: pip install zsasa "
-        f"(requires Zig 0.15.2+ to be installed)"
+        f"(requires Zig 0.16.0+ to be installed)"
     )
     raise FileNotFoundError(msg)
 

--- a/src/mmap_reader.zig
+++ b/src/mmap_reader.zig
@@ -33,11 +33,14 @@ pub fn mmapFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8) !Map
     if (is_windows) {
         var read_buf: [65536]u8 = undefined;
         var r = file.reader(io, &read_buf);
-        // Cap read to the file size obtained above to avoid unbounded allocation.
-        // .limited64 accepts u64 and treats values > maxInt(usize) as .unlimited.
-        const data = try r.interface.allocRemaining(allocator, .limited64(size));
-        // Detect TOCTOU: file grew/shrank between stat and read.
-        std.debug.assert(data.len == size);
+        // Use .unlimited rather than .limited64(size). On Windows the file
+        // size reported by stat occasionally diverges from the byte count
+        // produced by the buffered reader (text-mode line-ending handling
+        // and similar quirks), causing spurious StreamTooLong errors on
+        // benign reads of input fixtures (#352 / v0.2.10 publish failure).
+        // For trusted local input files this is acceptable; callers of
+        // mmapFile already trust the path.
+        const data = try r.interface.allocRemaining(allocator, .unlimited);
         return .{ .data = data, .allocator = allocator };
     } else {
         const mapped = try std.posix.mmap(

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -41,7 +41,7 @@ curl -fsSL https://raw.githubusercontent.com/N283T/zsasa/main/install.sh | sh
 # Or with custom install directory
 curl -fsSL https://raw.githubusercontent.com/N283T/zsasa/main/install.sh | INSTALL_DIR=/usr/local/bin sh
 
-# Or build from source (requires Zig 0.15.2)
+# Or build from source (requires Zig 0.16.0)
 git clone https://github.com/N283T/zsasa.git
 cd zsasa
 zig build -Doptimize=ReleaseFast

--- a/website/docs/python-api/index.md
+++ b/website/docs/python-api/index.md
@@ -48,7 +48,7 @@ Python 3.11-3.13 supported.
 
 ### From Source (Development)
 
-Requires Zig 0.15.2+.
+Requires Zig 0.16.0+.
 
 ```bash
 cd zsasa/python


### PR DESCRIPTION
## Summary

Hotfix for the Build & Publish workflow which has been silently broken since v0.2.9.

PR1 (#345) missed several Zig version pins outside the canonical `build.zig.zon` / `flake.nix` / `.github/workflows/` set. v0.2.10's publish surfaced these plus two follow-on issues:

| # | Issue | Impact |
|---|---|---|
| 1 | `Dockerfile` pinned Zig 0.15.2 | Docker preflight failed (0.15 toolchain rejecting 0.16 API) |
| 2 | `python/pyproject.toml` cibuildwheel `before-all` pinned 0.15.2 | Linux wheels (x86_64 + aarch64) failed |
| 3 | 7 other text references (install.sh, hatch_build.py, _ffi.py, docs, ISSUE template) | Stale claims to users |
| 4 | cibuildwheel short alias `manylinux_2_28` → retired tag `2026.03.01-1` on quay.io | aarch64 wheel: `Error response from daemon: No such image` |
| 5 | Windows path in `mmap_reader.zig` used `.limited64(size)` | Spurious `StreamTooLong` reading `examples/1ubq.cif` (Windows wheel test) |

## Changes

- Bulk replace `0.15.2` → `0.16.0` in 9 files
- Pin manylinux images explicitly to `quay.io/pypa/manylinux_2_28_{x86_64,aarch64}:2026.04.25-0` (current tag)
- Switch Windows `mmapFile` to `.unlimited` (the cap was defensive but conflicted with Windows reader byte-count quirks; the calling parsers already trust the path)

## Test plan

- [x] `zig build` clean
- [x] `zig build test` 531/532 pass (1 skip)
- [x] `zig build -Doptimize=ReleaseFast` clean
- [x] `zsasa calc examples/1ubq.cif` works on macOS (mmap path unchanged)
- [ ] CI: Docker preflight (was the headline failure)
- [ ] CI: Wheels (Linux x86_64 + aarch64 + Windows + macOS)
- [ ] CI: Validate example, Format, Build, Python

Once CI passes, the next release (v0.2.11) republishes wheels + docker for the gzip-native-flate change in v0.2.10.

Refs: #342