### PR TITLE
[codex] add batch TOML manifests

### DIFF
--- a/docs/superpowers/plans/2026-05-17-batch-manifest.md
+++ b/docs/superpowers/plans/2026-05-17-batch-manifest.md
@@ -1,0 +1,1303 @@
+# Batch TOML Manifest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add TOML manifest support to `zsasa batch` so a single command can run named A/B/AB chain-selection batch jobs with job-separated output.
+
+**Architecture:** Extend the existing minimal TOML parser only enough for this manifest shape, add a focused `src/batch_manifest.zig` parser/resolver, then wire resolved manifest jobs into the existing `src/batch.zig` execution path. Existing non-manifest batch behavior remains the default path.
+
+**Tech Stack:** Zig 0.16, existing `std.Io` file APIs, existing `src/toml_parser.zig`, existing `src/batch.zig`, `zig build test`, `zig build run` smoke tests.
+
+---
+
+## File Structure
+
+- Modify `/Users/nagaet/zsasa/src/toml_parser.zig`
+  - Add boolean values and arrays of strings so TOML manifest files can express `use_bitmask = true` and `chains = ["A", "B"]`.
+- Create `/Users/nagaet/zsasa/src/batch_manifest.zig`
+  - Own all manifest parsing, validation, path-safe job name checks, and conversion of TOML values into manifest data structures.
+- Modify `/Users/nagaet/zsasa/src/batch.zig`
+  - Add `--manifest`, non-manifest `--chain`, `--auth-chain`, explicit CLI presence flags, chain-filter propagation, and manifest job execution.
+- Modify `/Users/nagaet/zsasa/src/root.zig`
+  - Export/import `batch_manifest` for tests and compilation coverage.
+- Modify `/Users/nagaet/zsasa/website/docs/cli/commands.md`
+  - Document `--manifest`, TOML example, precedence rules, and output layout.
+- Optionally modify `/Users/nagaet/zsasa/CHANGELOG.md`
+  - Add an unreleased entry if this repository expects every user-facing CLI feature to be listed immediately.
+
+---
+
+### Task 1: Extend TOML Parser for Manifest Values
+
+**Files:**
+- Modify: `/Users/nagaet/zsasa/src/toml_parser.zig`
+
+- [ ] **Step 1: Add failing tests for booleans and string arrays**
+
+Append these tests near the existing TOML parser tests in `/Users/nagaet/zsasa/src/toml_parser.zig`:
+
+```zig
+test "parse boolean values" {
+    const input =
+        \\use_bitmask = true
+        \\quiet = false
+    ;
+    var doc = try parse(std.testing.allocator, input);
+    defer doc.deinit();
+    const root = doc.getTable("").?;
+    try std.testing.expectEqual(@as(usize, 2), root.entries.len);
+    switch (root.entries[0].value) {
+        .boolean => |b| try std.testing.expectEqual(true, b),
+        else => return error.TestUnexpectedResult,
+    }
+    switch (root.entries[1].value) {
+        .boolean => |b| try std.testing.expectEqual(false, b),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "parse string array values" {
+    const input =
+        \\chains = ["A", "B"]
+        \\sdf = ["lig1.sdf", "lig2.sdf"]
+    ;
+    var doc = try parse(std.testing.allocator, input);
+    defer doc.deinit();
+    const root = doc.getTable("").?;
+    try std.testing.expectEqual(@as(usize, 2), root.entries.len);
+    switch (root.entries[0].value) {
+        .string_array => |items| {
+            try std.testing.expectEqual(@as(usize, 2), items.len);
+            try std.testing.expectEqualStrings("A", items[0]);
+            try std.testing.expectEqualStrings("B", items[1]);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    switch (root.entries[1].value) {
+        .string_array => |items| {
+            try std.testing.expectEqual(@as(usize, 2), items.len);
+            try std.testing.expectEqualStrings("lig1.sdf", items[0]);
+            try std.testing.expectEqualStrings("lig2.sdf", items[1]);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task1-fail.log
+```
+
+Expected: FAIL with compile errors referencing missing `boolean` and `string_array` union fields.
+
+- [ ] **Step 3: Add boolean and string-array TOML values**
+
+In `/Users/nagaet/zsasa/src/toml_parser.zig`, update `Value`:
+
+```zig
+pub const Value = union(enum) {
+    string: []const u8,
+    float: f64,
+    integer: i64,
+    boolean: bool,
+    string_array: []const []const u8,
+    inline_table: []const Entry,
+
+    pub const Entry = struct {
+        key: []const u8,
+        value: Value,
+    };
+};
+```
+
+Update `freeValue`:
+
+```zig
+fn freeValue(allocator: Allocator, value: Value) void {
+    switch (value) {
+        .inline_table => |entries| {
+            for (entries) |entry| {
+                freeValue(allocator, entry.value);
+            }
+            allocator.free(entries);
+        },
+        .string_array => |items| allocator.free(items),
+        .string, .float, .integer, .boolean => {},
+    }
+}
+```
+
+Update `parseValue` before number parsing:
+
+```zig
+fn parseValue(allocator: Allocator, raw: []const u8) Error!Value {
+    if (raw.len == 0) return error.ExpectedValue;
+
+    if (raw[0] == '"') return parseString(raw);
+    if (raw[0] == '{') return parseInlineTable(allocator, raw);
+    if (raw[0] == '[') return parseStringArray(allocator, raw);
+    if (std.mem.eql(u8, raw, "true")) return Value{ .boolean = true };
+    if (std.mem.eql(u8, raw, "false")) return Value{ .boolean = false };
+
+    return parseNumber(raw);
+}
+```
+
+Add this helper near `parseInlineTable`:
+
+```zig
+fn parseStringArray(allocator: Allocator, raw: []const u8) Error!Value {
+    std.debug.assert(raw[0] == '[');
+    const close = std.mem.findScalar(u8, raw, ']') orelse return error.UnexpectedCharacter;
+    const trailing = std.mem.trim(u8, raw[close + 1 ..], " \t");
+    if (trailing.len != 0) return error.UnexpectedCharacter;
+
+    const inner = std.mem.trim(u8, raw[1..close], " \t");
+    var items = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer items.deinit(allocator);
+
+    if (inner.len != 0) {
+        var iter = std.mem.splitScalar(u8, inner, ',');
+        while (iter.next()) |part_raw| {
+            const part = std.mem.trim(u8, part_raw, " \t");
+            if (part.len == 0) return error.ExpectedValue;
+            const parsed = try parseString(part);
+            switch (parsed) {
+                .string => |s| try items.append(allocator, s),
+                else => unreachable,
+            }
+        }
+    }
+
+    return Value{ .string_array = try items.toOwnedSlice(allocator) };
+}
+```
+
+- [ ] **Step 4: Run the TOML tests and verify they pass**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task1-pass.log
+```
+
+Expected: PASS for the full Zig test suite.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add /Users/nagaet/zsasa/src/toml_parser.zig
+git commit -m "feat: parse manifest TOML values"
+```
+
+---
+
+### Task 2: Add Batch Manifest Parser
+
+**Files:**
+- Create: `/Users/nagaet/zsasa/src/batch_manifest.zig`
+- Modify: `/Users/nagaet/zsasa/src/root.zig`
+
+- [ ] **Step 1: Create failing parser tests and public types**
+
+Create `/Users/nagaet/zsasa/src/batch_manifest.zig` with this initial content:
+
+```zig
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const toml_parser = @import("toml_parser.zig");
+
+pub const ManifestError = error{
+    UnsupportedVersion,
+    MissingJobName,
+    DuplicateJobName,
+    UnsafeJobName,
+    InvalidFieldType,
+    NoJobs,
+};
+
+pub const Error = ManifestError || Allocator.Error || toml_parser.Error || std.Io.File.OpenError || std.Io.File.ReadStreamingError;
+
+pub const Globals = struct {
+    input_dir: ?[]const u8 = null,
+    output_dir: ?[]const u8 = null,
+    algorithm: ?[]const u8 = null,
+    classifier: ?[]const u8 = null,
+    ccd: ?[]const u8 = null,
+    sdf: ?[]const []const u8 = null,
+    threads: ?usize = null,
+    probe_radius: ?f64 = null,
+    n_points: ?u32 = null,
+    n_slices: ?u32 = null,
+    precision: ?[]const u8 = null,
+    format: ?[]const u8 = null,
+    include_hydrogens: ?bool = null,
+    include_hetatm: ?bool = null,
+    use_bitmask: ?bool = null,
+    timing: ?bool = null,
+    quiet: ?bool = null,
+    auth_chain: ?bool = null,
+};
+
+pub const Job = struct {
+    name: []const u8,
+    chains: ?[]const []const u8 = null,
+    auth_chain: ?bool = null,
+};
+
+pub const Manifest = struct {
+    allocator: Allocator,
+    content: []const u8,
+    globals: Globals,
+    jobs: []Job,
+
+    pub fn deinit(self: *Manifest) void {
+        if (self.globals.sdf) |items| self.allocator.free(items);
+        for (self.jobs) |job| {
+            if (job.chains) |chains| self.allocator.free(chains);
+        }
+        self.allocator.free(self.jobs);
+        self.allocator.free(self.content);
+        self.* = undefined;
+    }
+};
+
+pub fn parse(allocator: Allocator, content: []const u8) Error!Manifest {
+    _ = allocator;
+    _ = content;
+    return error.NoJobs;
+}
+
+pub fn parseFile(allocator: Allocator, io: std.Io, path: []const u8) Error!Manifest {
+    const f = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer f.close(io);
+    var read_buf: [65536]u8 = undefined;
+    var reader = f.reader(io, &read_buf);
+    const content = try reader.interface.allocRemaining(allocator, .unlimited);
+    errdefer allocator.free(content);
+    return parseOwned(allocator, content);
+}
+
+fn parseOwned(allocator: Allocator, content: []const u8) Error!Manifest {
+    _ = allocator;
+    _ = content;
+    return error.NoJobs;
+}
+
+test "parse A B AB manifest" {
+    const input =
+        \\version = 1
+        \\input_dir = "structures"
+        \\output_dir = "results"
+        \\format = "jsonl"
+        \\use_bitmask = true
+        \\n_points = 128
+        \\classifier = "ccd"
+        \\
+        \\[[jobs]]
+        \\name = "chain_A"
+        \\chains = ["A"]
+        \\
+        \\[[jobs]]
+        \\name = "chain_B"
+        \\chains = ["B"]
+        \\
+        \\[[jobs]]
+        \\name = "complex_AB"
+        \\chains = ["A", "B"]
+    ;
+    var manifest = try parse(std.testing.allocator, input);
+    defer manifest.deinit();
+    try std.testing.expectEqualStrings("structures", manifest.globals.input_dir.?);
+    try std.testing.expectEqualStrings("results", manifest.globals.output_dir.?);
+    try std.testing.expectEqualStrings("jsonl", manifest.globals.format.?);
+    try std.testing.expectEqual(true, manifest.globals.use_bitmask.?);
+    try std.testing.expectEqual(@as(u32, 128), manifest.globals.n_points.?);
+    try std.testing.expectEqual(@as(usize, 3), manifest.jobs.len);
+    try std.testing.expectEqualStrings("chain_A", manifest.jobs[0].name);
+    try std.testing.expectEqualStrings("A", manifest.jobs[0].chains.?[0]);
+    try std.testing.expectEqualStrings("complex_AB", manifest.jobs[2].name);
+    try std.testing.expectEqual(@as(usize, 2), manifest.jobs[2].chains.?.len);
+}
+
+test "reject duplicate and unsafe job names" {
+    const duplicate =
+        \\version = 1
+        \\[[jobs]]
+        \\name = "dup"
+        \\[[jobs]]
+        \\name = "dup"
+    ;
+    try std.testing.expectError(error.DuplicateJobName, parse(std.testing.allocator, duplicate));
+
+    const unsafe =
+        \\version = 1
+        \\[[jobs]]
+        \\name = "../escape"
+    ;
+    try std.testing.expectError(error.UnsafeJobName, parse(std.testing.allocator, unsafe));
+}
+```
+
+- [ ] **Step 2: Export the module from root**
+
+Add this to `/Users/nagaet/zsasa/src/root.zig` near the other public imports:
+
+```zig
+pub const batch_manifest = @import("batch_manifest.zig");
+```
+
+Add this to the root test block near other `_ = ...;` lines:
+
+```zig
+    _ = batch_manifest;
+```
+
+- [ ] **Step 3: Run tests and verify parser tests fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task2-fail.log
+```
+
+Expected: FAIL in `batch_manifest` tests with `error.NoJobs`.
+
+- [ ] **Step 4: Implement manifest parsing helpers**
+
+Replace the initial `parse` and `parseOwned` bodies in `/Users/nagaet/zsasa/src/batch_manifest.zig` with these helpers and implementation:
+
+```zig
+pub fn parse(allocator: Allocator, content: []const u8) Error!Manifest {
+    const owned = try allocator.dupe(u8, content);
+    errdefer allocator.free(owned);
+    return parseOwned(allocator, owned);
+}
+
+fn parseOwned(allocator: Allocator, content: []const u8) Error!Manifest {
+    var doc = try toml_parser.parse(allocator, content);
+    defer doc.deinit();
+
+    const root = doc.getTable("") orelse return error.UnsupportedVersion;
+    const version = getInteger(root.entries, "version") orelse return error.UnsupportedVersion;
+    if (version != 1) return error.UnsupportedVersion;
+
+    var globals = Globals{};
+    globals.input_dir = getString(root.entries, "input_dir");
+    globals.output_dir = getString(root.entries, "output_dir");
+    globals.algorithm = getString(root.entries, "algorithm");
+    globals.classifier = getString(root.entries, "classifier");
+    globals.ccd = getString(root.entries, "ccd");
+    globals.threads = if (getInteger(root.entries, "threads")) |v| @intCast(v) else null;
+    globals.probe_radius = getFloat(root.entries, "probe_radius");
+    globals.n_points = if (getInteger(root.entries, "n_points")) |v| @intCast(v) else null;
+    globals.n_slices = if (getInteger(root.entries, "n_slices")) |v| @intCast(v) else null;
+    globals.precision = getString(root.entries, "precision");
+    globals.format = getString(root.entries, "format");
+    globals.include_hydrogens = getBool(root.entries, "include_hydrogens");
+    globals.include_hetatm = getBool(root.entries, "include_hetatm");
+    globals.use_bitmask = getBool(root.entries, "use_bitmask");
+    globals.timing = getBool(root.entries, "timing");
+    globals.quiet = getBool(root.entries, "quiet");
+    globals.auth_chain = getBool(root.entries, "auth_chain");
+    if (getStringArray(root.entries, "sdf")) |items| {
+        globals.sdf = try allocator.dupe([]const u8, items);
+    } else if (getString(root.entries, "sdf")) |one| {
+        const items = try allocator.alloc([]const u8, 1);
+        items[0] = one;
+        globals.sdf = items;
+    }
+    errdefer if (globals.sdf) |items| allocator.free(items);
+
+    var jobs = std.ArrayListUnmanaged(Job).empty;
+    errdefer {
+        for (jobs.items) |job| if (job.chains) |chains| allocator.free(chains);
+        jobs.deinit(allocator);
+    }
+
+    for (doc.array_tables) |at| {
+        if (!std.mem.eql(u8, at.name, "jobs")) continue;
+        const name = getString(at.entries, "name") orelse return error.MissingJobName;
+        if (!isSafeJobName(name)) return error.UnsafeJobName;
+        for (jobs.items) |existing| {
+            if (std.mem.eql(u8, existing.name, name)) return error.DuplicateJobName;
+        }
+        var chains_copy: ?[]const []const u8 = null;
+        if (getStringArray(at.entries, "chains")) |chains| {
+            chains_copy = try allocator.dupe([]const u8, chains);
+        }
+        errdefer if (chains_copy) |chains| allocator.free(chains);
+        try jobs.append(allocator, .{
+            .name = name,
+            .chains = chains_copy,
+            .auth_chain = getBool(at.entries, "auth_chain"),
+        });
+    }
+
+    if (jobs.items.len == 0) return error.NoJobs;
+
+    return .{
+        .allocator = allocator,
+        .content = content,
+        .globals = globals,
+        .jobs = try jobs.toOwnedSlice(allocator),
+    };
+}
+
+fn getString(entries: []const toml_parser.Value.Entry, key: []const u8) ?[]const u8 {
+    for (entries) |entry| if (std.mem.eql(u8, entry.key, key)) {
+        return switch (entry.value) { .string => |s| s, else => null };
+    };
+    return null;
+}
+
+fn getStringArray(entries: []const toml_parser.Value.Entry, key: []const u8) ?[]const []const u8 {
+    for (entries) |entry| if (std.mem.eql(u8, entry.key, key)) {
+        return switch (entry.value) { .string_array => |items| items, else => null };
+    };
+    return null;
+}
+
+fn getBool(entries: []const toml_parser.Value.Entry, key: []const u8) ?bool {
+    for (entries) |entry| if (std.mem.eql(u8, entry.key, key)) {
+        return switch (entry.value) { .boolean => |b| b, else => null };
+    };
+    return null;
+}
+
+fn getInteger(entries: []const toml_parser.Value.Entry, key: []const u8) ?i64 {
+    for (entries) |entry| if (std.mem.eql(u8, entry.key, key)) {
+        return switch (entry.value) { .integer => |i| i, else => null };
+    };
+    return null;
+}
+
+fn getFloat(entries: []const toml_parser.Value.Entry, key: []const u8) ?f64 {
+    for (entries) |entry| if (std.mem.eql(u8, entry.key, key)) {
+        return switch (entry.value) {
+            .float => |f| f,
+            .integer => |i| @floatFromInt(i),
+            else => null,
+        };
+    };
+    return null;
+}
+
+fn isSafeJobName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (std.mem.indexOfScalar(u8, name, '/') != null) return false;
+    if (std.mem.indexOfScalar(u8, name, '\\') != null) return false;
+    var parts = std.mem.splitScalar(u8, name, '.');
+    _ = parts;
+    return std.mem.indexOf(u8, name, "..") == null;
+}
+```
+
+- [ ] **Step 5: Run parser tests and verify they pass**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task2-pass.log
+```
+
+Expected: PASS for the full Zig test suite.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add /Users/nagaet/zsasa/src/batch_manifest.zig /Users/nagaet/zsasa/src/root.zig
+git commit -m "feat: parse batch manifests"
+```
+
+---
+
+### Task 3: Add Batch CLI State for Manifest and Chain Filtering
+
+**Files:**
+- Modify: `/Users/nagaet/zsasa/src/batch.zig`
+
+- [ ] **Step 1: Add failing argument parser tests**
+
+Append these tests near the existing `BatchArgs` tests in `/Users/nagaet/zsasa/src/batch.zig`:
+
+```zig
+test "BatchArgs --manifest" {
+    const args = [_][]const u8{ "zsasa", "batch", "--manifest", "bsa.toml" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqualStrings("bsa.toml", parsed.manifest_path.?);
+}
+
+test "BatchArgs --chain=A" {
+    const args = [_][]const u8{ "zsasa", "batch", "--chain=A", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqualStrings("A", parsed.chain_filter.?);
+    try std.testing.expectEqualStrings("input_dir/", parsed.input_path.?);
+}
+
+test "BatchArgs --auth-chain" {
+    const args = [_][]const u8{ "zsasa", "batch", "--auth-chain", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.use_auth_chain);
+}
+
+test "BatchArgs explicit option flags" {
+    const args = [_][]const u8{
+        "zsasa", "batch", "--threads=8", "--n-points=128", "--format=jsonl", "--use-bitmask", "input_dir/",
+    };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.threads_explicit);
+    try std.testing.expectEqual(true, parsed.n_points_explicit);
+    try std.testing.expectEqual(true, parsed.format_explicit);
+    try std.testing.expectEqual(true, parsed.use_bitmask_explicit);
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task3-fail.log
+```
+
+Expected: FAIL with missing `BatchArgs` fields such as `manifest_path` and `chain_filter`.
+
+- [ ] **Step 3: Extend imports and `BatchArgs` fields**
+
+At the top of `/Users/nagaet/zsasa/src/batch.zig`, add:
+
+```zig
+const batch_manifest = @import("batch_manifest.zig");
+```
+
+Extend `BatchArgs` with these fields:
+
+```zig
+    manifest_path: ?[]const u8 = null,
+    chain_filter: ?[]const u8 = null,
+    use_auth_chain: bool = false,
+    threads_explicit: bool = false,
+    probe_radius_explicit: bool = false,
+    n_points_explicit: bool = false,
+    n_slices_explicit: bool = false,
+    algorithm_explicit: bool = false,
+    precision_explicit: bool = false,
+    format_explicit: bool = false,
+    classifier_explicit: bool = false,
+    include_hydrogens_explicit: bool = false,
+    include_hetatm_explicit: bool = false,
+    use_bitmask_explicit: bool = false,
+    ccd_explicit: bool = false,
+    sdf_explicit: bool = false,
+    quiet_explicit: bool = false,
+    timing_explicit: bool = false,
+```
+
+- [ ] **Step 4: Update `parseArgs` for manifest, chain, auth-chain, and presence flags**
+
+In each existing option branch in `parseArgs`, set the matching explicit flag when the user provided that option. For example:
+
+```zig
+if (std.mem.startsWith(u8, arg, "--threads=")) {
+    const value = arg["--threads=".len..];
+    result.n_threads = std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("Error: Invalid thread count: {s}\n", .{value});
+        std.process.exit(1);
+    };
+    result.threads_explicit = true;
+} else if (std.mem.eql(u8, arg, "--threads")) {
+    i += 1;
+    if (i >= args.len) {
+        std.debug.print("Error: Missing value for --threads\n", .{});
+        std.process.exit(1);
+    }
+    result.n_threads = std.fmt.parseInt(usize, args[i], 10) catch {
+        std.debug.print("Error: Invalid thread count: {s}\n", .{args[i]});
+        std.process.exit(1);
+    };
+    result.threads_explicit = true;
+}
+```
+
+Add these new option branches before the unknown-option branch:
+
+```zig
+        // --manifest=PATH or --manifest PATH
+        else if (std.mem.startsWith(u8, arg, "--manifest=")) {
+            result.manifest_path = arg["--manifest=".len..];
+        } else if (std.mem.eql(u8, arg, "--manifest")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --manifest\n", .{});
+                std.process.exit(1);
+            }
+            result.manifest_path = args[i];
+        }
+        // --chain=ID or --chain ID
+        else if (std.mem.startsWith(u8, arg, "--chain=")) {
+            result.chain_filter = arg["--chain=".len..];
+        } else if (std.mem.eql(u8, arg, "--chain")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --chain\n", .{});
+                std.process.exit(1);
+            }
+            result.chain_filter = args[i];
+        }
+        // --auth-chain
+        else if (std.mem.eql(u8, arg, "--auth-chain")) {
+            result.use_auth_chain = true;
+        }
+```
+
+Set the matching explicit flags in existing branches:
+
+```zig
+result.probe_radius_explicit = true;
+result.n_points_explicit = true;
+result.n_slices_explicit = true;
+result.format_explicit = true;
+result.algorithm_explicit = true;
+result.classifier_explicit = true;
+result.precision_explicit = true;
+result.include_hydrogens_explicit = true;
+result.include_hetatm_explicit = true;
+result.use_bitmask_explicit = true;
+result.ccd_explicit = true;
+result.sdf_explicit = true;
+result.quiet_explicit = true;
+result.timing_explicit = true;
+```
+
+- [ ] **Step 5: Run parser tests and verify they pass**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task3-pass.log
+```
+
+Expected: PASS for the full Zig test suite.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add /Users/nagaet/zsasa/src/batch.zig
+git commit -m "feat: parse batch manifest options"
+```
+
+---
+
+### Task 4: Add Chain Filtering to Existing Batch Execution
+
+**Files:**
+- Modify: `/Users/nagaet/zsasa/src/batch.zig`
+
+- [ ] **Step 1: Add a failing non-manifest chain filtering test**
+
+Add this test near the `BatchArgs --chain=A` test in `/Users/nagaet/zsasa/src/batch.zig`:
+
+```zig
+test "parseBatchChainFilter splits comma-separated chains" {
+    const chains = try parseBatchChainFilter(std.testing.allocator, "A, B,AB");
+    defer std.testing.allocator.free(chains);
+    try std.testing.expectEqual(@as(usize, 3), chains.len);
+    try std.testing.expectEqualStrings("A", chains[0]);
+    try std.testing.expectEqualStrings("B", chains[1]);
+    try std.testing.expectEqualStrings("AB", chains[2]);
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task4-fail.log
+```
+
+Expected: FAIL with missing `parseBatchChainFilter`.
+
+- [ ] **Step 3: Add `BatchConfig` chain fields and parser helper**
+
+Extend `BatchConfig` in `/Users/nagaet/zsasa/src/batch.zig`:
+
+```zig
+    chain_filter: ?[]const []const u8 = null,
+    use_auth_chain: bool = false,
+```
+
+Add this helper near the parse helper functions:
+
+```zig
+fn parseBatchChainFilter(allocator: Allocator, filter_str: []const u8) ![]const []const u8 {
+    var chains = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer chains.deinit(allocator);
+
+    var iter = std.mem.splitScalar(u8, filter_str, ',');
+    while (iter.next()) |chain| {
+        const trimmed = std.mem.trim(u8, chain, " ");
+        if (trimmed.len > 0) {
+            try chains.append(allocator, trimmed);
+        }
+    }
+
+    return chains.toOwnedSlice(allocator);
+}
+```
+
+Update `readInputFile` parser setup:
+
+```zig
+        .mmcif => blk: {
+            var parser = mmcif_parser.MmcifParser.init(allocator);
+            parser.skip_hydrogens = !config.include_hydrogens;
+            parser.atom_only = !config.include_hetatm;
+            parser.chain_filter = config.chain_filter;
+            parser.use_auth_chain = config.use_auth_chain;
+            break :blk parser.parseFile(io, path);
+        },
+        .pdb => blk: {
+            var parser = pdb_parser.PdbParser.init(allocator);
+            parser.skip_hydrogens = !config.include_hydrogens;
+            parser.atom_only = !config.include_hetatm;
+            parser.chain_filter = config.chain_filter;
+            break :blk parser.parseFile(io, path);
+        },
+```
+
+Update the non-manifest `config` construction in `run` to parse the CLI chain filter:
+
+```zig
+    var chain_filter_slice: ?[]const []const u8 = null;
+    if (args.chain_filter) |filter_str| {
+        chain_filter_slice = try parseBatchChainFilter(allocator, filter_str);
+    }
+    defer if (chain_filter_slice) |s| allocator.free(s);
+```
+
+Set these `BatchConfig` fields:
+
+```zig
+        .chain_filter = chain_filter_slice,
+        .use_auth_chain = args.use_auth_chain,
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task4-pass.log
+```
+
+Expected: PASS for the full Zig test suite.
+
+- [ ] **Step 5: Smoke check current issue symptom is fixed for non-manifest mode**
+
+Run:
+
+```bash
+zig build run -- batch --chain=A --help 2>&1 | tee /tmp/zsasa-task4-help.log
+```
+
+Expected: the command prints batch help or exits through the help path, not `Unknown option: --chain=A`.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add /Users/nagaet/zsasa/src/batch.zig
+git commit -m "feat: filter batch inputs by chain"
+```
+
+---
+
+### Task 5: Resolve and Run Manifest Jobs
+
+**Files:**
+- Modify: `/Users/nagaet/zsasa/src/batch.zig`
+
+- [ ] **Step 1: Add failing manifest conflict and output tests**
+
+Append these tests near the batch tests in `/Users/nagaet/zsasa/src/batch.zig`:
+
+```zig
+test "manifestJsonlOutputPath uses job file under output dir" {
+    const path = try manifestJsonlOutputPath(std.testing.allocator, "results", "chain_A");
+    defer std.testing.allocator.free(path);
+    try std.testing.expectEqualStrings("results/chain_A.jsonl", path);
+}
+
+test "manifestPerFileOutputDir uses job directory under output dir" {
+    const path = try manifestPerFileOutputDir(std.testing.allocator, "results", "complex_AB");
+    defer std.testing.allocator.free(path);
+    try std.testing.expectEqualStrings("results/complex_AB", path);
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task5-fail.log
+```
+
+Expected: FAIL with missing output helper functions.
+
+- [ ] **Step 3: Add output path helpers**
+
+Add these helpers near `getOutputExtension` in `/Users/nagaet/zsasa/src/batch.zig`:
+
+```zig
+fn manifestJsonlOutputPath(allocator: Allocator, output_dir: []const u8, job_name: []const u8) ![]const u8 {
+    const filename = try std.fmt.allocPrint(allocator, "{s}.jsonl", .{job_name});
+    defer allocator.free(filename);
+    return std.fs.path.join(allocator, &.{ output_dir, filename });
+}
+
+fn manifestPerFileOutputDir(allocator: Allocator, output_dir: []const u8, job_name: []const u8) ![]const u8 {
+    return std.fs.path.join(allocator, &.{ output_dir, job_name });
+}
+```
+
+- [ ] **Step 4: Add manifest execution functions**
+
+Add these functions above `run` in `/Users/nagaet/zsasa/src/batch.zig`:
+
+```zig
+fn applyManifestGlobals(config: *BatchConfig, args: BatchArgs, globals: batch_manifest.Globals) void {
+    if (!args.threads_explicit) if (globals.threads) |v| config.n_threads = v;
+    if (!args.algorithm_explicit) if (globals.algorithm) |v| config.algorithm = parseAlgorithm(v);
+    if (!args.n_points_explicit) if (globals.n_points) |v| config.n_points = v;
+    if (!args.n_slices_explicit) if (globals.n_slices) |v| config.n_slices = v;
+    if (!args.probe_radius_explicit) if (globals.probe_radius) |v| config.probe_radius = v;
+    if (!args.precision_explicit) if (globals.precision) |v| config.precision = parsePrecision(v);
+    if (!args.format_explicit) if (globals.format) |v| config.output_format = parseOutputFormat(v);
+    if (!args.timing_explicit) if (globals.timing) |v| config.show_timing = v;
+    if (!args.quiet_explicit) if (globals.quiet) |v| {
+        config.quiet = v;
+        config.show_progress = !v;
+    };
+    if (!args.classifier_explicit) if (globals.classifier) |v| config.classifier_type = parseClassifierType(v);
+    if (!args.include_hydrogens_explicit) if (globals.include_hydrogens) |v| config.include_hydrogens = v;
+    if (!args.include_hetatm_explicit) if (globals.include_hetatm) |v| config.include_hetatm = v;
+    if (!args.use_bitmask_explicit) if (globals.use_bitmask) |v| config.use_bitmask = v;
+    if (globals.auth_chain) |v| config.use_auth_chain = v;
+}
+
+fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
+    if (args.threads_explicit) config.n_threads = args.n_threads;
+    if (args.algorithm_explicit) config.algorithm = args.algorithm;
+    if (args.n_points_explicit) config.n_points = args.n_points;
+    if (args.n_slices_explicit) config.n_slices = args.n_slices;
+    if (args.probe_radius_explicit) config.probe_radius = args.probe_radius;
+    if (args.precision_explicit) config.precision = args.precision;
+    if (args.format_explicit) config.output_format = args.output_format;
+    if (args.timing_explicit) config.show_timing = args.show_timing;
+    if (args.quiet_explicit) {
+        config.quiet = args.quiet;
+        config.show_progress = args.show_progress;
+    }
+    if (args.classifier_explicit) config.classifier_type = args.classifier_type;
+    if (args.include_hydrogens_explicit) config.include_hydrogens = args.include_hydrogens;
+    if (args.include_hetatm_explicit) config.include_hetatm = args.include_hetatm;
+    if (args.use_bitmask_explicit) config.use_bitmask = args.use_bitmask;
+}
+
+fn runManifest(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    if (args.chain_filter != null) {
+        std.debug.print("Error: --manifest cannot be combined with --chain; use [[jobs]].chains in the manifest\n", .{});
+        return error.InvalidArgument;
+    }
+
+    const path = args.manifest_path.?;
+    var manifest = batch_manifest.parseFile(allocator, io, path) catch |err| {
+        std.debug.print("Error reading manifest '{s}': {s}\n", .{ path, @errorName(err) });
+        return err;
+    };
+    defer manifest.deinit();
+
+    const input_dir = args.input_path orelse manifest.globals.input_dir orelse {
+        std.debug.print("Error: Missing input directory; set input_dir in manifest or pass <input_dir>\n", .{});
+        return error.MissingArgument;
+    };
+    const output_dir = args.output_path orelse manifest.globals.output_dir;
+    if (manifest.jobs.len > 1 and output_dir == null) {
+        std.debug.print("Error: Manifest with multiple jobs requires output_dir or positional [output_dir]\n", .{});
+        return error.MissingArgument;
+    }
+
+    var aggregate_success: usize = 0;
+    var aggregate_failed: usize = 0;
+
+    for (manifest.jobs) |job| {
+        var config = BatchConfig{};
+        applyManifestGlobals(&config, args, manifest.globals);
+        applyCliOverrides(&config, args);
+        config.include_hetatm = config.include_hetatm or (config.classifier_type == .ccd);
+        config.store_atom_areas = (config.output_format == .jsonl);
+        if (job.auth_chain) |v| config.use_auth_chain = v;
+        config.chain_filter = job.chains;
+
+        const job_output_dir = if (output_dir) |out| blk: {
+            if (config.output_format == .jsonl) {
+                break :blk out;
+            }
+            break :blk try manifestPerFileOutputDir(allocator, out, job.name);
+        } else null;
+        defer if (output_dir != null and config.output_format != .jsonl) if (job_output_dir) |p| allocator.free(p);
+
+        const jsonl_output_path = if (output_dir) |out| blk: {
+            if (config.output_format == .jsonl) break :blk try manifestJsonlOutputPath(allocator, out, job.name);
+            break :blk null;
+        } else null;
+        defer if (jsonl_output_path) |p| allocator.free(p);
+
+        if (!config.quiet) {
+            std.debug.print("Manifest job: {s}\n", .{job.name});
+        }
+
+        var result = try runBatch(allocator, io, input_dir, job_output_dir, config, jsonl_output_path);
+        defer result.deinit();
+        aggregate_success += result.successful;
+        aggregate_failed += result.failed;
+        if (!config.quiet) result.printSummary(config.show_timing);
+    }
+
+    std.debug.print("Manifest complete: {d} successful, {d} failed\n", .{ aggregate_success, aggregate_failed });
+}
+```
+
+If `runBatch` has a different signature in the current file, use the existing public entry point that accepts `(allocator, io, input_dir, output_dir, config, jsonl_output_path)`; do not duplicate sequential/parallel dispatch logic.
+
+- [ ] **Step 5: Route `run` to manifest mode**
+
+At the top of `pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void`, add:
+
+```zig
+    if (args.manifest_path != null) {
+        return runManifest(allocator, io, args);
+    }
+```
+
+Keep the rest of `run` as the non-manifest path.
+
+- [ ] **Step 6: Run tests and verify manifest execution compiles**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task5-pass.log
+```
+
+Expected: PASS. The existing dispatcher is `runBatch(allocator, io, input_dir, output_dir, config, jsonl_output_path)`, so `runManifest` should call that function exactly once per manifest job with the resolved `BatchConfig`.
+
+- [ ] **Step 7: Commit Task 5**
+
+Run:
+
+```bash
+git add /Users/nagaet/zsasa/src/batch.zig
+git commit -m "feat: run batch manifests"
+```
+
+---
+
+### Task 6: Add CLI Help and Website Docs
+
+**Files:**
+- Modify: `/Users/nagaet/zsasa/src/batch.zig`
+- Modify: `/Users/nagaet/zsasa/website/docs/cli/commands.md`
+
+- [ ] **Step 1: Update batch help text**
+
+In `printHelp` in `/Users/nagaet/zsasa/src/batch.zig`, add option lines:
+
+```text
+        \    --manifest=PATH     TOML manifest with one or more named batch jobs
+        \    --chain=ID          Filter by chain ID for non-manifest batch (e.g. A or A,B)
+        \    --auth-chain        Use auth_asym_id instead of label_asym_id for mmCIF chain matching
+```
+
+Add examples:
+
+```text
+        \    {s} batch --manifest bsa.toml
+        \    {s} batch structures/ results/ --manifest bsa.toml
+        \    {s} batch structures/ results_A/ --chain=A --format=jsonl
+```
+
+Update the format string argument list to include `program_name` for each new `{s}`.
+
+- [ ] **Step 2: Update CLI docs with manifest example**
+
+In `/Users/nagaet/zsasa/website/docs/cli/commands.md`, add this subsection under `batch`:
+
+```markdown
+#### Batch TOML manifest
+
+Use `--manifest` to run several named batch jobs over the same input directory. CLI positional paths and explicit options override manifest values.
+
+```bash
+zsasa batch --manifest bsa.toml
+zsasa batch structures/ results/ --manifest bsa.toml --threads=8
+```
+
+```toml
+version = 1
+input_dir = "structures"
+output_dir = "results"
+format = "jsonl"
+use_bitmask = true
+n_points = 128
+classifier = "ccd"
+
+[[jobs]]
+name = "chain_A"
+chains = ["A"]
+
+[[jobs]]
+name = "chain_B"
+chains = ["B"]
+
+[[jobs]]
+name = "complex_AB"
+chains = ["A", "B"]
+```
+
+For `format = "jsonl"`, each job writes one file such as `results/chain_A.jsonl`. For `json`, `compact`, and `csv`, each job writes a directory such as `results/chain_A/`.
+
+Precedence is: built-in defaults < manifest globals < job settings < explicit CLI options. `--chain` is for non-manifest single-job batch mode; manifest jobs should use `[[jobs]].chains`.
+```
+
+- [ ] **Step 3: Run docs/build-neutral checks**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-task6-test.log
+```
+
+Expected: PASS for the full Zig test suite.
+
+- [ ] **Step 4: Commit Task 6**
+
+Run:
+
+```bash
+git add /Users/nagaet/zsasa/src/batch.zig /Users/nagaet/zsasa/website/docs/cli/commands.md
+git commit -m "docs: document batch manifests"
+```
+
+---
+
+### Task 7: End-to-End Manifest Smoke Test
+
+**Files:**
+- Create temporary files under `/tmp/zsasa-manifest-smoke/` only
+- No source changes expected unless the smoke test finds a bug
+
+- [ ] **Step 1: Create a small multi-chain PDB fixture**
+
+Run:
+
+```bash
+rm -rf /tmp/zsasa-manifest-smoke
+mkdir -p /tmp/zsasa-manifest-smoke/structures
+cat > /tmp/zsasa-manifest-smoke/structures/two_chains.pdb <<'PDB'
+ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00 20.00           N
+ATOM      2  CA  ALA A   1       1.500   0.000   0.000  1.00 20.00           C
+ATOM      3  C   ALA A   1       2.000   1.400   0.000  1.00 20.00           C
+ATOM      4  N   ALA B   1       8.000   0.000   0.000  1.00 20.00           N
+ATOM      5  CA  ALA B   1       9.500   0.000   0.000  1.00 20.00           C
+ATOM      6  C   ALA B   1      10.000   1.400   0.000  1.00 20.00           C
+TER
+END
+PDB
+cat > /tmp/zsasa-manifest-smoke/bsa.toml <<'TOML'
+version = 1
+input_dir = "/tmp/zsasa-manifest-smoke/structures"
+output_dir = "/tmp/zsasa-manifest-smoke/results"
+format = "jsonl"
+n_points = 32
+classifier = "naccess"
+quiet = true
+
+[[jobs]]
+name = "chain_A"
+chains = ["A"]
+
+[[jobs]]
+name = "chain_B"
+chains = ["B"]
+
+[[jobs]]
+name = "complex_AB"
+chains = ["A", "B"]
+TOML
+```
+
+- [ ] **Step 2: Run the manifest**
+
+Run:
+
+```bash
+zig build run -- batch --manifest /tmp/zsasa-manifest-smoke/bsa.toml 2>&1 | tee /tmp/zsasa-manifest-smoke/run.log
+```
+
+Expected: exit code 0 and output includes `Manifest complete`.
+
+- [ ] **Step 3: Verify three JSONL outputs exist**
+
+Run:
+
+```bash
+ls -1 /tmp/zsasa-manifest-smoke/results
+wc -l /tmp/zsasa-manifest-smoke/results/*.jsonl
+```
+
+Expected:
+
+```text
+chain_A.jsonl
+chain_B.jsonl
+complex_AB.jsonl
+```
+
+Each JSONL file should have one line.
+
+- [ ] **Step 4: Verify atom counts reflect chain selection**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+base = Path('/tmp/zsasa-manifest-smoke/results')
+counts = {}
+for name in ['chain_A', 'chain_B', 'complex_AB']:
+    row = json.loads((base / f'{name}.jsonl').read_text().strip())
+    counts[name] = len(row['atom_areas'])
+print(counts)
+assert counts['chain_A'] == 3, counts
+assert counts['chain_B'] == 3, counts
+assert counts['complex_AB'] == 6, counts
+PY
+```
+
+Expected: prints `{'chain_A': 3, 'chain_B': 3, 'complex_AB': 6}` and exits 0.
+
+- [ ] **Step 5: Verify CLI positional path override**
+
+Run:
+
+```bash
+cat > /tmp/zsasa-manifest-smoke/no_paths.toml <<'TOML'
+version = 1
+format = "jsonl"
+n_points = 32
+classifier = "naccess"
+quiet = true
+
+[[jobs]]
+name = "chain_A"
+chains = ["A"]
+TOML
+zig build run -- batch /tmp/zsasa-manifest-smoke/structures /tmp/zsasa-manifest-smoke/override-results --manifest /tmp/zsasa-manifest-smoke/no_paths.toml
+ls -1 /tmp/zsasa-manifest-smoke/override-results
+```
+
+Expected: `chain_A.jsonl` exists under `/tmp/zsasa-manifest-smoke/override-results`.
+
+- [ ] **Step 6: Commit source changes made during the smoke test**
+
+When the smoke test leads to a source change, run:
+
+```bash
+git add /Users/nagaet/zsasa/src /Users/nagaet/zsasa/website/docs/cli/commands.md
+git commit -m "fix: stabilize batch manifest execution"
+```
+
+When no code changes were needed, do not create an empty commit.
+
+---
+
+### Task 8: Final Verification and Review Prep
+
+**Files:**
+- No source changes expected unless verification finds a bug
+
+- [ ] **Step 1: Run full Zig tests**
+
+Run:
+
+```bash
+zig build test 2>&1 | tee /tmp/zsasa-final-zig-test.log
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run manifest smoke test again from Task 7**
+
+Run:
+
+```bash
+zig build run -- batch --manifest /tmp/zsasa-manifest-smoke/bsa.toml 2>&1 | tee /tmp/zsasa-final-manifest-smoke.log
+python3 - <<'PY'
+import json
+from pathlib import Path
+base = Path('/tmp/zsasa-manifest-smoke/results')
+counts = {}
+for name in ['chain_A', 'chain_B', 'complex_AB']:
+    row = json.loads((base / f'{name}.jsonl').read_text().strip())
+    counts[name] = len(row['atom_areas'])
+print(counts)
+assert counts == {'chain_A': 3, 'chain_B': 3, 'complex_AB': 6}, counts
+PY
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Inspect git history and status**
+
+Run:
+
+```bash
+git log --oneline --decorate -8
+git status --short
+```
+
+Expected: recent commits include the design commit and task commits. `git status --short` should show no modified tracked files. It may still show the pre-existing untracked `/Users/nagaet/zsasa/zig-pkg/` directory; do not add it unless the user explicitly asks.
+
+- [ ] **Step 4: Summarize implementation for review**
+
+Prepare a concise review summary containing:
+
+```markdown
+## Summary
+- Added TOML batch manifests with named jobs and A/B/AB chain selections.
+- Added batch chain filtering for non-manifest mode.
+- Documented manifest precedence and output layout.
+
+## Verification
+- `zig build test`
+- `zig build run -- batch --manifest /tmp/zsasa-manifest-smoke/bsa.toml`
+- JSONL atom count smoke: chain_A=3, chain_B=3, complex_AB=6
+```
+
+Do not claim verification passed unless the exact commands above passed in the current session.

--- a/docs/superpowers/specs/2026-05-17-batch-manifest-design.md
+++ b/docs/superpowers/specs/2026-05-17-batch-manifest-design.md
@@ -1,0 +1,232 @@
+# Batch TOML Manifest Design
+
+## Summary
+
+Add a TOML manifest mode for `zsasa batch` so one command can run multiple named batch jobs over the same structure directory. The motivating workflow is homo-dimer/interface analysis: calculate atom-level SASA for chain A, chain B, and the AB complex without writing an external loop.
+
+The manifest is self-contained when it defines input and output paths, but CLI positional arguments and explicit options can override manifest values. This keeps simple scripted use possible while supporting reusable workflow files.
+
+## Goals
+
+- Support `zsasa batch --manifest bsa.toml` as a self-contained batch workflow.
+- Support `zsasa batch structures/ results/ --manifest bsa.toml` as CLI path override/fallback.
+- Support multiple named jobs, each with its own chain selection.
+- Keep output separated by job name.
+- Preserve existing `zsasa batch` behavior when no manifest is provided.
+- Reuse existing project patterns and avoid adding a YAML parser dependency.
+
+## Non-goals
+
+- Do not add YAML support in the first implementation.
+- Do not compute buried SASA/BSA directly in this feature; the manifest produces the required A, B, and AB atom-level SASA outputs for downstream analysis.
+- Do not redesign the batch output schema beyond job-level output placement.
+- Do not add Python API manifest support in the first implementation.
+
+## Manifest format
+
+The first implementation uses TOML and a required `version = 1` field.
+
+Example:
+
+```toml
+version = 1
+
+input_dir = "structures"
+output_dir = "results"
+
+format = "jsonl"
+use_bitmask = true
+n_points = 128
+classifier = "ccd"
+
+[[jobs]]
+name = "chain_A"
+chains = ["A"]
+
+[[jobs]]
+name = "chain_B"
+chains = ["B"]
+
+[[jobs]]
+name = "complex_AB"
+chains = ["A", "B"]
+```
+
+### Global fields
+
+Manifest globals map to existing batch settings:
+
+- `input_dir`: input directory, optional if CLI positional input is supplied.
+- `output_dir`: output directory, optional; current no-file-output behavior remains available when neither manifest nor CLI supplies output.
+- `algorithm`: `sr` or `lr`.
+- `classifier`: `ccd`, `protor`, `naccess`, or `oons`.
+- `ccd`: external CCD dictionary path.
+- `sdf`: string or array of strings for SDF topology files.
+- `threads`: number of file-level worker threads.
+- `probe_radius`: probe radius in Å.
+- `n_points`: SR point count.
+- `n_slices`: LR slice count.
+- `precision`: `f32` or `f64`.
+- `format`: `json`, `compact`, `csv`, or `jsonl`.
+- `include_hydrogens`: boolean.
+- `include_hetatm`: boolean.
+- `use_bitmask`: boolean.
+- `timing`: boolean.
+- `quiet`: boolean.
+- `auth_chain`: boolean, using `auth_asym_id` instead of `label_asym_id` for mmCIF chain matching.
+
+### Job fields
+
+Each `[[jobs]]` table defines one run over the input directory:
+
+- `name`: required, used for output placement and user-facing status.
+- `chains`: optional array of chain IDs. If omitted, the job uses all chains.
+- Any safe global calculation option may be overridden per job, but the first implementation can limit job-specific overrides to `chains` and `auth_chain` if that keeps the patch small.
+
+Job names must be non-empty and path-safe. The parser should reject names containing `/`, `\\`, or `..` path traversal components.
+
+## Precedence rules
+
+Configuration is resolved in this order:
+
+```text
+built-in defaults
+  < manifest global defaults
+  < manifest job-specific settings
+  < explicit CLI options
+```
+
+Path handling:
+
+- `zsasa batch --manifest bsa.toml` uses `input_dir` and `output_dir` from the manifest.
+- `zsasa batch structures/ results/ --manifest bsa.toml` overrides manifest `input_dir` and `output_dir`.
+- If no input directory is available after merging, the command errors with a clear message.
+
+Option handling:
+
+- Existing CLI options continue to work and override manifest globals when explicitly supplied.
+- To distinguish explicit CLI options from defaults, `BatchArgs` needs presence flags for options that can come from the manifest.
+- `--chain` is useful for non-manifest single-job batch mode, but in manifest mode it should not silently override all job chain selections. The initial behavior should reject `--manifest` combined with `--chain` and explain that chain selections belong in `[[jobs]].chains`.
+
+## Output layout
+
+Each job writes to a separate output target under the resolved output directory.
+
+For JSONL:
+
+```text
+results/
+  chain_A.jsonl
+  chain_B.jsonl
+  complex_AB.jsonl
+```
+
+For per-file formats (`json`, `compact`, `csv`):
+
+```text
+results/
+  chain_A/
+    input1.json
+    input2.json
+  chain_B/
+    input1.json
+    input2.json
+  complex_AB/
+    input1.json
+    input2.json
+```
+
+If no output directory is configured and `format = "jsonl"`, existing stdout behavior can remain for a single job. Multiple manifest jobs should require an output directory to avoid interleaving unrelated JSONL streams on stdout.
+
+## Architecture
+
+### Parser module
+
+Add a focused manifest parser module, for example `src/batch_manifest.zig`, rather than expanding `src/batch.zig` further. It should:
+
+1. Read a TOML file.
+2. Validate `version = 1`.
+3. Parse globals into a manifest config structure.
+4. Parse `[[jobs]]` into named job definitions.
+5. Return structured validation errors that can be rendered as concise CLI messages.
+
+The project already has a minimal TOML parser for classifier configuration. Reuse it if it supports arrays of tables and the needed value types; otherwise extend it narrowly for this manifest shape or use `std.json` only for tests/fixtures if TOML support is insufficient. Do not introduce YAML support.
+
+### Batch configuration merge
+
+Add an intermediate resolved-job structure:
+
+```zig
+const ResolvedBatchJob = struct {
+    name: []const u8,
+    input_dir: []const u8,
+    output_dir: ?[]const u8,
+    config: BatchConfig,
+};
+```
+
+Resolution should be separate from execution so it can be unit-tested without running SASA.
+
+### Chain filtering
+
+Extend `BatchConfig` with:
+
+- `chain_filter: ?[]const []const u8`
+- `use_auth_chain: bool`
+
+When reading PDB/mmCIF files in batch mode, pass these settings to `PdbParser` and `MmcifParser`. JSON input is not chain-filtered in the first implementation unless a safe existing helper is available.
+
+### Execution flow
+
+Without a manifest, `zsasa batch` follows the current path.
+
+With a manifest:
+
+1. Parse CLI args including `--manifest`.
+2. Parse the TOML manifest.
+3. Resolve one `ResolvedBatchJob` per manifest job.
+4. For each resolved job, call the existing `runBatch` path with that job's `BatchConfig` and output target.
+5. Aggregate and print a concise manifest summary after all jobs complete.
+
+The first implementation can run jobs sequentially at the manifest-job level. File-level parallelism within each job remains controlled by `threads`.
+
+## Error handling
+
+- Missing manifest file: clear file-open error including the path.
+- Unsupported manifest version: explain supported version is `1`.
+- Missing input directory after merge: explain how to fix with manifest `input_dir` or CLI positional input.
+- Duplicate job names: reject before running any job.
+- Unsafe job names: reject before running any job.
+- Multiple jobs without output directory: reject if output would otherwise go to stdout/no files in a confusing way.
+- `--manifest` with `--chain`: reject and direct users to `[[jobs]].chains`.
+
+## Documentation
+
+Update CLI docs and help text with:
+
+- `--manifest=PATH` / `--manifest PATH`.
+- A homo-dimer A/B/AB example.
+- Precedence rules.
+- Output layout for JSONL and per-file formats.
+
+## Testing
+
+Add focused tests for:
+
+- Manifest parsing of the A/B/AB example.
+- CLI positional input/output overriding manifest paths.
+- CLI options overriding manifest globals.
+- Duplicate and unsafe job names.
+- `--manifest` plus `--chain` rejection.
+- Batch parser accepting `--chain` in non-manifest mode.
+- PDB/mmCIF batch chain filtering smoke tests using a small multi-chain fixture.
+- JSONL output path generation per job.
+
+Run at least:
+
+```bash
+zig build test
+zig build run -- batch --manifest <fixture.toml>
+```
+
+Use the narrowest smoke fixture that verifies chain A, chain B, and AB produce distinct atom counts or chain IDs in output.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -2113,6 +2113,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\zsasa batch - Calculate SASA for all files in a directory
         \\
         \\USAGE:
+        \\    {s} batch --manifest <manifest.toml>
         \\    {s} batch [OPTIONS] <input_dir> [output_dir]
         \\
         \\ARGUMENTS:
@@ -2155,9 +2156,9 @@ pub fn printHelp(program_name: []const u8) void {
         \\    {s} batch structures/ -o results.jsonl --format=jsonl
         \\    {s} batch --manifest bsa.toml
         \\    {s} batch structures/ results/ --manifest bsa.toml
-        \\    {s} batch structures/ results_A/ --chain=A --format=jsonl
+        \\    {s} batch structures/ results_A.jsonl --chain=A --format=jsonl
         \\
-    , .{ program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name });
+    , .{ program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name });
 }
 
 /// Load SDF files and build a ComponentDict from their bond topology.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -2233,6 +2233,12 @@ fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
     if (args.use_auth_chain) config.use_auth_chain = true;
 }
 
+fn applyManifestJobOverrides(config: *BatchConfig, args: BatchArgs, job: batch_manifest.Job) void {
+    if (job.auth_chain) |v| config.use_auth_chain = v;
+    if (args.use_auth_chain) config.use_auth_chain = true;
+    config.chain_filter = job.chains;
+}
+
 fn parseManifestFile(allocator: Allocator, io: std.Io, path: []const u8) !batch_manifest.Manifest {
     const file = try std.Io.Dir.cwd().openFile(io, path, .{});
     defer file.close(io);
@@ -2329,8 +2335,7 @@ fn runManifest(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         config.store_atom_areas = (config.output_format == .jsonl);
         config.external_ccd = if (ext_ccd != null) &ext_ccd.? else null;
         config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
-        if (job.auth_chain) |v| config.use_auth_chain = v;
-        config.chain_filter = job.chains;
+        applyManifestJobOverrides(&config, args, job);
 
         if ((config.classifier_type == .ccd or config.classifier_type == .protor) and config.include_hydrogens and !config.quiet) {
             std.debug.print("Warning: --include-hydrogens with CCD classifier may give inaccurate results\n", .{});
@@ -2623,6 +2628,19 @@ test "manifest numeric validators reject invalid values" {
     try std.testing.expectError(error.InvalidArgument, validateManifestNPoints(10001));
     try std.testing.expectError(error.InvalidArgument, validateManifestNSlices(0));
     try std.testing.expectError(error.InvalidArgument, validateManifestNSlices(1001));
+}
+
+test "CLI auth-chain overrides manifest job auth_chain false" {
+    var config = BatchConfig{};
+    const args = BatchArgs{ .use_auth_chain = true };
+    const job = batch_manifest.Job{
+        .name = "chain_A",
+        .auth_chain = false,
+    };
+
+    applyManifestJobOverrides(&config, args, job);
+
+    try std.testing.expectEqual(true, config.use_auth_chain);
 }
 
 test "manifestJsonlOutputPath uses job file under output dir" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -1719,17 +1719,37 @@ pub const BatchArgs = struct {
 
 // Parse helper functions (local to batch.zig)
 
+fn validateManifestProbeRadius(radius: f64) !f64 {
+    if (radius <= 0 or radius > 10.0 or !std.math.isFinite(radius)) {
+        return error.InvalidArgument;
+    }
+    return radius;
+}
+
+fn validateManifestNPoints(n: u32) !u32 {
+    if (n == 0 or n > 10000) {
+        return error.InvalidArgument;
+    }
+    return n;
+}
+
+fn validateManifestNSlices(n: u32) !u32 {
+    if (n == 0 or n > 1000) {
+        return error.InvalidArgument;
+    }
+    return n;
+}
+
 /// Parse and validate probe radius value
 fn parseProbeRadius(value: []const u8) f64 {
     const radius = std.fmt.parseFloat(f64, value) catch {
         std.debug.print("Error: Invalid probe radius: {s}\n", .{value});
         std.process.exit(1);
     };
-    if (radius <= 0 or radius > 10.0 or !std.math.isFinite(radius)) {
+    return validateManifestProbeRadius(radius) catch {
         std.debug.print("Error: Probe radius must be between 0 and 10 Angstroms: {d}\n", .{radius});
         std.process.exit(1);
-    }
-    return radius;
+    };
 }
 
 /// Parse and validate n-points value
@@ -1738,11 +1758,10 @@ fn parseNPoints(value: []const u8) u32 {
         std.debug.print("Error: Invalid n-points: {s}\n", .{value});
         std.process.exit(1);
     };
-    if (n == 0 or n > 10000) {
+    return validateManifestNPoints(n) catch {
         std.debug.print("Error: n-points must be between 1 and 10000: {d}\n", .{n});
         std.process.exit(1);
-    }
-    return n;
+    };
 }
 
 /// Parse and validate n-slices value (for Lee-Richards)
@@ -1751,11 +1770,10 @@ fn parseNSlices(value: []const u8) u32 {
         std.debug.print("Error: Invalid n-slices: {s}\n", .{value});
         std.process.exit(1);
     };
-    if (n == 0 or n > 1000) {
+    return validateManifestNSlices(n) catch {
         std.debug.print("Error: n-slices must be between 1 and 1000: {d}\n", .{n});
         std.process.exit(1);
-    }
-    return n;
+    };
 }
 
 /// Parse and validate algorithm value
@@ -2140,7 +2158,7 @@ pub fn printHelp(program_name: []const u8) void {
 /// Delegates to sdf_parser.loadSdfComponents.
 const loadSdfComponents = sdf_parser.loadSdfComponents;
 
-fn applyManifestGlobals(config: *BatchConfig, args: BatchArgs, globals: batch_manifest.Globals) void {
+fn applyManifestGlobals(config: *BatchConfig, args: BatchArgs, globals: batch_manifest.Globals) !void {
     if (!args.threads_explicit) {
         if (globals.threads) |v| config.n_threads = v;
     }
@@ -2148,13 +2166,22 @@ fn applyManifestGlobals(config: *BatchConfig, args: BatchArgs, globals: batch_ma
         if (globals.algorithm) |v| config.algorithm = parseAlgorithm(v);
     }
     if (!args.n_points_explicit) {
-        if (globals.n_points) |v| config.n_points = v;
+        if (globals.n_points) |v| config.n_points = validateManifestNPoints(v) catch |err| {
+            std.debug.print("Error: manifest n_points must be between 1 and 10000: {d}\n", .{v});
+            return err;
+        };
     }
     if (!args.n_slices_explicit) {
-        if (globals.n_slices) |v| config.n_slices = v;
+        if (globals.n_slices) |v| config.n_slices = validateManifestNSlices(v) catch |err| {
+            std.debug.print("Error: manifest n_slices must be between 1 and 1000: {d}\n", .{v});
+            return err;
+        };
     }
     if (!args.probe_radius_explicit) {
-        if (globals.probe_radius) |v| config.probe_radius = v;
+        if (globals.probe_radius) |v| config.probe_radius = validateManifestProbeRadius(v) catch |err| {
+            std.debug.print("Error: manifest probe_radius must be finite and between 0 and 10 Angstroms: {d}\n", .{v});
+            return err;
+        };
     }
     if (!args.precision_explicit) {
         if (globals.precision) |v| config.precision = parsePrecision(v);
@@ -2295,7 +2322,7 @@ fn runManifest(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
 
     for (manifest.jobs) |job| {
         var config = BatchConfig{};
-        applyManifestGlobals(&config, args, manifest.globals);
+        try applyManifestGlobals(&config, args, manifest.globals);
         applyCliOverrides(&config, args);
 
         config.include_hetatm = config.include_hetatm or (config.classifier_type == .ccd);
@@ -2579,6 +2606,23 @@ test "parseBatchChainFilter splits comma-separated chains" {
     try std.testing.expectEqualStrings("A", chains[0]);
     try std.testing.expectEqualStrings("B", chains[1]);
     try std.testing.expectEqualStrings("AB", chains[2]);
+}
+
+test "manifest numeric validators reject invalid values" {
+    try std.testing.expectEqual(@as(f64, 1.4), try validateManifestProbeRadius(1.4));
+    try std.testing.expectEqual(@as(u32, 1), try validateManifestNPoints(1));
+    try std.testing.expectEqual(@as(u32, 10000), try validateManifestNPoints(10000));
+    try std.testing.expectEqual(@as(u32, 1), try validateManifestNSlices(1));
+    try std.testing.expectEqual(@as(u32, 1000), try validateManifestNSlices(1000));
+
+    try std.testing.expectError(error.InvalidArgument, validateManifestProbeRadius(0));
+    try std.testing.expectError(error.InvalidArgument, validateManifestProbeRadius(-1));
+    try std.testing.expectError(error.InvalidArgument, validateManifestProbeRadius(10.1));
+    try std.testing.expectError(error.InvalidArgument, validateManifestProbeRadius(std.math.nan(f64)));
+    try std.testing.expectError(error.InvalidArgument, validateManifestNPoints(0));
+    try std.testing.expectError(error.InvalidArgument, validateManifestNPoints(10001));
+    try std.testing.expectError(error.InvalidArgument, validateManifestNSlices(0));
+    try std.testing.expectError(error.InvalidArgument, validateManifestNSlices(1001));
 }
 
 test "manifestJsonlOutputPath uses job file under output dir" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -115,6 +115,16 @@ fn getOutputExtension(format: OutputFormat) []const u8 {
     };
 }
 
+fn manifestJsonlOutputPath(allocator: Allocator, output_dir: []const u8, job_name: []const u8) ![]const u8 {
+    const filename = try std.fmt.allocPrint(allocator, "{s}.jsonl", .{job_name});
+    defer allocator.free(filename);
+    return std.fs.path.join(allocator, &.{ output_dir, filename });
+}
+
+fn manifestPerFileOutputDir(allocator: Allocator, output_dir: []const u8, job_name: []const u8) ![]const u8 {
+    return std.fs.path.join(allocator, &.{ output_dir, job_name });
+}
+
 /// Replace file extension for output (e.g., "file.pdb" -> "file.json")
 fn replaceExtension(allocator: Allocator, filename: []const u8, new_ext: []const u8) ![]const u8 {
     // Strip compression extension if present.
@@ -2130,8 +2140,214 @@ pub fn printHelp(program_name: []const u8) void {
 /// Delegates to sdf_parser.loadSdfComponents.
 const loadSdfComponents = sdf_parser.loadSdfComponents;
 
+fn applyManifestGlobals(config: *BatchConfig, args: BatchArgs, globals: batch_manifest.Globals) void {
+    if (!args.threads_explicit) {
+        if (globals.threads) |v| config.n_threads = v;
+    }
+    if (!args.algorithm_explicit) {
+        if (globals.algorithm) |v| config.algorithm = parseAlgorithm(v);
+    }
+    if (!args.n_points_explicit) {
+        if (globals.n_points) |v| config.n_points = v;
+    }
+    if (!args.n_slices_explicit) {
+        if (globals.n_slices) |v| config.n_slices = v;
+    }
+    if (!args.probe_radius_explicit) {
+        if (globals.probe_radius) |v| config.probe_radius = v;
+    }
+    if (!args.precision_explicit) {
+        if (globals.precision) |v| config.precision = parsePrecision(v);
+    }
+    if (!args.format_explicit) {
+        if (globals.format) |v| config.output_format = parseOutputFormat(v);
+    }
+    if (!args.timing_explicit) {
+        if (globals.timing) |v| config.show_timing = v;
+    }
+    if (!args.quiet_explicit) {
+        if (globals.quiet) |v| {
+            config.quiet = v;
+            config.show_progress = !v;
+        }
+    }
+    if (!args.classifier_explicit) {
+        if (globals.classifier) |v| config.classifier_type = parseClassifierType(v);
+    }
+    if (!args.include_hydrogens_explicit) {
+        if (globals.include_hydrogens) |v| config.include_hydrogens = v;
+    }
+    if (!args.include_hetatm_explicit) {
+        if (globals.include_hetatm) |v| config.include_hetatm = v;
+    }
+    if (!args.use_bitmask_explicit) {
+        if (globals.use_bitmask) |v| config.use_bitmask = v;
+    }
+    if (globals.auth_chain) |v| config.use_auth_chain = v;
+}
+
+fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
+    if (args.threads_explicit) config.n_threads = args.n_threads;
+    if (args.algorithm_explicit) config.algorithm = args.algorithm;
+    if (args.n_points_explicit) config.n_points = args.n_points;
+    if (args.n_slices_explicit) config.n_slices = args.n_slices;
+    if (args.probe_radius_explicit) config.probe_radius = args.probe_radius;
+    if (args.precision_explicit) config.precision = args.precision;
+    if (args.format_explicit) config.output_format = args.output_format;
+    if (args.timing_explicit) config.show_timing = args.show_timing;
+    if (args.quiet_explicit) {
+        config.quiet = args.quiet;
+        config.show_progress = args.show_progress;
+    }
+    if (args.classifier_explicit) config.classifier_type = args.classifier_type;
+    if (args.include_hydrogens_explicit) config.include_hydrogens = args.include_hydrogens;
+    if (args.include_hetatm_explicit) config.include_hetatm = args.include_hetatm;
+    if (args.use_bitmask_explicit) config.use_bitmask = args.use_bitmask;
+    if (args.use_auth_chain) config.use_auth_chain = true;
+}
+
+fn parseManifestFile(allocator: Allocator, io: std.Io, path: []const u8) !batch_manifest.Manifest {
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+
+    var read_buf: [65536]u8 = undefined;
+    var reader = file.reader(io, &read_buf);
+    const content = try reader.interface.allocRemaining(allocator, .unlimited);
+    errdefer allocator.free(content);
+
+    const manifest = try batch_manifest.parse(allocator, content);
+    allocator.free(content);
+    return manifest;
+}
+
+fn runManifest(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    if (args.chain_filter != null) {
+        std.debug.print("Error: --manifest cannot be combined with --chain; use [[jobs]].chains in the manifest\n", .{});
+        return error.InvalidArgument;
+    }
+
+    const manifest_path = args.manifest_path.?;
+    var manifest = parseManifestFile(allocator, io, manifest_path) catch |err| {
+        std.debug.print("Error reading manifest '{s}': {s}\n", .{ manifest_path, @errorName(err) });
+        return err;
+    };
+    defer manifest.deinit();
+
+    const input_dir = args.input_path orelse manifest.globals.input_dir orelse {
+        std.debug.print("Error: Missing input directory (provide positional input_dir or input_dir in manifest)\n", .{});
+        return error.MissingArgument;
+    };
+    const output_dir = args.output_path orelse manifest.globals.output_dir;
+
+    if (manifest.jobs.len > 1 and output_dir == null) {
+        std.debug.print("Error: --manifest with multiple jobs requires an output directory\n", .{});
+        return error.InvalidArgument;
+    }
+
+    const load_quiet = if (args.quiet_explicit) args.quiet else (manifest.globals.quiet orelse args.quiet);
+
+    const ccd_path = if (args.ccd_explicit) args.ccd_path else manifest.globals.ccd;
+    var ext_ccd: ?ccd_parser.ComponentDict = null;
+    if (ccd_path) |path| {
+        const ccd_data = if (compressed.isCompressed(path))
+            compressed.read(allocator, path) catch |err| {
+                std.debug.print("Error reading CCD file '{s}': {s}\n", .{ path, @errorName(err) });
+                return err;
+            }
+        else blk: {
+            const f = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| {
+                std.debug.print("Error opening CCD file '{s}': {s}\n", .{ path, @errorName(err) });
+                return err;
+            };
+            defer f.close(io);
+            var read_buf_ccd: [65536]u8 = undefined;
+            var file_r_ccd = f.reader(io, &read_buf_ccd);
+            break :blk file_r_ccd.interface.allocRemaining(allocator, .unlimited) catch |err| {
+                std.debug.print("Error reading CCD file '{s}': {s}\n", .{ path, @errorName(err) });
+                return err;
+            };
+        };
+        defer allocator.free(ccd_data);
+
+        ext_ccd = ccd_binary.loadDict(allocator, ccd_data) catch |err| {
+            std.debug.print("Error loading CCD dictionary '{s}': {s}\n", .{ path, @errorName(err) });
+            return err;
+        };
+        if (!load_quiet) {
+            std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), path });
+        }
+    }
+    defer if (ext_ccd) |*d| d.deinit();
+
+    const manifest_sdf_paths: []const []const u8 = manifest.globals.sdf orelse &.{};
+    const sdf_paths = if (args.sdf_explicit) args.sdf_paths.constSlice() else manifest_sdf_paths;
+    var sdf_ccd: ?ccd_parser.ComponentDict = null;
+    if (sdf_paths.len > 0) {
+        sdf_ccd = loadSdfComponents(allocator, io, sdf_paths, load_quiet) catch |err| {
+            std.debug.print("Error loading SDF components: {s}\n", .{@errorName(err)});
+            return err;
+        };
+    }
+    defer if (sdf_ccd) |*d| d.deinit();
+
+    var successful: usize = 0;
+    var failed: usize = 0;
+
+    for (manifest.jobs) |job| {
+        var config = BatchConfig{};
+        applyManifestGlobals(&config, args, manifest.globals);
+        applyCliOverrides(&config, args);
+
+        config.include_hetatm = config.include_hetatm or (config.classifier_type == .ccd);
+        config.store_atom_areas = (config.output_format == .jsonl);
+        config.external_ccd = if (ext_ccd != null) &ext_ccd.? else null;
+        config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
+        if (job.auth_chain) |v| config.use_auth_chain = v;
+        config.chain_filter = job.chains;
+
+        if ((config.classifier_type == .ccd or config.classifier_type == .protor) and config.include_hydrogens and !config.quiet) {
+            std.debug.print("Warning: --include-hydrogens with CCD classifier may give inaccurate results\n", .{});
+            std.debug.print("         CCD uses united-atom radii that already account for implicit hydrogens\n", .{});
+        }
+
+        var job_output_dir: ?[]const u8 = null;
+        defer if (job_output_dir) |path| allocator.free(path);
+        var jsonl_output_path: ?[]const u8 = null;
+        defer if (jsonl_output_path) |path| allocator.free(path);
+
+        if (config.output_format == .jsonl) {
+            if (output_dir) |out| {
+                try std.Io.Dir.cwd().createDirPath(io, out);
+                jsonl_output_path = try manifestJsonlOutputPath(allocator, out, job.name);
+            }
+        } else if (output_dir) |out| {
+            job_output_dir = try manifestPerFileOutputDir(allocator, out, job.name);
+        }
+
+        if (!config.quiet) {
+            std.debug.print("Manifest job: {s}\n", .{job.name});
+        }
+
+        var result = runBatch(allocator, io, input_dir, job_output_dir, config, jsonl_output_path) catch |err| {
+            std.debug.print("Error running manifest job '{s}': {s}\n", .{ job.name, @errorName(err) });
+            failed += 1;
+            continue;
+        };
+        defer result.deinit();
+
+        successful += result.successful;
+        failed += result.failed;
+    }
+
+    std.debug.print("Manifest complete: {d} successful, {d} failed\n", .{ successful, failed });
+}
+
 /// Run batch processing from parsed CLI arguments
 pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    if (args.manifest_path != null) {
+        return runManifest(allocator, io, args);
+    }
+
     const input_dir = args.input_path orelse {
         std.debug.print("Error: Missing input directory\n", .{});
         std.debug.print("Usage: zsasa batch [OPTIONS] <input_dir> [output_dir]\n", .{});
@@ -2363,6 +2579,18 @@ test "parseBatchChainFilter splits comma-separated chains" {
     try std.testing.expectEqualStrings("A", chains[0]);
     try std.testing.expectEqualStrings("B", chains[1]);
     try std.testing.expectEqualStrings("AB", chains[2]);
+}
+
+test "manifestJsonlOutputPath uses job file under output dir" {
+    const path = try manifestJsonlOutputPath(std.testing.allocator, "results", "chain_A");
+    defer std.testing.allocator.free(path);
+    try std.testing.expectEqualStrings("results/chain_A.jsonl", path);
+}
+
+test "manifestPerFileOutputDir uses job directory under output dir" {
+    const path = try manifestPerFileOutputDir(std.testing.allocator, "results", "complex_AB");
+    defer std.testing.allocator.free(path);
+    try std.testing.expectEqualStrings("results/complex_AB", path);
 }
 
 test "BatchArgs explicit option flags" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const batch_manifest = @import("batch_manifest.zig");
 const types = @import("types.zig");
 const format_detect = @import("format_detect.zig");
 const json_parser = @import("json_parser.zig");
@@ -1664,6 +1665,9 @@ pub const BatchArgs = struct {
     input_path: ?[]const u8 = null,
     output_path: ?[]const u8 = null, // Output directory; null means no file output
     output_path_explicit: bool = false, // Track if -o/--output was explicitly set
+    manifest_path: ?[]const u8 = null,
+    chain_filter: ?[]const u8 = null,
+    use_auth_chain: bool = false,
     n_threads: usize = 0,
     probe_radius: f64 = 1.4,
     n_points: u32 = 100,
@@ -1681,6 +1685,21 @@ pub const BatchArgs = struct {
     show_progress: bool = true,
     show_timing: bool = false,
     show_help: bool = false,
+    threads_explicit: bool = false,
+    probe_radius_explicit: bool = false,
+    n_points_explicit: bool = false,
+    n_slices_explicit: bool = false,
+    algorithm_explicit: bool = false,
+    precision_explicit: bool = false,
+    format_explicit: bool = false,
+    classifier_explicit: bool = false,
+    include_hydrogens_explicit: bool = false,
+    include_hetatm_explicit: bool = false,
+    use_bitmask_explicit: bool = false,
+    ccd_explicit: bool = false,
+    sdf_explicit: bool = false,
+    quiet_explicit: bool = false,
+    timing_explicit: bool = false,
 };
 
 // Parse helper functions (local to batch.zig)
@@ -1787,12 +1806,14 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
 
         // --threads=N or --threads N
         if (std.mem.startsWith(u8, arg, "--threads=")) {
+            result.threads_explicit = true;
             const value = arg["--threads=".len..];
             result.n_threads = std.fmt.parseInt(usize, value, 10) catch {
                 std.debug.print("Error: Invalid thread count: {s}\n", .{value});
                 std.process.exit(1);
             };
         } else if (std.mem.eql(u8, arg, "--threads")) {
+            result.threads_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --threads\n", .{});
@@ -1805,9 +1826,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --probe-radius=R or --probe-radius R
         else if (std.mem.startsWith(u8, arg, "--probe-radius=")) {
+            result.probe_radius_explicit = true;
             const value = arg["--probe-radius=".len..];
             result.probe_radius = parseProbeRadius(value);
         } else if (std.mem.eql(u8, arg, "--probe-radius")) {
+            result.probe_radius_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --probe-radius\n", .{});
@@ -1817,9 +1840,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --n-points=N or --n-points N
         else if (std.mem.startsWith(u8, arg, "--n-points=")) {
+            result.n_points_explicit = true;
             const value = arg["--n-points=".len..];
             result.n_points = parseNPoints(value);
         } else if (std.mem.eql(u8, arg, "--n-points")) {
+            result.n_points_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --n-points\n", .{});
@@ -1829,9 +1854,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --n-slices=N or --n-slices N (for Lee-Richards)
         else if (std.mem.startsWith(u8, arg, "--n-slices=")) {
+            result.n_slices_explicit = true;
             const value = arg["--n-slices=".len..];
             result.n_slices = parseNSlices(value);
         } else if (std.mem.eql(u8, arg, "--n-slices")) {
+            result.n_slices_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --n-slices\n", .{});
@@ -1841,9 +1868,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --format=FORMAT or --format FORMAT
         else if (std.mem.startsWith(u8, arg, "--format=")) {
+            result.format_explicit = true;
             const value = arg["--format=".len..];
             result.output_format = parseOutputFormat(value);
         } else if (std.mem.eql(u8, arg, "--format")) {
+            result.format_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --format\n", .{});
@@ -1853,9 +1882,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --algorithm=ALGO or --algorithm ALGO
         else if (std.mem.startsWith(u8, arg, "--algorithm=")) {
+            result.algorithm_explicit = true;
             const value = arg["--algorithm=".len..];
             result.algorithm = parseAlgorithm(value);
         } else if (std.mem.eql(u8, arg, "--algorithm")) {
+            result.algorithm_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --algorithm\n", .{});
@@ -1865,9 +1896,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --classifier=TYPE or --classifier TYPE
         else if (std.mem.startsWith(u8, arg, "--classifier=")) {
+            result.classifier_explicit = true;
             const value = arg["--classifier=".len..];
             result.classifier_type = parseClassifierType(value);
         } else if (std.mem.eql(u8, arg, "--classifier")) {
+            result.classifier_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --classifier\n", .{});
@@ -1877,9 +1910,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --precision=PREC or --precision PREC
         else if (std.mem.startsWith(u8, arg, "--precision=")) {
+            result.precision_explicit = true;
             const value = arg["--precision=".len..];
             result.precision = parsePrecision(value);
         } else if (std.mem.eql(u8, arg, "--precision")) {
+            result.precision_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --precision\n", .{});
@@ -1887,23 +1922,54 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
             }
             result.precision = parsePrecision(args[i]);
         }
+        // --manifest=PATH or --manifest PATH
+        else if (std.mem.startsWith(u8, arg, "--manifest=")) {
+            result.manifest_path = arg["--manifest=".len..];
+        } else if (std.mem.eql(u8, arg, "--manifest")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --manifest\n", .{});
+                std.process.exit(1);
+            }
+            result.manifest_path = args[i];
+        }
+        // --chain=ID or --chain ID
+        else if (std.mem.startsWith(u8, arg, "--chain=")) {
+            result.chain_filter = arg["--chain=".len..];
+        } else if (std.mem.eql(u8, arg, "--chain")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --chain\n", .{});
+                std.process.exit(1);
+            }
+            result.chain_filter = args[i];
+        }
+        // --auth-chain
+        else if (std.mem.eql(u8, arg, "--auth-chain")) {
+            result.use_auth_chain = true;
+        }
         // --include-hydrogens
         else if (std.mem.eql(u8, arg, "--include-hydrogens")) {
             result.include_hydrogens = true;
+            result.include_hydrogens_explicit = true;
         }
         // --include-hetatm
         else if (std.mem.eql(u8, arg, "--include-hetatm")) {
             result.include_hetatm = true;
+            result.include_hetatm_explicit = true;
         }
         // --use-bitmask
         else if (std.mem.eql(u8, arg, "--use-bitmask")) {
             result.use_bitmask = true;
+            result.use_bitmask_explicit = true;
         }
         // --ccd=PATH or --ccd PATH (external CCD dictionary)
         else if (std.mem.startsWith(u8, arg, "--ccd=")) {
+            result.ccd_explicit = true;
             const value = arg["--ccd=".len..];
             result.ccd_path = value;
         } else if (std.mem.eql(u8, arg, "--ccd")) {
+            result.ccd_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --ccd\n", .{});
@@ -1913,12 +1979,14 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         }
         // --sdf=PATH or --sdf PATH (SDF file with bond topology for CCD classifier)
         else if (std.mem.startsWith(u8, arg, "--sdf=")) {
+            result.sdf_explicit = true;
             const value = arg["--sdf=".len..];
             result.sdf_paths.append(value) catch {
                 std.debug.print("Error: Too many --sdf paths (max 16)\n", .{});
                 std.process.exit(1);
             };
         } else if (std.mem.eql(u8, arg, "--sdf")) {
+            result.sdf_explicit = true;
             i += 1;
             if (i >= args.len) {
                 std.debug.print("Error: Missing value for --sdf\n", .{});
@@ -1932,11 +2000,13 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         // --quiet or -q
         else if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
             result.quiet = true;
+            result.quiet_explicit = true;
             result.show_progress = false;
         }
         // --timing
         else if (std.mem.eql(u8, arg, "--timing")) {
             result.show_timing = true;
+            result.timing_explicit = true;
         }
         // --help or -h
         else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
@@ -2237,6 +2307,36 @@ test "BatchArgs help flag" {
     const args = [_][]const u8{ "zsasa", "batch", "--help" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.show_help);
+}
+
+test "BatchArgs --manifest" {
+    const args = [_][]const u8{ "zsasa", "batch", "--manifest", "bsa.toml" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqualStrings("bsa.toml", parsed.manifest_path.?);
+}
+
+test "BatchArgs --chain=A" {
+    const args = [_][]const u8{ "zsasa", "batch", "--chain=A", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqualStrings("A", parsed.chain_filter.?);
+    try std.testing.expectEqualStrings("input_dir/", parsed.input_path.?);
+}
+
+test "BatchArgs --auth-chain" {
+    const args = [_][]const u8{ "zsasa", "batch", "--auth-chain", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.use_auth_chain);
+}
+
+test "BatchArgs explicit option flags" {
+    const args = [_][]const u8{
+        "zsasa", "batch", "--threads=8", "--n-points=128", "--format=jsonl", "--use-bitmask", "input_dir/",
+    };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.threads_explicit);
+    try std.testing.expectEqual(true, parsed.n_points_explicit);
+    try std.testing.expectEqual(true, parsed.format_explicit);
+    try std.testing.expectEqual(true, parsed.use_bitmask_explicit);
 }
 
 test "BatchArgs output via -o flag" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -2129,6 +2129,9 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --sdf=PATH          SDF file with bond topology for CCD classifier
         \\                        Can be specified multiple times for multiple ligands
         \\    --threads=N         Number of threads (default: auto-detect)
+        \\    --manifest=PATH     TOML manifest with one or more named batch jobs
+        \\    --chain=ID          Filter by chain ID for non-manifest batch (e.g. A or A,B)
+        \\    --auth-chain        Use auth_asym_id instead of label_asym_id for mmCIF chain matching
         \\    --probe-radius=R    Probe radius in Angstroms (default: 1.4)
         \\    --n-points=N        Test points per atom (default: 100, for sr)
         \\    --n-slices=N        Slices per atom diameter (default: 20, for lr)
@@ -2150,8 +2153,11 @@ pub fn printHelp(program_name: []const u8) void {
         \\    {s} batch structures/ --classifier=naccess --format=csv
         \\    {s} batch structures/ results/ --timing --quiet
         \\    {s} batch structures/ -o results.jsonl --format=jsonl
+        \\    {s} batch --manifest bsa.toml
+        \\    {s} batch structures/ results/ --manifest bsa.toml
+        \\    {s} batch structures/ results_A/ --chain=A --format=jsonl
         \\
-    , .{ program_name, program_name, program_name, program_name, program_name, program_name, program_name });
+    , .{ program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name });
 }
 
 /// Load SDF files and build a ComponentDict from their bond topology.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -71,6 +71,8 @@ pub const BatchConfig = struct {
     store_atom_areas: bool = false, // When true, copy atom_areas to result_allocator for jsonl
     external_ccd: ?*const ccd_parser.ComponentDict = null, // External CCD dictionary
     sdf_ccd: ?*const ccd_parser.ComponentDict = null, // SDF bond topology dictionary
+    chain_filter: ?[]const []const u8 = null,
+    use_auth_chain: bool = false,
 };
 
 /// Helper to build and hold bitmask LUTs for batch processing.
@@ -354,12 +356,15 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             var parser = mmcif_parser.MmcifParser.init(allocator);
             parser.skip_hydrogens = !config.include_hydrogens;
             parser.atom_only = !config.include_hetatm;
+            parser.chain_filter = config.chain_filter;
+            parser.use_auth_chain = config.use_auth_chain;
             break :blk parser.parseFile(io, path);
         },
         .pdb => blk: {
             var parser = pdb_parser.PdbParser.init(allocator);
             parser.skip_hydrogens = !config.include_hydrogens;
             parser.atom_only = !config.include_hetatm;
+            parser.chain_filter = config.chain_filter;
             break :blk parser.parseFile(io, path);
         },
         .sdf => blk: {
@@ -1795,6 +1800,21 @@ fn parsePrecision(value: []const u8) Precision {
     }
 }
 
+fn parseBatchChainFilter(allocator: Allocator, filter_str: []const u8) ![]const []const u8 {
+    var chains = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer chains.deinit(allocator);
+
+    var iter = std.mem.splitScalar(u8, filter_str, ',');
+    while (iter.next()) |chain| {
+        const trimmed = std.mem.trim(u8, chain, " ");
+        if (trimmed.len > 0) {
+            try chains.append(allocator, trimmed);
+        }
+    }
+
+    return chains.toOwnedSlice(allocator);
+}
+
 /// Parse batch subcommand arguments
 pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
     var result = BatchArgs{};
@@ -2164,6 +2184,12 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     // For jsonl, don't pass output_dir to runBatch (no per-file I/O during computation)
     const output_dir: ?[]const u8 = if (args.output_format == .jsonl) null else args.output_path;
 
+    var chain_filter_slice: ?[]const []const u8 = null;
+    if (args.chain_filter) |filter_str| {
+        chain_filter_slice = try parseBatchChainFilter(allocator, filter_str);
+    }
+    defer if (chain_filter_slice) |s| allocator.free(s);
+
     // Build batch config from parsed args
     // CCD/ProtOr use united-atom radii (implicit H) — warn if explicit H included
     if ((args.classifier_type == .ccd or args.classifier_type == .protor) and args.include_hydrogens and !args.quiet) {
@@ -2189,6 +2215,8 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         .store_atom_areas = (args.output_format == .jsonl),
         .external_ccd = if (ext_ccd != null) &ext_ccd.? else null,
         .sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null,
+        .chain_filter = chain_filter_slice,
+        .use_auth_chain = args.use_auth_chain,
     };
 
     if (!args.quiet) {
@@ -2326,6 +2354,15 @@ test "BatchArgs --auth-chain" {
     const args = [_][]const u8{ "zsasa", "batch", "--auth-chain", "input_dir/" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.use_auth_chain);
+}
+
+test "parseBatchChainFilter splits comma-separated chains" {
+    const chains = try parseBatchChainFilter(std.testing.allocator, "A, B,AB");
+    defer std.testing.allocator.free(chains);
+    try std.testing.expectEqual(@as(usize, 3), chains.len);
+    try std.testing.expectEqualStrings("A", chains[0]);
+    try std.testing.expectEqualStrings("B", chains[1]);
+    try std.testing.expectEqualStrings("AB", chains[2]);
 }
 
 test "BatchArgs explicit option flags" {

--- a/src/batch_manifest.zig
+++ b/src/batch_manifest.zig
@@ -1,0 +1,333 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const toml_parser = @import("toml_parser.zig");
+
+pub const ManifestError = error{
+    UnsupportedVersion,
+    MissingJobName,
+    DuplicateJobName,
+    UnsafeJobName,
+    InvalidFieldType,
+    NoJobs,
+};
+
+pub const Error = ManifestError || Allocator.Error || toml_parser.Error || std.Io.File.OpenError || std.Io.File.ReadStreamingError;
+
+pub const Globals = struct {
+    input_dir: ?[]const u8 = null,
+    output_dir: ?[]const u8 = null,
+    algorithm: ?[]const u8 = null,
+    classifier: ?[]const u8 = null,
+    ccd: ?[]const u8 = null,
+    sdf: ?[]const []const u8 = null,
+    threads: ?usize = null,
+    probe_radius: ?f64 = null,
+    n_points: ?u32 = null,
+    n_slices: ?u32 = null,
+    precision: ?[]const u8 = null,
+    format: ?[]const u8 = null,
+    include_hydrogens: ?bool = null,
+    include_hetatm: ?bool = null,
+    use_bitmask: ?bool = null,
+    timing: ?bool = null,
+    quiet: ?bool = null,
+    auth_chain: ?bool = null,
+};
+
+pub const Job = struct {
+    name: []const u8,
+    chains: ?[]const []const u8 = null,
+    auth_chain: ?bool = null,
+};
+
+pub const Manifest = struct {
+    allocator: Allocator,
+    content: []const u8,
+    globals: Globals,
+    jobs: []Job,
+
+    pub fn deinit(self: *Manifest) void {
+        if (self.globals.sdf) |items| self.allocator.free(items);
+        for (self.jobs) |job| {
+            if (job.chains) |chains| self.allocator.free(chains);
+        }
+        self.allocator.free(self.jobs);
+        self.allocator.free(self.content);
+        self.* = undefined;
+    }
+};
+
+pub fn parse(allocator: Allocator, content: []const u8) Error!Manifest {
+    const owned_content = try allocator.dupe(u8, content);
+    errdefer allocator.free(owned_content);
+    return parseOwned(allocator, owned_content);
+}
+
+pub fn parseFile(allocator: Allocator, io: std.Io, path: []const u8) Error!Manifest {
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+
+    var read_buf: [65536]u8 = undefined;
+    var reader = file.reader(io, &read_buf);
+    const content = try reader.interface.allocRemaining(allocator, .unlimited);
+    errdefer allocator.free(content);
+    return parseOwned(allocator, content);
+}
+
+fn parseOwned(allocator: Allocator, owned_content: []const u8) Error!Manifest {
+    var doc = try toml_parser.parse(allocator, owned_content);
+    defer doc.deinit();
+
+    const root = doc.getTable("") orelse return error.UnsupportedVersion;
+    try validateVersion(root);
+
+    const globals = try parseGlobals(allocator, root);
+    errdefer if (globals.sdf) |items| allocator.free(items);
+
+    var jobs = std.ArrayListUnmanaged(Job).empty;
+    errdefer {
+        for (jobs.items) |job| {
+            if (job.chains) |chains| allocator.free(chains);
+        }
+        jobs.deinit(allocator);
+    }
+
+    for (doc.array_tables) |table| {
+        if (!std.mem.eql(u8, table.name, "jobs")) continue;
+        {
+            const job = try parseJob(allocator, table.entries, jobs.items);
+            errdefer if (job.chains) |chains| allocator.free(chains);
+            try jobs.append(allocator, job);
+        }
+    }
+
+    if (jobs.items.len == 0) return error.NoJobs;
+
+    return .{
+        .allocator = allocator,
+        .content = owned_content,
+        .globals = globals,
+        .jobs = try jobs.toOwnedSlice(allocator),
+    };
+}
+
+fn validateVersion(root: toml_parser.Table) ManifestError!void {
+    const value = findValue(root.entries, "version") orelse return error.UnsupportedVersion;
+    switch (value) {
+        .integer => |version| if (version == 1) return else return error.UnsupportedVersion,
+        else => return error.UnsupportedVersion,
+    }
+}
+
+fn parseGlobals(allocator: Allocator, root: toml_parser.Table) Error!Globals {
+    var globals = Globals{};
+    errdefer if (globals.sdf) |items| allocator.free(items);
+
+    globals.input_dir = try optionalString(root.entries, "input_dir");
+    globals.output_dir = try optionalString(root.entries, "output_dir");
+    globals.algorithm = try optionalString(root.entries, "algorithm");
+    globals.classifier = try optionalString(root.entries, "classifier");
+    globals.ccd = try optionalString(root.entries, "ccd");
+    globals.sdf = try optionalStringOrStringArray(allocator, root.entries, "sdf");
+    globals.threads = try optionalUsize(root.entries, "threads");
+    globals.probe_radius = try optionalFloat(root.entries, "probe_radius");
+    globals.n_points = try optionalU32(root.entries, "n_points");
+    globals.n_slices = try optionalU32(root.entries, "n_slices");
+    globals.precision = try optionalString(root.entries, "precision");
+    globals.format = try optionalString(root.entries, "format");
+    globals.include_hydrogens = try optionalBool(root.entries, "include_hydrogens");
+    globals.include_hetatm = try optionalBool(root.entries, "include_hetatm");
+    globals.use_bitmask = try optionalBool(root.entries, "use_bitmask");
+    globals.timing = try optionalBool(root.entries, "timing");
+    globals.quiet = try optionalBool(root.entries, "quiet");
+    globals.auth_chain = try optionalBool(root.entries, "auth_chain");
+    return globals;
+}
+
+fn parseJob(allocator: Allocator, entries: []const toml_parser.Value.Entry, existing_jobs: []const Job) Error!Job {
+    const name = try optionalString(entries, "name") orelse return error.MissingJobName;
+    if (name.len == 0) return error.MissingJobName;
+    if (!isSafeJobName(name)) return error.UnsafeJobName;
+    for (existing_jobs) |job| {
+        if (std.mem.eql(u8, job.name, name)) return error.DuplicateJobName;
+    }
+
+    const chains = try optionalStringArray(allocator, entries, "chains");
+    errdefer if (chains) |items| allocator.free(items);
+    const auth_chain = try optionalBool(entries, "auth_chain");
+
+    return .{
+        .name = name,
+        .chains = chains,
+        .auth_chain = auth_chain,
+    };
+}
+
+fn isSafeJobName(name: []const u8) bool {
+    return std.mem.indexOfScalar(u8, name, '/') == null and
+        std.mem.indexOfScalar(u8, name, '\\') == null and
+        std.mem.indexOf(u8, name, "..") == null;
+}
+
+fn findValue(entries: []const toml_parser.Value.Entry, key: []const u8) ?toml_parser.Value {
+    for (entries) |entry| {
+        if (std.mem.eql(u8, entry.key, key)) return entry.value;
+    }
+    return null;
+}
+
+fn optionalString(entries: []const toml_parser.Value.Entry, key: []const u8) ManifestError!?[]const u8 {
+    const value = findValue(entries, key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => error.InvalidFieldType,
+    };
+}
+
+fn optionalBool(entries: []const toml_parser.Value.Entry, key: []const u8) ManifestError!?bool {
+    const value = findValue(entries, key) orelse return null;
+    return switch (value) {
+        .boolean => |b| b,
+        else => error.InvalidFieldType,
+    };
+}
+
+fn optionalFloat(entries: []const toml_parser.Value.Entry, key: []const u8) ManifestError!?f64 {
+    const value = findValue(entries, key) orelse return null;
+    return switch (value) {
+        .float => |f| f,
+        .integer => |i| @floatFromInt(i),
+        else => error.InvalidFieldType,
+    };
+}
+
+fn optionalUsize(entries: []const toml_parser.Value.Entry, key: []const u8) ManifestError!?usize {
+    const value = findValue(entries, key) orelse return null;
+    return switch (value) {
+        .integer => |i| if (i >= 0 and i <= std.math.maxInt(usize)) @intCast(i) else error.InvalidFieldType,
+        else => error.InvalidFieldType,
+    };
+}
+
+fn optionalU32(entries: []const toml_parser.Value.Entry, key: []const u8) ManifestError!?u32 {
+    const value = findValue(entries, key) orelse return null;
+    return switch (value) {
+        .integer => |i| if (i >= 0 and i <= std.math.maxInt(u32)) @intCast(i) else error.InvalidFieldType,
+        else => error.InvalidFieldType,
+    };
+}
+
+fn optionalStringArray(allocator: Allocator, entries: []const toml_parser.Value.Entry, key: []const u8) Error!?[]const []const u8 {
+    const value = findValue(entries, key) orelse return null;
+    return switch (value) {
+        .string_array => |items| try allocator.dupe([]const u8, items),
+        else => error.InvalidFieldType,
+    };
+}
+
+fn optionalStringOrStringArray(allocator: Allocator, entries: []const toml_parser.Value.Entry, key: []const u8) Error!?[]const []const u8 {
+    const value = findValue(entries, key) orelse return null;
+    return switch (value) {
+        .string => |s| blk: {
+            const items = try allocator.alloc([]const u8, 1);
+            items[0] = s;
+            break :blk items;
+        },
+        .string_array => |items| try allocator.dupe([]const u8, items),
+        else => error.InvalidFieldType,
+    };
+}
+
+test "parse A B AB manifest" {
+    const input =
+        \\version = 1
+        \\
+        \\input_dir = "structures"
+        \\output_dir = "results"
+        \\
+        \\format = "jsonl"
+        \\use_bitmask = true
+        \\n_points = 128
+        \\classifier = "ccd"
+        \\
+        \\[[jobs]]
+        \\name = "chain_A"
+        \\chains = ["A"]
+        \\
+        \\[[jobs]]
+        \\name = "chain_B"
+        \\chains = ["B"]
+        \\
+        \\[[jobs]]
+        \\name = "complex_AB"
+        \\chains = ["A", "B"]
+    ;
+
+    var manifest = try parse(std.testing.allocator, input);
+    defer manifest.deinit();
+
+    try std.testing.expectEqualStrings("structures", manifest.globals.input_dir.?);
+    try std.testing.expectEqualStrings("results", manifest.globals.output_dir.?);
+    try std.testing.expectEqualStrings("jsonl", manifest.globals.format.?);
+    try std.testing.expectEqual(true, manifest.globals.use_bitmask.?);
+    try std.testing.expectEqual(@as(u32, 128), manifest.globals.n_points.?);
+    try std.testing.expectEqualStrings("ccd", manifest.globals.classifier.?);
+    try std.testing.expectEqual(@as(usize, 3), manifest.jobs.len);
+    try std.testing.expectEqualStrings("chain_A", manifest.jobs[0].name);
+    try std.testing.expectEqualStrings("A", manifest.jobs[0].chains.?[0]);
+    try std.testing.expectEqualStrings("chain_B", manifest.jobs[1].name);
+    try std.testing.expectEqualStrings("B", manifest.jobs[1].chains.?[0]);
+    try std.testing.expectEqualStrings("complex_AB", manifest.jobs[2].name);
+    try std.testing.expectEqualStrings("A", manifest.jobs[2].chains.?[0]);
+    try std.testing.expectEqualStrings("B", manifest.jobs[2].chains.?[1]);
+}
+
+test "reject duplicate and unsafe job names" {
+    const duplicate =
+        \\version = 1
+        \\[[jobs]]
+        \\name = "chain_A"
+        \\[[jobs]]
+        \\name = "chain_A"
+    ;
+    try std.testing.expectError(error.DuplicateJobName, parse(std.testing.allocator, duplicate));
+
+    const unsafe_slash =
+        \\version = 1
+        \\[[jobs]]
+        \\name = "bad/name"
+    ;
+    try std.testing.expectError(error.UnsafeJobName, parse(std.testing.allocator, unsafe_slash));
+
+    const unsafe_parent =
+        \\version = 1
+        \\[[jobs]]
+        \\name = ".."
+    ;
+    try std.testing.expectError(error.UnsafeJobName, parse(std.testing.allocator, unsafe_parent));
+}
+
+test "parse sdf string and array globals" {
+    const single =
+        \\version = 1
+        \\sdf = "lig.sdf"
+        \\[[jobs]]
+        \\name = "all"
+    ;
+    var single_manifest = try parse(std.testing.allocator, single);
+    defer single_manifest.deinit();
+    try std.testing.expectEqual(@as(usize, 1), single_manifest.globals.sdf.?.len);
+    try std.testing.expectEqualStrings("lig.sdf", single_manifest.globals.sdf.?[0]);
+
+    const array =
+        \\version = 1
+        \\sdf = ["a.sdf", "b.sdf"]
+        \\[[jobs]]
+        \\name = "all"
+    ;
+    var array_manifest = try parse(std.testing.allocator, array);
+    defer array_manifest.deinit();
+    try std.testing.expectEqual(@as(usize, 2), array_manifest.globals.sdf.?.len);
+    try std.testing.expectEqualStrings("a.sdf", array_manifest.globals.sdf.?[0]);
+    try std.testing.expectEqualStrings("b.sdf", array_manifest.globals.sdf.?[1]);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -33,6 +33,7 @@ pub const classifier = @import("classifier.zig");
 pub const analysis = @import("analysis.zig");
 pub const toml_parser = @import("toml_parser.zig");
 pub const toml_classifier_parser = @import("toml_classifier_parser.zig");
+pub const batch_manifest = @import("batch_manifest.zig");
 pub const dcd = @import("dcd.zig");
 pub const bitmask_lut = @import("bitmask_lut.zig");
 pub const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
@@ -57,6 +58,7 @@ test {
     _ = analysis;
     _ = toml_parser;
     _ = toml_classifier_parser;
+    _ = batch_manifest;
     _ = dcd;
     _ = bitmask_lut;
     _ = shrake_rupley_bitmask;

--- a/src/toml_parser.zig
+++ b/src/toml_parser.zig
@@ -469,8 +469,11 @@ fn parseInlineTable(allocator: Allocator, raw: []const u8) Error!Value {
         const val_raw = std.mem.trim(u8, pair[eq + 1 ..], " \t");
         if (val_raw.len == 0) return error.ExpectedValue;
 
-        const value = try parseValue(allocator, val_raw);
-        try entries.append(allocator, .{ .key = key, .value = value });
+        {
+            const value = try parseValue(allocator, val_raw);
+            errdefer freeValue(allocator, value);
+            try entries.append(allocator, .{ .key = key, .value = value });
+        }
     }
 
     return Value{ .inline_table = try entries.toOwnedSlice(allocator) };
@@ -666,6 +669,17 @@ test "parse cleans up owned values on allocation failure" {
         \\chains = ["A", "B"]
         \\[types]
         \\C = { radius = 1.70, class = "apolar" }
+    ;
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parseAndDeinitForAllocationFailure,
+        .{input},
+    );
+}
+
+test "parse inline table cleans up owned values on allocation failure" {
+    const input =
+        \\settings = { chains = ["A"] }
     ;
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,

--- a/src/toml_parser.zig
+++ b/src/toml_parser.zig
@@ -6,11 +6,13 @@
 //! - `[[array_of_tables]]` sections
 //! - Inline tables `{ key = value, ... }`
 //! - `"string"` values (with `\"` and `\\` escape handling)
+//! - Boolean values
+//! - Arrays of string values
 //! - Float and integer values
 //! - `#` comments (line-end and full-line)
 //!
 //! All string slices point into the original input buffer; only inline table
-//! entry slices are heap-allocated.
+//! entry slices and string array slices are heap-allocated.
 //!
 //! ## Usage
 //!
@@ -41,6 +43,8 @@ pub const Error = TomlError || Allocator.Error;
 /// A TOML value.
 pub const Value = union(enum) {
     string: []const u8,
+    boolean: bool,
+    string_array: []const []const u8,
     float: f64,
     integer: i64,
     inline_table: []const Entry,
@@ -129,7 +133,8 @@ fn freeValue(allocator: Allocator, value: Value) void {
             }
             allocator.free(entries);
         },
-        .string, .float, .integer => {},
+        .string_array => |items| allocator.free(items),
+        .string, .boolean, .float, .integer => {},
     }
 }
 
