### PR TITLE
[codex] use std progress for CLI progress bars

### DIFF
--- a/docs/superpowers/specs/2026-05-15-cli-progress-bars-design.md
+++ b/docs/superpowers/specs/2026-05-15-cli-progress-bars-design.md
@@ -1,0 +1,31 @@
+# CLI Progress Bars Design
+
+## Goal
+
+Replace the CLI's hand-written carriage-return progress messages for `batch` and `traj` with Zig's standard `std.Progress` reporting while preserving current quiet-mode and output behavior.
+
+## Scope
+
+- Applies to `zsasa batch` and `zsasa traj` only.
+- Keeps `zsasa calc` unchanged.
+- Keeps `-q, --quiet` as the single user-facing way to suppress progress.
+- Does not add new CLI flags.
+
+## Architecture
+
+Use `std.Progress.start(...)` to create a progress root in each subcommand path that currently prints periodic progress. Create child nodes for file/item processing in `batch` and frame processing in `traj`. Existing status summaries, timing output, result files, CSV, JSON, and JSONL output stay unchanged.
+
+For parallel batch processing, workers continue to update the existing atomic `processed_count`; the monitor loop owns the progress node and advances it by the observed delta. This avoids cross-thread progress node mutation. For sequential batch and trajectory paths, the processing loop advances the node after each completed item or frame.
+
+## Behavior
+
+- Non-quiet `batch` shows a standard progress bar/count for processed work items.
+- Non-quiet `traj` shows standard progress for processed frames when the total is known from `--end`; otherwise it shows an indeterminate/processed-count style progress node.
+- Quiet mode suppresses progress bars and keeps script-friendly output behavior.
+- Existing final summaries remain visible in non-quiet mode.
+
+## Testing
+
+- Unit tests should cover argument parsing remains unchanged.
+- Build/test with Zig 0.16.0 through the repository's Nix/flake tooling.
+- Smoke test `batch` on `examples/` and `traj` on `test_data/1l2y.xtc` + `test_data/1l2y.pdb` with a short frame range.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -57,6 +57,7 @@ pub const BatchConfig = struct {
     output_format: OutputFormat = .json,
     show_timing: bool = false,
     quiet: bool = false,
+    show_progress: bool = true,
     precision: Precision = .f64, // f32 or f64
     classifier_type: ?ClassifierType = .ccd, // Default: ccd (ProtOr-compatible with CCD extension)
     include_hydrogens: bool = false, // Include hydrogen atoms (default: exclude)
@@ -924,6 +925,13 @@ pub fn runBatchSequential(
         allocator.free(files);
     }
 
+    var progress_root: std.Progress.Node = if (config.show_progress)
+        std.Progress.start(io, .{ .root_name = "Processing files", .estimated_total_items = files.len })
+    else
+        .none;
+    defer progress_root.end();
+    const progress_node: ?std.Progress.Node = if (config.show_progress) progress_root else null;
+
     // Create output directory if specified
     if (output_dir) |out_dir| {
         try std.Io.Dir.cwd().createDirPath(io, out_dir);
@@ -969,7 +977,7 @@ pub fn runBatchSequential(
 
     var total_items: usize = 0;
 
-    for (files, 0..) |filename, file_idx| {
+    for (files) |filename| {
         const format = format_detect.detectInputFormat(filename);
 
         if (format == .sdf) {
@@ -1135,14 +1143,9 @@ pub fn runBatchSequential(
             _ = arena.reset(.retain_capacity);
         }
 
-        // Progress output
-        if (!config.quiet) {
-            std.debug.print("\rProcessing: {d}/{d} files", .{ file_idx + 1, files.len });
+        if (progress_node) |node| {
+            node.completeOne();
         }
-    }
-
-    if (!config.quiet) {
-        std.debug.print("\n", .{});
     }
 
     const total_time_ns: u64 = @intCast(total_timer.untilNow(io, .awake).nanoseconds);
@@ -1576,14 +1579,20 @@ pub fn runBatchParallel(
         thread.* = try std.Thread.spawn(.{}, parallelWorker, .{&ctx});
     }
 
+    var progress_root: std.Progress.Node = if (config.show_progress)
+        std.Progress.start(io, .{ .root_name = "Processing items", .estimated_total_items = work_items.len })
+    else
+        .none;
+    defer progress_root.end();
+
     // Progress monitoring (optional)
-    if (!config.quiet) {
+    if (config.show_progress) {
         while (ctx.processed_count.load(.acquire) < work_items.len) {
             const processed = ctx.processed_count.load(.acquire);
-            std.debug.print("\rProcessing: {d}/{d}", .{ processed, work_items.len });
+            progress_root.setCompletedItems(processed);
             std.Io.sleep(io, .fromMilliseconds(50), .awake) catch {}; // 50ms update interval
         }
-        std.debug.print("\rProcessing: {d}/{d}\n", .{ work_items.len, work_items.len });
+        progress_root.setCompletedItems(work_items.len);
     }
 
     // Wait for all threads to complete
@@ -1665,6 +1674,7 @@ pub const BatchArgs = struct {
     ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz|.zst])
     sdf_paths: SdfPathList = .{}, // --sdf=PATH (up to 16)
     quiet: bool = false,
+    show_progress: bool = true,
     show_timing: bool = false,
     show_help: bool = false,
 };
@@ -1918,6 +1928,7 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         // --quiet or -q
         else if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
             result.quiet = true;
+            result.show_progress = false;
         }
         // --timing
         else if (std.mem.eql(u8, arg, "--timing")) {
@@ -2096,6 +2107,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         .output_format = args.output_format,
         .show_timing = args.show_timing,
         .quiet = args.quiet,
+        .show_progress = args.show_progress,
         .classifier_type = args.classifier_type,
         .include_hydrogens = args.include_hydrogens,
         .include_hetatm = args.include_hetatm or (args.classifier_type == .ccd),
@@ -2186,6 +2198,7 @@ test "BatchArgs defaults" {
     try std.testing.expectEqual(@as(usize, 0), parsed.n_threads);
     try std.testing.expectEqual(Algorithm.sr, parsed.algorithm);
     try std.testing.expectEqual(false, parsed.quiet);
+    try std.testing.expectEqual(true, parsed.show_progress);
     try std.testing.expectEqual(false, parsed.show_help);
     try std.testing.expectEqual(false, parsed.include_hydrogens);
     try std.testing.expectEqual(false, parsed.include_hetatm);
@@ -2212,6 +2225,7 @@ test "BatchArgs with options" {
     try std.testing.expectEqual(Algorithm.lr, parsed.algorithm);
     try std.testing.expectEqual(@as(usize, 4), parsed.n_threads);
     try std.testing.expectEqual(true, parsed.quiet);
+    try std.testing.expectEqual(false, parsed.show_progress);
     try std.testing.expectEqual(true, parsed.show_timing);
 }
 

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -31,6 +31,10 @@ const OutputFormat = json_writer.OutputFormat;
 const LeeRichardsConfig = lee_richards.LeeRichardsConfig;
 const LeeRichardsConfigGen = lee_richards.LeeRichardsConfigGen;
 
+fn shouldShowProgress(config: BatchConfig) bool {
+    return config.show_progress and !config.quiet;
+}
+
 /// Write a warning message to stderr.
 ///
 /// Uses std.debug.print which writes to stderr. Note: errors during the write
@@ -925,12 +929,12 @@ pub fn runBatchSequential(
         allocator.free(files);
     }
 
-    var progress_root: std.Progress.Node = if (config.show_progress)
+    var progress_root: std.Progress.Node = if (shouldShowProgress(config))
         std.Progress.start(io, .{ .root_name = "Processing files", .estimated_total_items = files.len })
     else
         .none;
     defer progress_root.end();
-    const progress_node: ?std.Progress.Node = if (config.show_progress) progress_root else null;
+    const progress_node: ?std.Progress.Node = if (shouldShowProgress(config)) progress_root else null;
 
     // Create output directory if specified
     if (output_dir) |out_dir| {
@@ -1579,14 +1583,14 @@ pub fn runBatchParallel(
         thread.* = try std.Thread.spawn(.{}, parallelWorker, .{&ctx});
     }
 
-    var progress_root: std.Progress.Node = if (config.show_progress)
+    var progress_root: std.Progress.Node = if (shouldShowProgress(config))
         std.Progress.start(io, .{ .root_name = "Processing items", .estimated_total_items = work_items.len })
     else
         .none;
     defer progress_root.end();
 
     // Progress monitoring (optional)
-    if (config.show_progress) {
+    if (shouldShowProgress(config)) {
         while (ctx.processed_count.load(.acquire) < work_items.len) {
             const processed = ctx.processed_count.load(.acquire);
             progress_root.setCompletedItems(processed);
@@ -2327,4 +2331,9 @@ test "BatchArgs classifier_type defaults to ccd" {
     const args = [_][]const u8{ "zsasa", "batch", "input_dir/" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(ClassifierType.ccd, parsed.classifier_type);
+}
+
+test "BatchConfig quiet suppresses progress even when show_progress defaults true" {
+    const config = BatchConfig{ .quiet = true };
+    try std.testing.expectEqual(false, shouldShowProgress(config));
 }

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -141,6 +141,7 @@ pub const TrajArgs = struct {
     batch_size: u32 = 0, // Frames per batch for parallel processing (0 = auto)
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
     quiet: bool = false,
+    show_progress: bool = true,
     show_help: bool = false,
 };
 
@@ -257,6 +258,7 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
                 result.use_bitmask = true;
             } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
                 result.quiet = true;
+                result.show_progress = false;
             } else {
                 std.debug.print("Error: Unknown option: {s}\n", .{arg});
                 std.process.exit(1);
@@ -265,6 +267,7 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
             result.show_help = true;
         } else if (std.mem.eql(u8, arg, "-q")) {
             result.quiet = true;
+            result.show_progress = false;
         } else if (std.mem.startsWith(u8, arg, "-o")) {
             // -o FILE
             if (arg.len > 2) {
@@ -403,6 +406,12 @@ const FrameData = struct {
     step: i32,
     time: f32,
 };
+
+fn estimateProcessedFrames(args: TrajArgs) usize {
+    const end = args.end_frame orelse return 0;
+    if (end < args.start_frame) return 0;
+    return @as(usize, @intCast((end - args.start_frame) / args.stride)) + 1;
+}
 
 /// SASA result for one frame
 const FrameResult = struct {
@@ -830,12 +839,20 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
         .format = traj_format,
     };
 
-    if (n_threads <= 1) {
-        // Sequential path: single-threaded SASA per frame
-        try runSequential(allocator, &traj_reader, writer, &topology, args, &luts, &frame_idx, &processed_count);
-    } else {
-        // Batch parallel path: frame-level parallelism across threads
-        try runBatchParallel(allocator, &traj_reader, writer, &topology, args, &luts, n_threads, natoms, &frame_idx, &processed_count);
+    {
+        var progress_root: std.Progress.Node = if (args.show_progress)
+            std.Progress.start(io, .{ .root_name = "Processing frames", .estimated_total_items = estimateProcessedFrames(args) })
+        else
+            .none;
+        defer progress_root.end();
+
+        if (n_threads <= 1) {
+            // Sequential path: single-threaded SASA per frame
+            try runSequential(allocator, &traj_reader, writer, &topology, args, &luts, &frame_idx, &processed_count, progress_root);
+        } else {
+            // Batch parallel path: frame-level parallelism across threads
+            try runBatchParallel(allocator, &traj_reader, writer, &topology, args, &luts, n_threads, natoms, &frame_idx, &processed_count, progress_root);
+        }
     }
 
     // Flush buffered output
@@ -864,6 +881,7 @@ fn runSequential(
     luts: *const TrajLuts,
     frame_idx: *u32,
     processed_count: *u32,
+    progress_node: std.Progress.Node,
 ) !void {
     const natoms = topology.atomCount();
 
@@ -978,10 +996,7 @@ fn runSequential(
         processed_count.* += 1;
         frame_idx.* += 1;
 
-        // Progress indicator
-        if (!args.quiet and processed_count.* % 100 == 0) {
-            std.debug.print("\r  Processed {d} frames...", .{processed_count.*});
-        }
+        progress_node.completeOne();
     }
 }
 
@@ -997,6 +1012,7 @@ fn runBatchParallel(
     natoms: usize,
     frame_idx: *u32,
     processed_count: *u32,
+    progress_node: std.Progress.Node,
 ) !void {
     const batch_size: usize = if (args.batch_size > 0) args.batch_size else n_threads * 2;
 
@@ -1089,9 +1105,7 @@ fn runBatchParallel(
 
         processed_count.* += @intCast(read_result.count);
 
-        if (!args.quiet and processed_count.* % 100 < @as(u32, @intCast(read_result.count))) {
-            std.debug.print("\r  Processed {d} frames...", .{processed_count.*});
-        }
+        progress_node.setCompletedItems(processed_count.*);
 
         if (read_result.eof) break;
     }
@@ -1183,4 +1197,18 @@ fn applyBuiltinClassifier(
             fallback_count,
         });
     }
+}
+
+test "TrajArgs progress defaults to visible" {
+    const args = [_][]const u8{ "zsasa", "traj", "traj.xtc", "topology.pdb" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(false, parsed.quiet);
+    try std.testing.expectEqual(true, parsed.show_progress);
+}
+
+test "TrajArgs quiet disables progress" {
+    const args = [_][]const u8{ "zsasa", "traj", "--quiet", "traj.xtc", "topology.pdb" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.quiet);
+    try std.testing.expectEqual(false, parsed.show_progress);
 }

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -145,6 +145,10 @@ pub const TrajArgs = struct {
     show_help: bool = false,
 };
 
+fn shouldShowProgress(args: TrajArgs) bool {
+    return args.show_progress and !args.quiet;
+}
+
 /// Parse trajectory mode arguments
 pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
     var result = TrajArgs{};
@@ -840,7 +844,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
     };
 
     {
-        var progress_root: std.Progress.Node = if (args.show_progress)
+        var progress_root: std.Progress.Node = if (shouldShowProgress(args))
             std.Progress.start(io, .{ .root_name = "Processing frames", .estimated_total_items = estimateProcessedFrames(args) })
         else
             .none;
@@ -1211,4 +1215,9 @@ test "TrajArgs quiet disables progress" {
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.quiet);
     try std.testing.expectEqual(false, parsed.show_progress);
+}
+
+test "TrajArgs quiet suppresses progress even when show_progress defaults true" {
+    const args = TrajArgs{ .quiet = true };
+    try std.testing.expectEqual(false, shouldShowProgress(args));
 }

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -123,7 +123,7 @@ See [Output & Analysis](output.md#analysis-features) for detailed output descrip
 | `-o, --output=FILE` | Output file path | `output.json` |
 | `--format=FMT` | Output format: `json`, `compact`, `csv` | `json` |
 | `--timing` | Show timing breakdown (for benchmarking) | off |
-| `-q, --quiet` | Suppress progress output | off |
+| `-q, --quiet` | Suppress progress output, including standard progress bars shown by `batch` and `traj` | off |
 | `--validate` | Validate input only, do not calculate | off |
 
 ### Information Options


### PR DESCRIPTION
## Summary
- Replace hand-written `batch` and `traj` progress updates with Zig `std.Progress`.
- Keep `--quiet` as the existing switch that suppresses progress output.
- Add parser coverage for progress visibility and update CLI docs.

## Test Plan
- `/tmp/zig-0.16-check/zig-aarch64-macos-0.16.0/zig build test --summary all`
- `/tmp/zig-0.16-check/zig-aarch64-macos-0.16.0/zig build`
- `./zig-out/bin/zsasa batch examples /tmp/zsasa-progress-batch --quiet`
- `./zig-out/bin/zsasa traj test_data/1l2y.xtc test_data/1l2y.pdb --end=2 --quiet -o /tmp/zsasa-progress-traj.csv`
