### PR TITLE
[codex] add zstd compressed input support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Zstandard decompression for structure inputs**: `.json.zst`, `.pdb.zst`, `.cif.zst`, `.mmcif.zst`, `.ent.zst`, `.sdf.zst`, and `.mol.zst` are now detected and transparently decompressed via native `std.compress.zstd`.
+
 ## [0.2.11] - 2026-04-26
 
 ### Fixed

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -17,7 +17,7 @@ const classifier_ccd = @import("classifier_ccd.zig");
 const ccd_parser = @import("ccd_parser.zig");
 const ccd_binary = @import("ccd_binary.zig");
 const sdf_parser = @import("sdf_parser.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -109,10 +109,12 @@ fn getOutputExtension(format: OutputFormat) []const u8 {
 
 /// Replace file extension for output (e.g., "file.pdb" -> "file.json")
 fn replaceExtension(allocator: Allocator, filename: []const u8, new_ext: []const u8) ![]const u8 {
-    // Strip .gz if present
+    // Strip compression extension if present.
     var base = filename;
-    if (std.mem.endsWith(u8, base, ".gz")) {
+    if (compressed.isGzip(base)) {
         base = base[0 .. base.len - 3];
+    } else if (compressed.isZstd(base)) {
+        base = base[0 .. base.len - 4];
     }
 
     // Find and strip existing extension
@@ -129,9 +131,13 @@ fn replaceExtension(allocator: Allocator, filename: []const u8, new_ext: []const
 /// Strips the SDF file extension to produce "stem_molname" or "stem_N" format.
 /// This ensures `replaceExtension` produces unique output filenames.
 fn sdfMoleculeDisplayName(allocator: Allocator, filename: []const u8, mol_name: []const u8, mol_idx: usize) ![]const u8 {
-    // Strip extension (.sdf, .sdf.gz, .mol, .mol.gz) to get stem
+    // Strip extension (.sdf, .sdf.gz, .sdf.zst, .mol, .mol.gz, .mol.zst) to get stem.
     var base = filename;
-    if (std.mem.endsWith(u8, base, ".gz")) base = base[0 .. base.len - 3];
+    if (compressed.isGzip(base)) {
+        base = base[0 .. base.len - 3];
+    } else if (compressed.isZstd(base)) {
+        base = base[0 .. base.len - 4];
+    }
     const stem = if (std.mem.findScalarLast(u8, base, '.')) |dot_idx|
         base[0..dot_idx]
     else
@@ -351,8 +357,8 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             break :blk parser.parseFile(io, path);
         },
         .sdf => blk: {
-            const source = if (std.mem.endsWith(u8, path, ".gz"))
-                try gzip.readGzip(allocator, path)
+            const source = if (compressed.isCompressed(path))
+                try compressed.read(allocator, path)
             else file_blk: {
                 const f = try std.Io.Dir.cwd().openFile(io, path, .{});
                 defer f.close(io);
@@ -984,8 +990,8 @@ pub fn runBatchSequential(
                 continue;
             };
 
-            const source = if (std.mem.endsWith(u8, input_path, ".gz"))
-                gzip.readGzip(arena.allocator(), input_path) catch |err| {
+            const source = if (compressed.isCompressed(input_path))
+                compressed.read(arena.allocator(), input_path) catch |err| {
                     const filename_copy = try allocator.dupe(u8, filename);
                     try results_list.append(allocator, FileResult{
                         .filename = filename_copy,
@@ -1366,10 +1372,10 @@ fn buildWorkItems(
             const input_path = try std.fs.path.join(allocator, &.{ input_dir, filename });
             defer allocator.free(input_path);
 
-            const source = if (std.mem.endsWith(u8, input_path, ".gz"))
-                gzip.readGzip(allocator, input_path) catch |err| {
+            const source = if (compressed.isCompressed(input_path))
+                compressed.read(allocator, input_path) catch |err| {
                     // If read fails, add a single error item
-                    logWarning("{s}: failed to read SDF (gzip): {s}", .{ filename, @errorName(err) });
+                    logWarning("{s}: failed to read SDF (compressed): {s}", .{ filename, @errorName(err) });
                     try items.append(allocator, .{
                         .filename = filename,
                         .display_name = filename,
@@ -1656,7 +1662,7 @@ pub const BatchArgs = struct {
     include_hydrogens: bool = false,
     include_hetatm: bool = false,
     use_bitmask: bool = false,
-    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz])
+    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz|.zst])
     sdf_paths: SdfPathList = .{}, // --sdf=PATH (up to 16)
     quiet: bool = false,
     show_timing: bool = false,
@@ -1985,7 +1991,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\                        Default: sr
         \\    --classifier=TYPE   Built-in classifier: ccd, protor, naccess, oons
         \\                        Default: ccd (protor is an alias for ccd)
-        \\    --ccd=PATH          External CCD dictionary file (.zsdc or .cif[.gz])
+        \\    --ccd=PATH          External CCD dictionary file (.zsdc or .cif[.gz|.zst])
         \\                        Used with --classifier=ccd for non-standard residues
         \\    --sdf=PATH          SDF file with bond topology for CCD classifier
         \\                        Can be specified multiple times for multiple ligands
@@ -2030,8 +2036,8 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     // Load external CCD dictionary if specified
     var ext_ccd: ?ccd_parser.ComponentDict = null;
     if (args.ccd_path) |ccd_path| {
-        const ccd_data = if (std.mem.endsWith(u8, ccd_path, ".gz"))
-            gzip.readGzip(allocator, ccd_path) catch |err| {
+        const ccd_data = if (compressed.isCompressed(ccd_path))
+            compressed.read(allocator, ccd_path) catch |err| {
                 std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
                 std.process.exit(1);
             }

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -22,7 +22,7 @@ const classifier_ccd = @import("classifier_ccd.zig");
 const ccd_parser = @import("ccd_parser.zig");
 const ccd_binary = @import("ccd_binary.zig");
 const sdf_parser = @import("sdf_parser.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 
 const Config = types.Config;
 const Configf32 = types.Configf32;
@@ -63,7 +63,7 @@ pub const CalcArgs = struct {
     rsa: bool = false, // Show RSA (Relative Solvent Accessibility)
     polar: bool = false, // Show polar/nonpolar SASA summary
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
-    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz])
+    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz|.zst])
     sdf_paths: SdfPathList = .{}, // --sdf=PATH (up to 16)
     mol_selector: ?[]const u8 = null, // --mol=NAME or --mol=N (1-based index)
     quiet: bool = false,
@@ -498,7 +498,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --classifier=TYPE  Built-in classifier: ccd, protor, naccess, oons
         \\                       Default: ccd for PDB/mmCIF, none for JSON
         \\                       protor is an alias for ccd
-        \\    --ccd=PATH         External CCD dictionary file (.zsdc or .cif[.gz])
+        \\    --ccd=PATH         External CCD dictionary file (.zsdc or .cif[.gz|.zst])
         \\                       Extends CCD coverage for non-standard residues
         \\    --sdf=PATH         SDF file with bond topology for CCD classifier
         \\                       Can be specified multiple times for multiple ligands
@@ -651,8 +651,8 @@ fn readInputFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, arg
             break :blk .{ .input = try parser.parseFile(io, path) };
         },
         .sdf => blk: {
-            const source = if (std.mem.endsWith(u8, path, ".gz"))
-                try gzip.readGzip(allocator, path)
+            const source = if (compressed.isCompressed(path))
+                try compressed.read(allocator, path)
             else file_blk: {
                 const f = try std.Io.Dir.cwd().openFile(io, path, .{});
                 defer f.close(io);
@@ -1056,8 +1056,8 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
             // Load external CCD dictionary if specified
             var ext_ccd: ?ccd_parser.ComponentDict = null;
             if (args.ccd_path) |ccd_path| {
-                const ccd_data = if (std.mem.endsWith(u8, ccd_path, ".gz"))
-                    gzip.readGzip(allocator, ccd_path) catch |err| {
+                const ccd_data = if (compressed.isCompressed(ccd_path))
+                    compressed.read(allocator, ccd_path) catch |err| {
                         std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
                         std.process.exit(1);
                     }

--- a/src/compile_dict.zig
+++ b/src/compile_dict.zig
@@ -1,7 +1,7 @@
 //! compile-dict subcommand: convert CIF text CCD data to ZSDC binary format.
 //!
 //! Usage:
-//!   zsasa compile-dict <input.cif[.gz]> -o <output.zsdc>
+//!   zsasa compile-dict <input.cif[.gz|.zst]> -o <output.zsdc>
 //!
 //! Reads a CIF (Chemical Component Dictionary) file, parses all components,
 //! and writes a compact binary dictionary suitable for use with `--ccd`.
@@ -10,17 +10,17 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ccd_parser = @import("ccd_parser.zig");
 const ccd_binary = @import("ccd_binary.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 
 pub fn printHelp(program_name: []const u8) void {
     std.debug.print(
         \\zsasa compile-dict - Compile CIF dictionary to binary ZSDC format
         \\
         \\USAGE:
-        \\    {s} compile-dict <input.cif[.gz]> -o <output.zsdc>
+        \\    {s} compile-dict <input.cif[.gz|.zst]> -o <output.zsdc>
         \\
         \\ARGUMENTS:
-        \\    <input>          Input CIF file (supports .gz compression)
+        \\    <input>          Input CIF file (supports .gz and .zst compression)
         \\
         \\OPTIONS:
         \\    -o, --output PATH  Output binary dictionary file (required)
@@ -28,7 +28,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\
         \\EXAMPLES:
         \\    {s} compile-dict components.cif -o components.zsdc
-        \\    {s} compile-dict components.cif.gz -o components.zsdc
+        \\    {s} compile-dict components.cif.zst -o components.zsdc
         \\
     , .{ program_name, program_name, program_name });
 }
@@ -72,7 +72,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: []const []const u8) !void {
 
     const in_path = input_path orelse {
         std.debug.print("Error: Missing input file\n", .{});
-        std.debug.print("Usage: zsasa compile-dict <input.cif[.gz]> -o <output.zsdc>\n", .{});
+        std.debug.print("Usage: zsasa compile-dict <input.cif[.gz|.zst]> -o <output.zsdc>\n", .{});
         return error.MissingArgument;
     };
 
@@ -81,10 +81,10 @@ pub fn run(allocator: Allocator, io: std.Io, args: []const []const u8) !void {
         return error.MissingArgument;
     };
 
-    // Read input file (handle .gz)
+    // Read input file (handle .gz/.zst)
     std.debug.print("Reading '{s}'...\n", .{in_path});
-    const source = if (std.mem.endsWith(u8, in_path, ".gz"))
-        try gzip.readGzip(allocator, in_path)
+    const source = if (compressed.isCompressed(in_path))
+        try compressed.read(allocator, in_path)
     else blk: {
         const file = std.Io.Dir.cwd().openFile(io, in_path, .{}) catch |err| {
             std.debug.print("Error: Could not open '{s}': {s}\n", .{ in_path, @errorName(err) });

--- a/src/compressed.zig
+++ b/src/compressed.zig
@@ -1,0 +1,32 @@
+//! Shared helpers for transparent compressed input formats.
+
+const std = @import("std");
+const gzip = @import("gzip.zig");
+const zstd = @import("zstd.zig");
+
+pub const ReadError = gzip.GzipError || zstd.ZstdError || error{NotCompressed};
+
+pub fn isGzip(path: []const u8) bool {
+    return std.mem.endsWith(u8, path, ".gz");
+}
+
+pub fn isZstd(path: []const u8) bool {
+    return std.mem.endsWith(u8, path, ".zst");
+}
+
+pub fn isCompressed(path: []const u8) bool {
+    return isGzip(path) or isZstd(path);
+}
+
+/// Read a supported compressed file. Caller owns the returned slice.
+pub fn read(allocator: std.mem.Allocator, path: []const u8) ReadError![]u8 {
+    if (isGzip(path)) return gzip.readGzip(allocator, path);
+    if (isZstd(path)) return zstd.readZstd(allocator, path);
+    return error.NotCompressed;
+}
+
+test "isCompressed recognizes gzip and zstd" {
+    try std.testing.expect(isCompressed("file.cif.gz"));
+    try std.testing.expect(isCompressed("file.cif.zst"));
+    try std.testing.expect(!isCompressed("file.cif"));
+}

--- a/src/format_detect.zig
+++ b/src/format_detect.zig
@@ -8,22 +8,29 @@ pub const InputFormat = enum {
     sdf,
 };
 
-/// Supported file extensions (lowercase, with .gz compression)
+/// Supported file extensions (lowercase, with .gz/.zst compression)
 pub const supported_extensions = [_][]const u8{
     ".json",
     ".json.gz",
+    ".json.zst",
     ".pdb",
     ".pdb.gz",
+    ".pdb.zst",
     ".cif",
     ".cif.gz",
+    ".cif.zst",
     ".mmcif",
     ".mmcif.gz",
+    ".mmcif.zst",
     ".ent",
     ".ent.gz",
+    ".ent.zst",
     ".sdf",
     ".sdf.gz",
+    ".sdf.zst",
     ".mol",
     ".mol.gz",
+    ".mol.zst",
 };
 
 /// Check if filename has a supported structure file extension
@@ -44,17 +51,20 @@ pub fn isSupportedFile(name: []const u8) bool {
     return false;
 }
 
-/// Strip .gz extension from path
-fn stripGzExt(path: []const u8) []const u8 {
+/// Strip supported compression extension from path.
+fn stripCompressionExt(path: []const u8) []const u8 {
     if (std.mem.endsWith(u8, path, ".gz")) {
         return path[0 .. path.len - 3];
+    }
+    if (std.mem.endsWith(u8, path, ".zst")) {
+        return path[0 .. path.len - 4];
     }
     return path;
 }
 
-/// Detect input file format from extension (handles .gz compression)
+/// Detect input file format from extension (handles .gz/.zst compression)
 pub fn detectInputFormat(path: []const u8) InputFormat {
-    const base = stripGzExt(path);
+    const base = stripCompressionExt(path);
 
     // mmCIF formats
     if (std.mem.endsWith(u8, base, ".cif")) return .mmcif;
@@ -87,11 +97,13 @@ test "isSupportedFile accepts structure files" {
     // PDB
     try std.testing.expect(isSupportedFile("structure.pdb"));
     try std.testing.expect(isSupportedFile("structure.pdb.gz"));
+    try std.testing.expect(isSupportedFile("structure.pdb.zst"));
     try std.testing.expect(isSupportedFile("structure.PDB"));
 
     // mmCIF
     try std.testing.expect(isSupportedFile("structure.cif"));
     try std.testing.expect(isSupportedFile("structure.cif.gz"));
+    try std.testing.expect(isSupportedFile("structure.cif.zst"));
     try std.testing.expect(isSupportedFile("structure.mmcif"));
     try std.testing.expect(isSupportedFile("structure.CIF"));
     try std.testing.expect(isSupportedFile("structure.mmCIF"));
@@ -103,6 +115,7 @@ test "isSupportedFile accepts structure files" {
     // JSON
     try std.testing.expect(isSupportedFile("structure.json"));
     try std.testing.expect(isSupportedFile("structure.json.gz"));
+    try std.testing.expect(isSupportedFile("structure.json.zst"));
 
     // Unsupported
     try std.testing.expect(!isSupportedFile("structure.txt"));
@@ -127,16 +140,21 @@ test "detectInputFormat handles plain files" {
 
 test "detectInputFormat handles .gz compressed files" {
     try std.testing.expectEqual(InputFormat.pdb, detectInputFormat("file.pdb.gz"));
+    try std.testing.expectEqual(InputFormat.pdb, detectInputFormat("file.pdb.zst"));
     try std.testing.expectEqual(InputFormat.mmcif, detectInputFormat("file.cif.gz"));
+    try std.testing.expectEqual(InputFormat.mmcif, detectInputFormat("file.cif.zst"));
     try std.testing.expectEqual(InputFormat.json, detectInputFormat("file.json.gz"));
+    try std.testing.expectEqual(InputFormat.json, detectInputFormat("file.json.zst"));
 }
 
 test "isSupportedFile accepts SDF/MOL files" {
     try std.testing.expect(isSupportedFile("molecule.sdf"));
     try std.testing.expect(isSupportedFile("molecule.sdf.gz"));
+    try std.testing.expect(isSupportedFile("molecule.sdf.zst"));
     try std.testing.expect(isSupportedFile("molecule.SDF"));
     try std.testing.expect(isSupportedFile("molecule.mol"));
     try std.testing.expect(isSupportedFile("molecule.mol.gz"));
+    try std.testing.expect(isSupportedFile("molecule.mol.zst"));
     try std.testing.expect(isSupportedFile("molecule.MOL"));
 }
 
@@ -146,5 +164,7 @@ test "detectInputFormat handles SDF/MOL files" {
     try std.testing.expectEqual(InputFormat.sdf, detectInputFormat("file.mol"));
     try std.testing.expectEqual(InputFormat.sdf, detectInputFormat("file.MOL"));
     try std.testing.expectEqual(InputFormat.sdf, detectInputFormat("file.sdf.gz"));
+    try std.testing.expectEqual(InputFormat.sdf, detectInputFormat("file.sdf.zst"));
     try std.testing.expectEqual(InputFormat.sdf, detectInputFormat("file.mol.gz"));
+    try std.testing.expectEqual(InputFormat.sdf, detectInputFormat("file.mol.zst"));
 }

--- a/src/gzip.zig
+++ b/src/gzip.zig
@@ -17,10 +17,18 @@ pub fn readGzip(allocator: std.mem.Allocator, path: []const u8) GzipError![]u8 {
     return readGzipLimited(allocator, path, DEFAULT_MAX_SIZE);
 }
 
+const ReadOptions = struct {
+    log_errors: bool = true,
+};
+
 /// Decompress a gzip file with a custom size limit. Caller owns the returned slice.
 /// The size limit is checked before each chunk read so a malicious file cannot
 /// allocate more than `max_size` bytes before the cap is detected.
 pub fn readGzipLimited(allocator: std.mem.Allocator, path: []const u8, max_size: usize) GzipError![]u8 {
+    return readGzipLimitedOptions(allocator, path, max_size, .{});
+}
+
+fn readGzipLimitedOptions(allocator: std.mem.Allocator, path: []const u8, max_size: usize, options: ReadOptions) GzipError![]u8 {
     // NOTE: gzip.zig deliberately does not take an `io: std.Io` parameter to
     // preserve the existing public API used by all callers (mmcif/pdb/json/sdf
     // parsers + batch + compile_dict + the FFI surface in c_api.zig). The
@@ -70,8 +78,10 @@ pub fn readGzipLimited(allocator: std.mem.Allocator, path: []const u8, max_size:
             // InvalidCode, WrongStoredBlockNlen, raw I/O error, etc.) on
             // decompress.err. Surface it via the log so debugging corrupt
             // archives doesn't require a debugger.
-            if (decompress.err) |inner| {
-                std.log.warn("gzip decode failed for {s}: {s}", .{ path, @errorName(inner) });
+            if (options.log_errors) {
+                if (decompress.err) |inner| {
+                    std.log.warn("gzip decode failed for {s}: {s}", .{ path, @errorName(inner) });
+                }
             }
             return error.GzipReadFailed;
         };
@@ -85,12 +95,16 @@ pub fn readGzipLimited(allocator: std.mem.Allocator, path: []const u8, max_size:
     // bytes. See the comment above the Crc32.init() for context.
     const meta = decompress.container_metadata.gzip;
     if (crc.final() != meta.crc) {
-        std.log.warn("gzip CRC mismatch for {s}", .{path});
+        if (options.log_errors) {
+            std.log.warn("gzip CRC mismatch for {s}", .{path});
+        }
         return error.GzipReadFailed;
     }
     const truncated_size: u32 = @truncate(buf.items.len);
     if (truncated_size != meta.count) {
-        std.log.warn("gzip ISIZE mismatch for {s}", .{path});
+        if (options.log_errors) {
+            std.log.warn("gzip ISIZE mismatch for {s}", .{path});
+        }
         return error.GzipReadFailed;
     }
 
@@ -171,6 +185,6 @@ test "readGzip rejects gzip with corrupted CRC" {
     const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "test.gz", allocator);
     defer allocator.free(tmp_path);
 
-    const result = readGzip(allocator, tmp_path);
+    const result = readGzipLimitedOptions(allocator, tmp_path, DEFAULT_MAX_SIZE, .{ .log_errors = false });
     try std.testing.expectError(error.GzipReadFailed, result);
 }

--- a/src/gzip.zig
+++ b/src/gzip.zig
@@ -68,7 +68,24 @@ fn readGzipLimitedOptions(allocator: std.mem.Allocator, path: []const u8, max_si
     var crc = std.hash.Crc32.init();
 
     while (true) {
-        if (buf.items.len >= max_size) return error.FileTooLarge;
+        if (buf.items.len == max_size) {
+            var extra: [1]u8 = undefined;
+            const n = reader.readSliceShort(&extra) catch {
+                // The underlying decompressor parks the real cause (BadGzipHeader,
+                // InvalidCode, WrongStoredBlockNlen, raw I/O error, etc.) on
+                // decompress.err. Surface it via the log so debugging corrupt
+                // archives doesn't require a debugger.
+                if (options.log_errors) {
+                    if (decompress.err) |inner| {
+                        std.log.warn("gzip decode failed for {s}: {s}", .{ path, @errorName(inner) });
+                    }
+                }
+                return error.GzipReadFailed;
+            };
+            if (n == 0) break;
+            return error.FileTooLarge;
+        }
+
         const room = max_size - buf.items.len;
         const want = @min(CHUNK_SIZE, room);
         try buf.ensureUnusedCapacity(allocator, want);
@@ -141,6 +158,30 @@ test "readGzip returns GzipOpenFailed for nonexistent file" {
     const allocator = std.testing.allocator;
     const result = readGzip(allocator, "/nonexistent/path/file.gz");
     try std.testing.expectError(error.GzipOpenFailed, result);
+}
+
+test "readGzipLimited accepts exact size limit" {
+    const allocator = std.testing.allocator;
+
+    // Minimal gzip containing "Hello world\n" (12 bytes decompressed)
+    const gz_data = [_]u8{
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+        0x01, 0x0c, 0x00, 0xf3, 0xff, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
+        0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a, 0xd5, 0xe0, 0x39,
+        0xb7, 0x0c, 0x00, 0x00, 0x00,
+    };
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "test.gz", .data = &gz_data });
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "test.gz", allocator);
+    defer allocator.free(tmp_path);
+
+    const content = try readGzipLimited(allocator, tmp_path, 12);
+    defer allocator.free(content);
+
+    try std.testing.expectEqualStrings("Hello world\n", content);
 }
 
 test "readGzipLimited returns FileTooLarge when limit exceeded" {

--- a/src/json_parser.zig
+++ b/src/json_parser.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const types = @import("types.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 const AtomInput = types.AtomInput;
 const Allocator = std.mem.Allocator;
 
@@ -130,11 +130,19 @@ pub fn printValidationErrors(errors: []const ValidationError) void {
     }
 }
 
+const DuplicateCoordinateOptions = struct {
+    log_warning: bool = true,
+};
+
 /// Check for duplicate coordinates and print warning if found.
 /// Returns the number of duplicate coordinate sets found.
 /// This is a warning only - duplicate atoms can cause SASA calculation discrepancies
 /// but are not treated as validation errors.
 pub fn checkDuplicateCoordinates(allocator: Allocator, input: AtomInput) !usize {
+    return checkDuplicateCoordinatesOptions(allocator, input, .{});
+}
+
+fn checkDuplicateCoordinatesOptions(allocator: Allocator, input: AtomInput, options: DuplicateCoordinateOptions) !usize {
     const n = input.atomCount();
     if (n < 2) return 0;
 
@@ -169,7 +177,7 @@ pub fn checkDuplicateCoordinates(allocator: Allocator, input: AtomInput) !usize 
         }
     }
 
-    if (duplicate_count > 0) {
+    if (duplicate_count > 0 and options.log_warning) {
         std.debug.print(
             "Warning: Found {} duplicate coordinate(s) in {} atoms. " ++
                 "This may cause SASA calculation discrepancies with other tools.\n",
@@ -271,12 +279,12 @@ pub fn parseAtomInput(allocator: Allocator, json_str: []const u8) !AtomInput {
     };
 }
 
-/// Read atom input from JSON file (handles both .json and .json.gz)
+/// Read atom input from JSON file (handles plain, .gz, and .zst files)
 pub fn readAtomInputFromFile(allocator: Allocator, io: std.Io, path: []const u8) !AtomInput {
     const max_size = 200 * 1024 * 1024; // 200 MB max
 
-    const contents = if (std.mem.endsWith(u8, path, ".gz"))
-        try gzip.readGzip(allocator, path)
+    const contents = if (compressed.isCompressed(path))
+        try compressed.read(allocator, path)
     else blk: {
         const file = try std.Io.Dir.cwd().openFile(io, path, .{});
         defer file.close(io);
@@ -753,7 +761,7 @@ test "checkDuplicateCoordinates with duplicates" {
         .allocator = allocator,
     };
 
-    const count = try checkDuplicateCoordinates(allocator, input);
+    const count = try checkDuplicateCoordinatesOptions(allocator, input, .{ .log_warning = false });
     try std.testing.expectEqual(@as(usize, 2), count);
 }
 

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -32,7 +32,7 @@ const Allocator = std.mem.Allocator;
 const cif = @import("cif_tokenizer.zig");
 const elem = @import("element.zig");
 const mmap_reader = @import("mmap_reader.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 const types = @import("types.zig");
 const AtomInput = types.AtomInput;
 const ccd_parser = @import("ccd_parser.zig");
@@ -172,10 +172,10 @@ pub const MmcifParser = struct {
         };
     }
 
-    /// Parse mmCIF from a file (handles both plain and .gz compressed)
+    /// Parse mmCIF from a file (handles plain, .gz, and .zst compressed)
     pub fn parseFile(self: *MmcifParser, io: std.Io, path: []const u8) !AtomInput {
-        if (std.mem.endsWith(u8, path, ".gz")) {
-            const data = try gzip.readGzip(self.allocator, path);
+        if (compressed.isCompressed(path)) {
+            const data = try compressed.read(self.allocator, path);
             defer self.allocator.free(data);
             return self.parse(data);
         }

--- a/src/pdb_parser.zig
+++ b/src/pdb_parser.zig
@@ -35,7 +35,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const elem = @import("element.zig");
 const mmap_reader = @import("mmap_reader.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 const types = @import("types.zig");
 const AtomInput = types.AtomInput;
 
@@ -213,10 +213,10 @@ pub const PdbParser = struct {
         };
     }
 
-    /// Parse PDB from a file (handles both plain and .gz compressed)
+    /// Parse PDB from a file (handles plain, .gz, and .zst compressed)
     pub fn parseFile(self: *PdbParser, io: std.Io, path: []const u8) !AtomInput {
-        if (std.mem.endsWith(u8, path, ".gz")) {
-            const data = try gzip.readGzip(self.allocator, path);
+        if (compressed.isCompressed(path)) {
+            const data = try compressed.read(self.allocator, path);
             defer self.allocator.free(data);
             return self.parse(data);
         }

--- a/src/root.zig
+++ b/src/root.zig
@@ -37,6 +37,8 @@ pub const dcd = @import("dcd.zig");
 pub const bitmask_lut = @import("bitmask_lut.zig");
 pub const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
 pub const gzip = @import("gzip.zig");
+pub const zstd = @import("zstd.zig");
+pub const compressed = @import("compressed.zig");
 pub const hybridization = @import("hybridization.zig");
 pub const ccd_parser = @import("ccd_parser.zig");
 pub const classifier_ccd = @import("classifier_ccd.zig");
@@ -59,6 +61,8 @@ test {
     _ = bitmask_lut;
     _ = shrake_rupley_bitmask;
     _ = gzip;
+    _ = zstd;
+    _ = compressed;
     _ = hybridization;
     _ = ccd_parser;
     _ = classifier_ccd;

--- a/src/sdf_parser.zig
+++ b/src/sdf_parser.zig
@@ -32,7 +32,7 @@ const Allocator = std.mem.Allocator;
 const elem = @import("element.zig");
 const hybridization = @import("hybridization.zig");
 const ccd_parser = @import("ccd_parser.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 const types = @import("types.zig");
 
 // =============================================================================
@@ -691,7 +691,7 @@ pub const SdfPathList = struct {
 
 /// Load SDF files and build a ComponentDict from their bond topology.
 ///
-/// Reads each SDF file (plain or gzip-compressed), parses molecules, and
+/// Reads each SDF file (plain, gzip-compressed, or zstd-compressed), parses molecules, and
 /// converts them to StoredComponents. Duplicate molecule names (truncated
 /// to 5 chars) are skipped to avoid leaking the first entry.
 ///
@@ -708,8 +708,8 @@ pub fn loadSdfComponents(
     errdefer dict.deinit();
 
     for (sdf_paths) |sdf_path| {
-        const source = if (std.mem.endsWith(u8, sdf_path, ".gz"))
-            gzip.readGzip(allocator, sdf_path) catch |err| {
+        const source = if (compressed.isCompressed(sdf_path))
+            compressed.read(allocator, sdf_path) catch |err| {
                 std.debug.print("Error reading SDF file '{s}': {s}\n", .{ sdf_path, @errorName(err) });
                 std.process.exit(1);
             }

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -23,7 +23,7 @@ const classifier_ccd = @import("classifier_ccd.zig");
 const ccd_parser = @import("ccd_parser.zig");
 const ccd_binary = @import("ccd_binary.zig");
 const sdf_parser = @import("sdf_parser.zig");
-const gzip = @import("gzip.zig");
+const compressed = @import("compressed.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -132,7 +132,7 @@ pub const TrajArgs = struct {
     n_slices: u32 = 20,
     precision: Precision = .f32, // Default f32 for trajectory (speed)
     classifier_type: ?ClassifierType = .naccess, // Default: NACCESS for trajectories (supports explicit H)
-    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz])
+    ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz|.zst])
     sdf_paths: SdfPathList = .{}, // --sdf=PATH (up to 16)
     stride: u32 = 1, // Process every Nth frame
     start_frame: u32 = 0, // Start frame
@@ -344,7 +344,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\                       Default: sr
         \\    --classifier=TYPE  Built-in classifier: ccd, protor, naccess, oons
         \\                       Default: naccess (supports explicit H in MD trajectories)
-        \\    --ccd=PATH         External CCD dictionary file (.zsdc or .cif[.gz])
+        \\    --ccd=PATH         External CCD dictionary file (.zsdc or .cif[.gz|.zst])
         \\                       Used with --classifier=ccd for non-standard residues
         \\    --sdf=PATH         SDF file with bond topology for CCD classifier
         \\                       Can be specified multiple times for multiple ligands
@@ -699,8 +699,8 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
     // Load external CCD dictionary if specified
     var ext_ccd: ?ccd_parser.ComponentDict = null;
     if (args.ccd_path) |ccd_path| {
-        const ccd_data = if (std.mem.endsWith(u8, ccd_path, ".gz"))
-            try gzip.readGzip(allocator, ccd_path)
+        const ccd_data = if (compressed.isCompressed(ccd_path))
+            try compressed.read(allocator, ccd_path)
         else blk: {
             const f = try std.Io.Dir.cwd().openFile(io, ccd_path, .{});
             defer f.close(io);

--- a/src/zstd.zig
+++ b/src/zstd.zig
@@ -1,0 +1,102 @@
+//! Zstandard decompression using native std.compress.zstd.
+
+const std = @import("std");
+
+pub const ZstdError = error{ ZstdOpenFailed, ZstdReadFailed, FileTooLarge, OutOfMemory };
+
+const CHUNK_SIZE = 64 * 1024;
+
+/// Default max decompressed size: 4 GB.
+pub const DEFAULT_MAX_SIZE: usize = 4 * 1024 * 1024 * 1024;
+
+/// Decompress a zstd file. Caller owns the returned slice.
+pub fn readZstd(allocator: std.mem.Allocator, path: []const u8) ZstdError![]u8 {
+    return readZstdLimited(allocator, path, DEFAULT_MAX_SIZE);
+}
+
+/// Decompress a zstd file with a custom size limit. Caller owns the returned slice.
+pub fn readZstdLimited(allocator: std.mem.Allocator, path: []const u8, max_size: usize) ZstdError![]u8 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io = threaded.io();
+
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch return error.ZstdOpenFailed;
+    defer file.close(io);
+
+    var file_buf: [CHUNK_SIZE]u8 = undefined;
+    var file_reader = file.reader(io, &file_buf);
+    return readZstdFromReader(allocator, path, &file_reader.interface, max_size);
+}
+
+fn readZstdFromReader(allocator: std.mem.Allocator, path: []const u8, input: *std.Io.Reader, max_size: usize) ZstdError![]u8 {
+    const window_len = std.compress.zstd.default_window_len;
+    const zstd_buf = try allocator.alloc(u8, window_len + std.compress.zstd.block_size_max);
+    defer allocator.free(zstd_buf);
+
+    var decompress: std.compress.zstd.Decompress = .init(input, zstd_buf, .{
+        .window_len = window_len,
+    });
+    const reader: *std.Io.Reader = &decompress.reader;
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer buf.deinit(allocator);
+
+    while (true) {
+        if (buf.items.len >= max_size) return error.FileTooLarge;
+        const room = max_size - buf.items.len;
+        const want = @min(CHUNK_SIZE, room);
+        try buf.ensureUnusedCapacity(allocator, want);
+        const dest = buf.unusedCapacitySlice()[0..want];
+        const n = reader.readSliceShort(dest) catch {
+            if (decompress.err) |inner| {
+                std.log.warn("zstd decode failed for {s}: {s}", .{ path, @errorName(inner) });
+            }
+            return error.ZstdReadFailed;
+        };
+        if (n == 0) break;
+        buf.items.len += n;
+    }
+
+    return buf.toOwnedSlice(allocator);
+}
+
+test "readZstd decompresses zstd frame" {
+    const allocator = std.testing.allocator;
+
+    const zst_data = [_]u8{
+        0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x0c, 0x61, 0x00, 0x00, 0x48, 0x65, 0x6c,
+        0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a, 0x8c, 0xa0, 0x38,
+        0x9a,
+    };
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "test.zst", .data = &zst_data });
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "test.zst", allocator);
+    defer allocator.free(tmp_path);
+
+    const content = try readZstd(allocator, tmp_path);
+    defer allocator.free(content);
+
+    try std.testing.expectEqualStrings("Hello world\n", content);
+}
+
+test "readZstdLimited returns FileTooLarge when limit exceeded" {
+    const allocator = std.testing.allocator;
+
+    const zst_data = [_]u8{
+        0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x0c, 0x61, 0x00, 0x00, 0x48, 0x65, 0x6c,
+        0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a, 0x8c, 0xa0, 0x38,
+        0x9a,
+    };
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "test.zst", .data = &zst_data });
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "test.zst", allocator);
+    defer allocator.free(tmp_path);
+
+    const result = readZstdLimited(allocator, tmp_path, 5);
+    try std.testing.expectError(error.FileTooLarge, result);
+}

--- a/src/zstd.zig
+++ b/src/zstd.zig
@@ -41,7 +41,18 @@ fn readZstdFromReader(allocator: std.mem.Allocator, path: []const u8, input: *st
     errdefer buf.deinit(allocator);
 
     while (true) {
-        if (buf.items.len >= max_size) return error.FileTooLarge;
+        if (buf.items.len == max_size) {
+            var extra: [1]u8 = undefined;
+            const n = reader.readSliceShort(&extra) catch {
+                if (decompress.err) |inner| {
+                    std.log.warn("zstd decode failed for {s}: {s}", .{ path, @errorName(inner) });
+                }
+                return error.ZstdReadFailed;
+            };
+            if (n == 0) break;
+            return error.FileTooLarge;
+        }
+
         const room = max_size - buf.items.len;
         const want = @min(CHUNK_SIZE, room);
         try buf.ensureUnusedCapacity(allocator, want);
@@ -76,6 +87,28 @@ test "readZstd decompresses zstd frame" {
     defer allocator.free(tmp_path);
 
     const content = try readZstd(allocator, tmp_path);
+    defer allocator.free(content);
+
+    try std.testing.expectEqualStrings("Hello world\n", content);
+}
+
+test "readZstdLimited accepts exact size limit" {
+    const allocator = std.testing.allocator;
+
+    const zst_data = [_]u8{
+        0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x0c, 0x61, 0x00, 0x00, 0x48, 0x65, 0x6c,
+        0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a, 0x8c, 0xa0, 0x38,
+        0x9a,
+    };
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "test.zst", .data = &zst_data });
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "test.zst", allocator);
+    defer allocator.free(tmp_path);
+
+    const content = try readZstdLimited(allocator, tmp_path, 12);
     defer allocator.free(content);
 
     try std.testing.expectEqualStrings("Hello world\n", content);

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -10,7 +10,7 @@ sidebar_position: 1
 zsasa calc <input> [output] [OPTIONS]
 zsasa batch <input_dir> [output_dir] [OPTIONS]
 zsasa traj <trajectory> <topology> [output] [OPTIONS]
-zsasa compile-dict <input.cif[.gz]> -o <output.zsdc>
+zsasa compile-dict <input.cif[.gz|.zst]> -o <output.zsdc>
 ```
 
 ## Subcommands

--- a/website/docs/cli/input.md
+++ b/website/docs/cli/input.md
@@ -8,9 +8,9 @@ The input format is auto-detected from the file extension.
 
 | Extension | Format |
 |-----------|--------|
-| `.json`, `.json.gz` | JSON |
-| `.cif`, `.mmcif`, `.CIF`, `.mmCIF` | mmCIF |
-| `.pdb`, `.PDB`, `.ent`, `.ENT` | PDB |
+| `.json`, `.json.gz`, `.json.zst` | JSON |
+| `.cif`, `.cif.gz`, `.cif.zst`, `.mmcif`, `.mmcif.gz`, `.mmcif.zst`, `.CIF`, `.mmCIF` | mmCIF |
+| `.pdb`, `.pdb.gz`, `.pdb.zst`, `.PDB`, `.ent`, `.ent.gz`, `.ent.zst`, `.ENT` | PDB |
 
 ## JSON Format
 

--- a/website/docs/guide/classifiers.mdx
+++ b/website/docs/guide/classifiers.mdx
@@ -272,6 +272,7 @@ zsasa calc --classifier=ccd --ccd=components.zsdc structure.pdb output.json
 Supported input formats for `compile-dict`:
 - `.cif` — CIF text
 - `.cif.gz` — gzip-compressed CIF text
+- `.cif.zst` — Zstandard-compressed CIF text
 
 ### Hybridization Analysis
 


### PR DESCRIPTION
## Summary

- Add native Zstandard (`.zst`) decompression support via `std.compress.zstd`.
- Detect and transparently read `.json.zst`, `.pdb.zst`, `.cif.zst`, `.mmcif.zst`, `.ent.zst`, `.sdf.zst`, and `.mol.zst` inputs.
- Route gzip and zstd handling through a shared compressed-input helper.
- Suppress expected warning noise in negative/diagnostic tests while preserving production warnings.
- Update CLI docs, website docs, and changelog.

## Validation

- `PATH="$HOME/.nix-profile/bin:$PATH" zig test src/gzip.zig`
- `PATH="$HOME/.nix-profile/bin:$PATH" zig test src/json_parser.zig`
- `PATH="$HOME/.nix-profile/bin:$PATH" zig test src/format_detect.zig`
- `PATH="$HOME/.nix-profile/bin:$PATH" zig test src/zstd.zig`
- `PATH="$HOME/.nix-profile/bin:$PATH" zig test src/compressed.zig`
- `PATH="$HOME/.nix-profile/bin:$PATH" zig build test`
- `git diff --check`

## Notes

Used Zig 0.16.0 from `$HOME/.nix-profile/bin` and checked the relevant stdlib APIs with `zigdoc`.