@@ -318,6 +323,13 @@ fn parseValue(allocator: Allocator, raw: []const u8) Error!Value {
     // Inline table
     if (raw[0] == '{') return parseInlineTable(allocator, raw);
 
+    // String array
+    if (raw[0] == '[') return parseStringArray(allocator, raw);
+
+    // Boolean
+    if (std.mem.eql(u8, raw, "true")) return Value{ .boolean = true };
+    if (std.mem.eql(u8, raw, "false")) return Value{ .boolean = false };
+
     // Number (float or integer)
     return parseNumber(raw);
 }
@@ -343,6 +355,32 @@ fn parseString(raw: []const u8) Error!Value {
         i += 1;
     }
     return error.UnterminatedString;
+}
+
+fn parseStringArray(allocator: Allocator, raw: []const u8) Error!Value {
+    std.debug.assert(raw[0] == '[');
+    const close = std.mem.findScalar(u8, raw, ']') orelse return error.UnexpectedCharacter;
+    const trailing = std.mem.trim(u8, raw[close + 1 ..], " \t");
+    if (trailing.len != 0) return error.UnexpectedCharacter;
+
+    const inner = std.mem.trim(u8, raw[1..close], " \t");
+    var items = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer items.deinit(allocator);
+
+    if (inner.len != 0) {
+        var iter = std.mem.splitScalar(u8, inner, ',');
+        while (iter.next()) |part_raw| {
+            const part = std.mem.trim(u8, part_raw, " \t");
+            if (part.len == 0) return error.ExpectedValue;
+            const parsed = try parseString(part);
+            switch (parsed) {
+                .string => |s| try items.append(allocator, s),
+                else => unreachable,
+            }
+        }
+    }
+
+    return Value{ .string_array = try items.toOwnedSlice(allocator) };
 }
 
 /// Parse an inline table `{ key = value, key = value }`.
@@ -505,6 +543,52 @@ test "parse float and integer values" {
     defer doc.deinit();
     const root = doc.getTable("").?;
     try std.testing.expectEqual(@as(usize, 2), root.entries.len);
+}
+
+test "parse boolean values" {
+    const input =
+        \\use_bitmask = true
+        \\quiet = false
+    ;
+    var doc = try parse(std.testing.allocator, input);
+    defer doc.deinit();
+    const root = doc.getTable("").?;
+    try std.testing.expectEqual(@as(usize, 2), root.entries.len);
+    switch (root.entries[0].value) {
+        .boolean => |b| try std.testing.expectEqual(true, b),
+        else => return error.TestUnexpectedResult,
+    }
+    switch (root.entries[1].value) {
+        .boolean => |b| try std.testing.expectEqual(false, b),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "parse string array values" {
+    const input =
+        \\chains = ["A", "B"]
+        \\sdf = ["lig1.sdf", "lig2.sdf"]
+    ;
+    var doc = try parse(std.testing.allocator, input);
+    defer doc.deinit();
+    const root = doc.getTable("").?;
+    try std.testing.expectEqual(@as(usize, 2), root.entries.len);
+    switch (root.entries[0].value) {
+        .string_array => |items| {
+            try std.testing.expectEqual(@as(usize, 2), items.len);
+            try std.testing.expectEqualStrings("A", items[0]);
+            try std.testing.expectEqualStrings("B", items[1]);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    switch (root.entries[1].value) {
+        .string_array => |items| {
+            try std.testing.expectEqual(@as(usize, 2), items.len);
+            try std.testing.expectEqualStrings("lig1.sdf", items[0]);
+            try std.testing.expectEqualStrings("lig2.sdf", items[1]);
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 test "parse error: unterminated string" {

--- a/src/toml_parser.zig
+++ b/src/toml_parser.zig
@@ -240,8 +240,11 @@ pub fn parse(allocator: Allocator, content: []const u8) Error!Document {
             const value_trimmed = std.mem.trim(u8, value_raw, " \t");
             if (value_trimmed.len == 0) return error.ExpectedValue;
 
-            const value = try parseValue(allocator, value_trimmed);
-            try current_entries.append(allocator, .{ .key = key, .value = value });
+            {
+                const value = try parseValue(allocator, value_trimmed);
+                errdefer freeValue(allocator, value);
+                try current_entries.append(allocator, .{ .key = key, .value = value });
+            }
             continue;
         }
 
@@ -296,7 +299,12 @@ fn flushSection(
     }
 
     const owned_entries = try entries.toOwnedSlice(allocator);
-    errdefer allocator.free(owned_entries);
+    errdefer {
+        for (owned_entries) |entry| {
+            freeValue(allocator, entry.value);
+        }
+        allocator.free(owned_entries);
+    }
     switch (kind) {
         .table => try tables.append(allocator, .{
             .name = name,
@@ -338,6 +346,15 @@ fn parseValue(allocator: Allocator, raw: []const u8) Error!Value {
 /// Returns a slice into the original input (no allocation).
 fn parseString(raw: []const u8) Error!Value {
     std.debug.assert(raw[0] == '"');
+    const close = try findStringClose(raw);
+    // Return the content between the quotes (excluding quotes).
+    // Note: this returns the raw content including escape sequences.
+    // For our use case (identifiers and simple strings), this is fine.
+    return Value{ .string = raw[1..close] };
+}
+
+fn findStringClose(raw: []const u8) Error!usize {
+    std.debug.assert(raw[0] == '"');
     var i: usize = 1;
     while (i < raw.len) {
         if (raw[i] == '\\') {
@@ -347,10 +364,7 @@ fn parseString(raw: []const u8) Error!Value {
             continue;
         }
         if (raw[i] == '"') {
-            // Return the content between the quotes (excluding quotes).
-            // Note: this returns the raw content including escape sequences.
-            // For our use case (identifiers and simple strings), this is fine.
-            return Value{ .string = raw[1..i] };
+            return i;
         }
         i += 1;
     }
@@ -359,28 +373,61 @@ fn parseString(raw: []const u8) Error!Value {
 
 fn parseStringArray(allocator: Allocator, raw: []const u8) Error!Value {
     std.debug.assert(raw[0] == '[');
-    const close = std.mem.findScalar(u8, raw, ']') orelse return error.UnexpectedCharacter;
+    const close = try findArrayClose(raw);
     const trailing = std.mem.trim(u8, raw[close + 1 ..], " \t");
     if (trailing.len != 0) return error.UnexpectedCharacter;
 
-    const inner = std.mem.trim(u8, raw[1..close], " \t");
+    const inner = raw[1..close];
     var items = std.ArrayListUnmanaged([]const u8).empty;
     errdefer items.deinit(allocator);
 
-    if (inner.len != 0) {
-        var iter = std.mem.splitScalar(u8, inner, ',');
-        while (iter.next()) |part_raw| {
-            const part = std.mem.trim(u8, part_raw, " \t");
-            if (part.len == 0) return error.ExpectedValue;
-            const parsed = try parseString(part);
-            switch (parsed) {
-                .string => |s| try items.append(allocator, s),
-                else => unreachable,
-            }
+    var pos: usize = 0;
+    skipArrayWhitespace(inner, &pos);
+    while (pos < inner.len) {
+        if (inner[pos] != '"') return error.ExpectedValue;
+
+        const value_start = pos;
+        const value_close = try findStringClose(inner[value_start..]);
+        try items.append(allocator, inner[value_start + 1 .. value_start + value_close]);
+        pos = value_start + value_close + 1;
+
+        skipArrayWhitespace(inner, &pos);
+        if (pos == inner.len) break;
+        if (inner[pos] != ',') return error.UnexpectedCharacter;
+        pos += 1;
+        skipArrayWhitespace(inner, &pos);
+        if (pos == inner.len) {
+            return error.ExpectedValue;
         }
     }
 
     return Value{ .string_array = try items.toOwnedSlice(allocator) };
+}
+
+fn findArrayClose(raw: []const u8) Error!usize {
+    std.debug.assert(raw[0] == '[');
+    var in_string = false;
+    var i: usize = 1;
+    while (i < raw.len) {
+        if (raw[i] == '\\' and in_string) {
+            if (i + 1 >= raw.len) return error.UnterminatedString;
+            i += 2;
+            continue;
+        }
+        if (raw[i] == '"') {
+            in_string = !in_string;
+        } else if (raw[i] == ']' and !in_string) {
+            return i;
+        }
+        i += 1;
+    }
+    return error.UnexpectedCharacter;
+}
+
+fn skipArrayWhitespace(raw: []const u8, pos: *usize) void {
+    while (pos.* < raw.len and (raw[pos.*] == ' ' or raw[pos.*] == '\t')) {
+        pos.* += 1;
+    }
 }
 
 /// Parse an inline table `{ key = value, key = value }`.
@@ -589,6 +636,42 @@ test "parse string array values" {
         },
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "parse string array values containing comma and bracket" {
+    const input =
+        \\chains = ["A,B", "a]b"]
+    ;
+    var doc = try parse(std.testing.allocator, input);
+    defer doc.deinit();
+    const root = doc.getTable("").?;
+    try std.testing.expectEqual(@as(usize, 1), root.entries.len);
+    switch (root.entries[0].value) {
+        .string_array => |items| {
+            try std.testing.expectEqual(@as(usize, 2), items.len);
+            try std.testing.expectEqualStrings("A,B", items[0]);
+            try std.testing.expectEqualStrings("a]b", items[1]);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+fn parseAndDeinitForAllocationFailure(allocator: Allocator, input: []const u8) !void {
+    var doc = try parse(allocator, input);
+    defer doc.deinit();
+}
+
+test "parse cleans up owned values on allocation failure" {
+    const input =
+        \\chains = ["A", "B"]
+        \\[types]
+        \\C = { radius = 1.70, class = "apolar" }
+    ;
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parseAndDeinitForAllocationFailure,
+        .{input},
+    );
 }
 
 test "parse error: unterminated string" {

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -33,6 +33,41 @@ zsasa batch input_dir/ output_dir/ [OPTIONS]
 
 Batch mode uses file-level parallelism: multiple files are processed simultaneously, one thread per file. Use `--threads` to control the number of concurrent files.
 
+#### Batch TOML manifest
+
+Use `--manifest` to run several named batch jobs over the same input directory. CLI positional paths and explicit options override manifest values.
+
+```bash
+zsasa batch --manifest bsa.toml
+zsasa batch structures/ results/ --manifest bsa.toml --threads=8
+```
+
+```toml
+version = 1
+input_dir = "structures"
+output_dir = "results"
+format = "jsonl"
+use_bitmask = true
+n_points = 128
+classifier = "ccd"
+
+[[jobs]]
+name = "chain_A"
+chains = ["A"]
+
+[[jobs]]
+name = "chain_B"
+chains = ["B"]
+
+[[jobs]]
+name = "complex_AB"
+chains = ["A", "B"]
+```
+
+For `format = "jsonl"`, each job writes one file such as `results/chain_A.jsonl`. For `json`, `compact`, and `csv`, each job writes a directory such as `results/chain_A/`.
+
+Precedence is: built-in defaults < manifest globals < job settings < explicit CLI options. `--chain` is for non-manifest single-job batch mode; manifest jobs should use `[[jobs]].chains`.
+
 ### `traj` - Trajectory Analysis
 
 Calculate SASA for each frame in a trajectory file (XTC or DCD).

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -9,6 +9,7 @@ sidebar_position: 1
 ```
 zsasa calc <input> [output] [OPTIONS]
 zsasa batch <input_dir> [output_dir] [OPTIONS]
+zsasa batch --manifest <manifest.toml>
 zsasa traj <trajectory> <topology> [output] [OPTIONS]
 zsasa compile-dict <input.cif[.gz|.zst]> -o <output.zsdc>
 ```
@@ -29,7 +30,10 @@ Process all structure files in a directory.
 
 ```bash
 zsasa batch input_dir/ output_dir/ [OPTIONS]
+zsasa batch --manifest manifest.toml
 ```
+
+Positional paths are required for ordinary batch mode, but can be supplied by the manifest when using `--manifest`.
 
 Batch mode uses file-level parallelism: multiple files are processed simultaneously, one thread per file. Use `--threads` to control the number of concurrent files.
 


### PR DESCRIPTION
## Summary
- Add TOML batch manifests with named jobs for workflows like chain A, chain B, and AB complex SASA.
- Add batch `--chain` / `--auth-chain` support and propagate chain filters through PDB/mmCIF parsing.
- Document manifest usage, precedence, and per-job output layout.

## Details
- Manifest config precedence is: built-in defaults < manifest globals < job settings < explicit CLI options.
- JSONL manifest output writes one file per job, e.g. `results/chain_A.jsonl`.
- Per-file formats write into per-job directories, e.g. `results/chain_A/`.
- `--manifest` and `--chain` are intentionally mutually exclusive; manifest jobs should use `[[jobs]].chains`.

## Verification
- `zig build test`
- `zig build run -- batch --manifest /tmp/zsasa-manifest-smoke/bsa.toml`
- JSONL atom count smoke: `chain_A=3`, `chain_B=3`, `complex_AB=6`

## Review notes
- Pre-PR review found no critical/important blockers.
- Pre-existing untracked `zig-pkg/` was left untouched and is not included in this PR.