### PR TITLE
[codex] Add batch JSONL residue map output

### DIFF
--- a/docs/superpowers/specs/2026-05-17-batch-residue-map-jsonl-design.md
+++ b/docs/superpowers/specs/2026-05-17-batch-residue-map-jsonl-design.md
@@ -1,0 +1,108 @@
+# Batch JSONL Residue Map Design
+
+## Context
+
+Issue #363 requests batch-compatible residue identifiers for large JSONL workflows. The motivating workflow is AFDB homo-dimer/interface analysis, where users need to join SASA output with residue-level data such as pLDDT, buried SASA, and PAE-derived confidence.
+
+Current `zsasa batch --format=jsonl` output contains `filename`, `total_area`, and a bare `atom_areas` array. The array is numerically useful but lacks enough identifiers to map atom SASA values back to residues without reparsing the input structure.
+
+## Decision
+
+Add an opt-in compact residue map for batch JSONL output rather than emitting verbose per-atom JSON objects or a fully opinionated RSA report.
+
+The new option is:
+
+```bash
+zsasa batch --format=jsonl --residue-map ...
+```
+
+Manifest equivalent:
+
+```toml
+residue_map = true
+```
+
+The JSONL shape extends the existing row with columnar residue arrays:
+
+```json
+{
+  "filename": "AF-...-model_v1.cif.zst",
+  "total_area": 16055.36,
+  "atom_areas": [46.45, 10.81, 1.13],
+  "residue_chain": ["A"],
+  "residue_name": ["MET"],
+  "residue_number": [1],
+  "residue_insertion_code": [""],
+  "residue_atom_start": [0],
+  "residue_atom_count": [3],
+  "residue_sasa": [58.39]
+}
+```
+
+All residue arrays have identical length. `residue_atom_start` and `residue_atom_count` refer to positions in `atom_areas` for the same JSONL row.
+
+## Scope
+
+In scope:
+
+- Add CLI flag `--residue-map` for `batch`.
+- Add manifest global `residue_map = true`.
+- Emit compact columnar residue arrays only for JSONL output when enabled.
+- Preserve existing JSONL output exactly when the option is not enabled.
+- Use the chain identifiers already selected by parser settings, including `--auth-chain` / manifest `auth_chain` for mmCIF chain matching and output.
+- Include residue SASA as the sum of corresponding atom SASA values.
+
+Out of scope for this change:
+
+- RSA output in batch JSONL.
+- Polar/nonpolar summaries in batch JSONL.
+- Verbose per-atom metadata objects.
+- Changing the default JSONL schema.
+- Computing buried SASA or interface metrics directly.
+
+## Data Model
+
+Add a batch-owned residue map representation with columnar fields:
+
+- `residue_chain: []FixedString4`
+- `residue_name: []FixedString5`
+- `residue_number: []i32`
+- `residue_insertion_code: []FixedString4`
+- `residue_atom_start: []usize`
+- `residue_atom_count: []usize`
+- `residue_sasa: []f64`
+
+The map groups consecutive atoms with the same residue key:
+
+```text
+(chain_id, residue_num, insertion_code, residue_name)
+```
+
+This preserves compact ranges for normal PDB/mmCIF atom ordering. If the same residue appears in non-contiguous blocks, the output contains multiple residue rows with the same identifiers. That behavior keeps `atom_start/count` correct and avoids storing an atom-to-residue index array.
+
+## Data Flow
+
+1. `batch` parses `--residue-map` or manifest `residue_map`.
+2. When `output_format == jsonl`, batch already stores `atom_areas` for streaming. With `residue_map` enabled, it also keeps enough residue map data for the current file before the per-file arena resets.
+3. After SASA calculation, batch builds the residue map from `AtomInput` metadata and calculated atom areas.
+4. The JSONL writer emits either the existing compact row or the extended residue-map row.
+
+If input metadata is insufficient, the file should fail with a clear error only when `--residue-map` is requested. Without `--residue-map`, existing behavior remains unchanged.
+
+## Error Handling
+
+- `--residue-map` with non-JSONL output is rejected with a clear message: residue map is only supported for `--format=jsonl`.
+- Missing chain/residue/insertion metadata while `--residue-map` is enabled marks the file as failed with an explanatory per-file error.
+- Existing error handling for parse, classifier, SASA, and JSONL write failures remains unchanged.
+
+## Testing
+
+Add focused tests for:
+
+- `batch` argument parsing accepts `--residue-map`.
+- manifest parsing accepts `residue_map = true`.
+- JSONL writer serializes columnar residue arrays.
+- residue map construction groups consecutive atoms and computes `atom_start`, `atom_count`, and `residue_sasa`.
+- non-contiguous repeated residue identifiers produce separate contiguous ranges.
+- `--residue-map` without `--format=jsonl` is rejected.
+- a small batch JSONL smoke test includes residue map fields when requested.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -73,6 +73,7 @@ pub const BatchConfig = struct {
     sdf_ccd: ?*const ccd_parser.ComponentDict = null, // SDF bond topology dictionary
     chain_filter: ?[]const []const u8 = null,
     use_auth_chain: bool = false,
+    residue_map: bool = false,
 };
 
 /// Helper to build and hold bitmask LUTs for batch processing.
@@ -1683,6 +1684,7 @@ pub const BatchArgs = struct {
     manifest_path: ?[]const u8 = null,
     chain_filter: ?[]const u8 = null,
     use_auth_chain: bool = false,
+    residue_map: bool = false,
     n_threads: usize = 0,
     probe_radius: f64 = 1.4,
     n_points: u32 = 100,
@@ -1996,6 +1998,10 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         else if (std.mem.eql(u8, arg, "--auth-chain")) {
             result.use_auth_chain = true;
         }
+        // --residue-map
+        else if (std.mem.eql(u8, arg, "--residue-map")) {
+            result.residue_map = true;
+        }
         // --include-hydrogens
         else if (std.mem.eql(u8, arg, "--include-hydrogens")) {
             result.include_hydrogens = true;
@@ -2133,6 +2139,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --manifest=PATH     TOML manifest with one or more named batch jobs
         \\    --chain=ID          Filter by chain ID for non-manifest batch (e.g. A or A,B)
         \\    --auth-chain        Use auth_asym_id instead of label_asym_id for mmCIF chain matching
+        \\    --residue-map      Include compact residue map arrays in JSONL output
         \\    --probe-radius=R    Probe radius in Angstroms (default: 1.4)
         \\    --n-points=N        Test points per atom (default: 100, for sr)
         \\    --n-slices=N        Slices per atom diameter (default: 20, for lr)
@@ -2218,6 +2225,7 @@ fn applyManifestGlobals(config: *BatchConfig, args: BatchArgs, globals: batch_ma
         if (globals.use_bitmask) |v| config.use_bitmask = v;
     }
     if (globals.auth_chain) |v| config.use_auth_chain = v;
+    if (globals.residue_map) |v| config.residue_map = v;
 }
 
 fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
@@ -2238,6 +2246,7 @@ fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
     if (args.include_hetatm_explicit) config.include_hetatm = args.include_hetatm;
     if (args.use_bitmask_explicit) config.use_bitmask = args.use_bitmask;
     if (args.use_auth_chain) config.use_auth_chain = true;
+    if (args.residue_map) config.residue_map = true;
 }
 
 fn applyManifestJobOverrides(config: *BatchConfig, args: BatchArgs, job: batch_manifest.Job) void {
@@ -2472,6 +2481,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         .sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null,
         .chain_filter = chain_filter_slice,
         .use_auth_chain = args.use_auth_chain,
+        .residue_map = args.residue_map,
     };
 
     if (!args.quiet) {
@@ -2611,6 +2621,13 @@ test "BatchArgs --auth-chain" {
     try std.testing.expectEqual(true, parsed.use_auth_chain);
 }
 
+test "BatchArgs --residue-map" {
+    const args = [_][]const u8{ "zsasa", "batch", "--format=jsonl", "--residue-map", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(OutputFormat.jsonl, parsed.output_format);
+    try std.testing.expectEqual(true, parsed.residue_map);
+}
+
 test "parseBatchChainFilter splits comma-separated chains" {
     const chains = try parseBatchChainFilter(std.testing.allocator, "A, B,AB");
     defer std.testing.allocator.free(chains);
@@ -2648,6 +2665,17 @@ test "CLI auth-chain overrides manifest job auth_chain false" {
     applyManifestJobOverrides(&config, args, job);
 
     try std.testing.expectEqual(true, config.use_auth_chain);
+}
+
+test "manifest residue_map applies when CLI does not override format" {
+    var config = BatchConfig{};
+    const args = BatchArgs{};
+    const globals = batch_manifest.Globals{ .format = "jsonl", .residue_map = true };
+
+    try applyManifestGlobals(&config, args, globals);
+
+    try std.testing.expectEqual(OutputFormat.jsonl, config.output_format);
+    try std.testing.expectEqual(true, config.residue_map);
 }
 
 test "manifestJsonlOutputPath uses job file under output dir" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -469,6 +469,21 @@ fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType, sdf_ccd: ?*cons
     input.r = new_radii;
 }
 
+fn attachResidueMap(
+    arena: Allocator,
+    result_allocator: Allocator,
+    input: AtomInput,
+    atom_areas: []const f64,
+    result: *FileResult,
+) bool {
+    result.residue_map = json_writer.buildResidueMap(arena, input, atom_areas) catch |err| {
+        result.status = .err;
+        result.error_msg = std.fmt.allocPrint(result_allocator, "residue map failed: {s}", .{@errorName(err)}) catch null;
+        return false;
+    };
+    return true;
+}
+
 /// Scan directory for structure files (.json, .pdb, .cif, .mmcif, .ent and compressed variants)
 pub fn scanDirectory(allocator: Allocator, io: std.Io, dir_path: []const u8) ![][]const u8 {
     var files: std.ArrayListUnmanaged([]const u8) = .empty;
@@ -594,6 +609,10 @@ fn processOneFile(
                     return result;
                 };
             }
+            if (config.residue_map) {
+                const areas = result.atom_areas orelse sasa_result.atom_areas;
+                if (!attachResidueMap(arena, result_allocator, input, areas, &result)) return result;
+            }
 
             if (output_dir) |out_dir| {
                 if (!config.store_atom_areas) {
@@ -634,6 +653,18 @@ fn processOneFile(
                 };
                 for (areas_f32, 0..) |v, j| areas_f64[j] = @floatCast(v);
                 result.atom_areas = areas_f64;
+            }
+            if (config.residue_map) {
+                const areas = result.atom_areas orelse blk: {
+                    const areas_f64 = arena.alloc(f64, sasa_result.atom_areas.len) catch {
+                        result.status = .err;
+                        result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                        return result;
+                    };
+                    for (sasa_result.atom_areas, 0..) |v, j| areas_f64[j] = @floatCast(v);
+                    break :blk areas_f64;
+                };
+                if (!attachResidueMap(arena, result_allocator, input, areas, &result)) return result;
             }
 
             if (output_dir) |out_dir| {
@@ -791,6 +822,10 @@ fn processOneSdfMoleculeInner(
                     return res;
                 };
             }
+            if (config.residue_map) {
+                const areas = res.atom_areas orelse sasa_result.atom_areas;
+                if (!attachResidueMap(arena, result_allocator, input.*, areas, &res)) return res;
+            }
 
             if (output_dir) |out_dir| {
                 if (!config.store_atom_areas) {
@@ -832,6 +867,18 @@ fn processOneSdfMoleculeInner(
                 for (areas_f32, 0..) |v, j| areas_f64[j] = @floatCast(v);
                 res.atom_areas = areas_f64;
             }
+            if (config.residue_map) {
+                const areas = res.atom_areas orelse blk: {
+                    const areas_f64 = arena.alloc(f64, sasa_result.atom_areas.len) catch {
+                        res.status = .err;
+                        res.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                        return res;
+                    };
+                    for (sasa_result.atom_areas, 0..) |v, j| areas_f64[j] = @floatCast(v);
+                    break :blk areas_f64;
+                };
+                if (!attachResidueMap(arena, result_allocator, input.*, areas, &res)) return res;
+            }
 
             if (output_dir) |out_dir| {
                 if (!config.store_atom_areas) {
@@ -866,12 +913,10 @@ const JsonlStreamWriter = struct {
     pub fn writeResult(
         self: *JsonlStreamWriter,
         alloc: Allocator,
-        filename: []const u8,
-        total_sasa: f64,
-        atom_areas: []const f64,
+        result: *FileResult,
     ) void {
-        const line = json_writer.fileResultToJsonlLine(alloc, filename, total_sasa, atom_areas) catch |err| {
-            logWarning("failed to serialize {s}: {s}", .{ filename, @errorName(err) });
+        const line = fileResultToJsonlLineForTest(alloc, result) catch |err| {
+            logWarning("failed to serialize {s}: {s}", .{ result.filename, @errorName(err) });
             return;
         };
         // line is on alloc (arena); no explicit free needed — arena reset handles it.
@@ -884,17 +929,17 @@ const JsonlStreamWriter = struct {
         var buf: [64 * 1024]u8 = undefined;
         var w = std.Io.File.Writer.initStreaming(self.file, self.io, &buf);
         w.interface.writeAll(line) catch |err| {
-            logWarning("JSONL write failed for {s}: {s}", .{ filename, @errorName(err) });
+            logWarning("JSONL write failed for {s}: {s}", .{ result.filename, @errorName(err) });
             self.write_failed = true;
             return;
         };
         w.interface.writeAll("\n") catch |err| {
-            logWarning("JSONL newline write failed for {s}: {s}", .{ filename, @errorName(err) });
+            logWarning("JSONL newline write failed for {s}: {s}", .{ result.filename, @errorName(err) });
             self.write_failed = true;
             return;
         };
         w.interface.flush() catch |err| {
-            logWarning("JSONL flush failed for {s}: {s}", .{ filename, @errorName(err) });
+            logWarning("JSONL flush failed for {s}: {s}", .{ result.filename, @errorName(err) });
             self.write_failed = true;
         };
     }
@@ -1132,6 +1177,7 @@ pub fn runBatchSequential(
                     writeJsonlResult(w, arena.allocator(), &mol_result);
                 }
                 mol_result.atom_areas = null;
+                mol_result.residue_map = null;
 
                 try results_list.append(allocator, mol_result);
                 total_items += 1;
@@ -1168,6 +1214,7 @@ pub fn runBatchSequential(
                 writeJsonlResult(w, arena.allocator(), &result);
             }
             result.atom_areas = null;
+            result.residue_map = null;
 
             try results_list.append(allocator, result);
             total_items += 1;
@@ -1329,12 +1376,11 @@ fn parallelWorker(ctx: *ParallelContext) void {
 
             if (ctx.jsonl_stream) |stream| {
                 if (result.status == .ok) {
-                    if (result.atom_areas) |areas| {
-                        stream.writeResult(arena.allocator(), result.filename, result.total_sasa, areas);
-                    }
+                    stream.writeResult(arena.allocator(), &result);
                 }
             }
             ctx.results[item_idx].atom_areas = null;
+            ctx.results[item_idx].residue_map = null;
         } else {
             // Non-SDF file: existing logic
             var result = processOneFile(
@@ -1357,13 +1403,12 @@ fn parallelWorker(ctx: *ParallelContext) void {
             // Stream JSONL output (atom_areas on arena, valid until reset)
             if (ctx.jsonl_stream) |stream| {
                 if (result.status == .ok) {
-                    if (result.atom_areas) |areas| {
-                        stream.writeResult(arena.allocator(), result.filename, result.total_sasa, areas);
-                    }
+                    stream.writeResult(arena.allocator(), &result);
                 }
             }
             // Clear atom_areas since arena will free them
             ctx.results[item_idx].atom_areas = null;
+            ctx.results[item_idx].residue_map = null;
         }
 
         // Update progress counter (.release pairs with .acquire in progress monitor)

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -2201,7 +2201,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --manifest=PATH     TOML manifest with one or more named batch jobs
         \\    --chain=ID          Filter by chain ID for non-manifest batch (e.g. A or A,B)
         \\    --auth-chain        Use auth_asym_id instead of label_asym_id for mmCIF chain matching
-        \\    --residue-map      Include compact residue map arrays in JSONL output
+        \\    --residue-map       Include compact residue map arrays in JSONL output
         \\    --probe-radius=R    Probe radius in Angstroms (default: 1.4)
         \\    --n-points=N        Test points per atom (default: 100, for sr)
         \\    --n-slices=N        Slices per atom diameter (default: 20, for lr)

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -254,6 +254,7 @@ pub const FileResult = struct {
     status: Status,
     error_msg: ?[]const u8 = null,
     atom_areas: ?[]const f64 = null, // Populated for jsonl output
+    residue_map: ?json_writer.ResidueMap = null, // Populated for jsonl residue-map output
 
     pub const Status = enum {
         ok,
@@ -279,6 +280,9 @@ pub const BatchResult = struct {
             }
             if (result.atom_areas) |areas| {
                 self.allocator.free(areas);
+            }
+            if (result.residue_map) |*map| {
+                map.deinit();
             }
         }
         self.allocator.free(self.file_results);
@@ -903,14 +907,21 @@ const JsonlStreamWriter = struct {
 
 /// Write a JSONL line for a result via the buffered writer.
 /// atom_areas live on the arena and are invalidated after arena reset.
+fn fileResultToJsonlLineForTest(allocator: Allocator, result: *FileResult) ![]u8 {
+    const areas = result.atom_areas orelse return error.MissingAtomAreas;
+    if (result.residue_map) |map| {
+        return json_writer.fileResultWithResidueMapToJsonlLine(allocator, result.filename, result.total_sasa, areas, map);
+    }
+    return json_writer.fileResultToJsonlLine(allocator, result.filename, result.total_sasa, areas);
+}
+
 fn writeJsonlResult(
     jsonl_writer: *std.Io.File.Writer,
     arena_alloc: Allocator,
     result: *FileResult,
 ) void {
     if (result.status != .ok) return;
-    const areas = result.atom_areas orelse return;
-    const line = json_writer.fileResultToJsonlLine(arena_alloc, result.filename, result.total_sasa, areas) catch |err| {
+    const line = fileResultToJsonlLineForTest(arena_alloc, result) catch |err| {
         logWarning("failed to serialize {s}: {s}", .{ result.filename, @errorName(err) });
         return;
     };
@@ -2715,6 +2726,45 @@ test "manifestPerFileOutputDir uses job directory under output dir" {
     const path = try manifestPerFileOutputDir(std.testing.allocator, "results", "complex_AB");
     defer std.testing.allocator.free(path);
     try std.testing.expectEqualStrings("results/complex_AB", path);
+}
+
+test "FileResult JSONL uses residue map serializer when present" {
+    const allocator = std.testing.allocator;
+    const atom_areas = [_]f64{ 1.0, 2.0 };
+    const residue_chain = [_]types.FixedString4{types.FixedString4.fromSlice("A")};
+    const residue_name = [_]types.FixedString5{types.FixedString5.fromSlice("GLY")};
+    const residue_number = [_]i32{5};
+    const residue_insertion_code = [_]types.FixedString4{types.FixedString4.fromSlice("")};
+    const residue_atom_start = [_]usize{0};
+    const residue_atom_count = [_]usize{2};
+    const residue_sasa = [_]f64{3.0};
+
+    const map = json_writer.ResidueMap{
+        .allocator = allocator,
+        .residue_chain = residue_chain[0..],
+        .residue_name = residue_name[0..],
+        .residue_number = residue_number[0..],
+        .residue_insertion_code = residue_insertion_code[0..],
+        .residue_atom_start = residue_atom_start[0..],
+        .residue_atom_count = residue_atom_count[0..],
+        .residue_sasa = residue_sasa[0..],
+    };
+
+    var result = FileResult{
+        .filename = "example.cif",
+        .n_atoms = 2,
+        .sasa_time_ns = 0,
+        .total_sasa = 3.0,
+        .status = .ok,
+        .atom_areas = atom_areas[0..],
+        .residue_map = map,
+    };
+
+    const line = try fileResultToJsonlLineForTest(allocator, &result);
+    defer allocator.free(line);
+
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_chain\":[\"A\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_sasa\":[3]") != null);
 }
 
 test "BatchArgs explicit option flags" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -1742,6 +1742,12 @@ fn validateManifestNSlices(n: u32) !u32 {
     return n;
 }
 
+fn validateResidueMapFormat(output_format: OutputFormat, residue_map: bool) !void {
+    if (residue_map and output_format != .jsonl) {
+        return error.InvalidArgument;
+    }
+}
+
 /// Parse and validate probe radius value
 fn parseProbeRadius(value: []const u8) f64 {
     const radius = std.fmt.parseFloat(f64, value) catch {
@@ -2352,6 +2358,10 @@ fn runManifest(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         config.external_ccd = if (ext_ccd != null) &ext_ccd.? else null;
         config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
         applyManifestJobOverrides(&config, args, job);
+        validateResidueMapFormat(config.output_format, config.residue_map) catch {
+            std.debug.print("Error: residue_map is only supported with format = \"jsonl\"\n", .{});
+            return error.InvalidArgument;
+        };
 
         if ((config.classifier_type == .ccd or config.classifier_type == .protor) and config.include_hydrogens and !config.quiet) {
             std.debug.print("Warning: --include-hydrogens with CCD classifier may give inaccurate results\n", .{});
@@ -2444,6 +2454,11 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         };
     }
     defer if (sdf_ccd) |*d| d.deinit();
+
+    validateResidueMapFormat(args.output_format, args.residue_map) catch {
+        std.debug.print("Error: --residue-map is only supported with --format=jsonl\n", .{});
+        return error.InvalidArgument;
+    };
 
     // For jsonl, don't pass output_dir to runBatch (no per-file I/O during computation)
     const output_dir: ?[]const u8 = if (args.output_format == .jsonl) null else args.output_path;
@@ -2652,6 +2667,18 @@ test "manifest numeric validators reject invalid values" {
     try std.testing.expectError(error.InvalidArgument, validateManifestNPoints(10001));
     try std.testing.expectError(error.InvalidArgument, validateManifestNSlices(0));
     try std.testing.expectError(error.InvalidArgument, validateManifestNSlices(1001));
+}
+
+test "validateResidueMapFormat accepts JSONL residue map" {
+    try validateResidueMapFormat(.jsonl, true);
+    try validateResidueMapFormat(.jsonl, false);
+    try validateResidueMapFormat(.json, false);
+}
+
+test "validateResidueMapFormat rejects non-JSONL residue map" {
+    try std.testing.expectError(error.InvalidArgument, validateResidueMapFormat(.json, true));
+    try std.testing.expectError(error.InvalidArgument, validateResidueMapFormat(.compact, true));
+    try std.testing.expectError(error.InvalidArgument, validateResidueMapFormat(.csv, true));
 }
 
 test "CLI auth-chain overrides manifest job auth_chain false" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -915,7 +915,7 @@ const JsonlStreamWriter = struct {
         alloc: Allocator,
         result: *FileResult,
     ) void {
-        const line = fileResultToJsonlLineForTest(alloc, result) catch |err| {
+        const line = fileResultToJsonlLine(alloc, result) catch |err| {
             logWarning("failed to serialize {s}: {s}", .{ result.filename, @errorName(err) });
             return;
         };
@@ -952,7 +952,7 @@ const JsonlStreamWriter = struct {
 
 /// Write a JSONL line for a result via the buffered writer.
 /// atom_areas live on the arena and are invalidated after arena reset.
-fn fileResultToJsonlLineForTest(allocator: Allocator, result: *FileResult) ![]u8 {
+fn fileResultToJsonlLine(allocator: Allocator, result: *FileResult) ![]u8 {
     const areas = result.atom_areas orelse return error.MissingAtomAreas;
     if (result.residue_map) |map| {
         return json_writer.fileResultWithResidueMapToJsonlLine(allocator, result.filename, result.total_sasa, areas, map);
@@ -966,7 +966,7 @@ fn writeJsonlResult(
     result: *FileResult,
 ) void {
     if (result.status != .ok) return;
-    const line = fileResultToJsonlLineForTest(arena_alloc, result) catch |err| {
+    const line = fileResultToJsonlLine(arena_alloc, result) catch |err| {
         logWarning("failed to serialize {s}: {s}", .{ result.filename, @errorName(err) });
         return;
     };
@@ -2805,7 +2805,7 @@ test "FileResult JSONL uses residue map serializer when present" {
         .residue_map = map,
     };
 
-    const line = try fileResultToJsonlLineForTest(allocator, &result);
+    const line = try fileResultToJsonlLine(allocator, &result);
     defer allocator.free(line);
 
     try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_chain\":[\"A\"]") != null);

--- a/src/batch_manifest.zig
+++ b/src/batch_manifest.zig
@@ -32,6 +32,7 @@ pub const Globals = struct {
     timing: ?bool = null,
     quiet: ?bool = null,
     auth_chain: ?bool = null,
+    residue_map: ?bool = null,
 };
 
 pub const Job = struct {
@@ -141,6 +142,7 @@ fn parseGlobals(allocator: Allocator, root: toml_parser.Table) Error!Globals {
     globals.timing = try optionalBool(root.entries, "timing");
     globals.quiet = try optionalBool(root.entries, "quiet");
     globals.auth_chain = try optionalBool(root.entries, "auth_chain");
+    globals.residue_map = try optionalBool(root.entries, "residue_map");
     return globals;
 }
 
@@ -246,6 +248,7 @@ test "parse A B AB manifest" {
         \\output_dir = "results"
         \\
         \\format = "jsonl"
+        \\residue_map = true
         \\use_bitmask = true
         \\n_points = 128
         \\classifier = "ccd"
@@ -269,6 +272,7 @@ test "parse A B AB manifest" {
     try std.testing.expectEqualStrings("structures", manifest.globals.input_dir.?);
     try std.testing.expectEqualStrings("results", manifest.globals.output_dir.?);
     try std.testing.expectEqualStrings("jsonl", manifest.globals.format.?);
+    try std.testing.expectEqual(true, manifest.globals.residue_map.?);
     try std.testing.expectEqual(true, manifest.globals.use_bitmask.?);
     try std.testing.expectEqual(@as(u32, 128), manifest.globals.n_points.?);
     try std.testing.expectEqualStrings("ccd", manifest.globals.classifier.?);

--- a/src/json_writer.zig
+++ b/src/json_writer.zig
@@ -184,6 +184,110 @@ pub fn writeSasaResult(allocator: Allocator, io: std.Io, result: SasaResult, pat
     return writeSasaResultWithFormat(allocator, io, result, path, .compact);
 }
 
+pub const ResidueMap = struct {
+    allocator: Allocator,
+    residue_chain: []const types.FixedString4,
+    residue_name: []const types.FixedString5,
+    residue_number: []const i32,
+    residue_insertion_code: []const types.FixedString4,
+    residue_atom_start: []const usize,
+    residue_atom_count: []const usize,
+    residue_sasa: []const f64,
+
+    pub fn len(self: ResidueMap) usize {
+        return self.residue_chain.len;
+    }
+
+    pub fn deinit(self: *ResidueMap) void {
+        self.allocator.free(self.residue_chain);
+        self.allocator.free(self.residue_name);
+        self.allocator.free(self.residue_number);
+        self.allocator.free(self.residue_insertion_code);
+        self.allocator.free(self.residue_atom_start);
+        self.allocator.free(self.residue_atom_count);
+        self.allocator.free(self.residue_sasa);
+        self.* = undefined;
+    }
+};
+
+fn sameResidue(
+    chain_ids: []const types.FixedString4,
+    residue_names: []const types.FixedString5,
+    residue_nums: []const i32,
+    insertion_codes: []const types.FixedString4,
+    a: usize,
+    b: usize,
+) bool {
+    return residue_nums[a] == residue_nums[b] and
+        std.mem.eql(u8, chain_ids[a].slice(), chain_ids[b].slice()) and
+        std.mem.eql(u8, residue_names[a].slice(), residue_names[b].slice()) and
+        std.mem.eql(u8, insertion_codes[a].slice(), insertion_codes[b].slice());
+}
+
+pub fn buildResidueMap(allocator: Allocator, input: AtomInput, atom_areas: []const f64) !ResidueMap {
+    const n = input.atomCount();
+    if (atom_areas.len != n) return error.LengthMismatch;
+
+    const chain_ids = input.chain_id orelse return error.MissingChainInfo;
+    const residue_names = input.residue orelse return error.MissingResidueInfo;
+    const residue_nums = input.residue_num orelse return error.MissingResidueNumInfo;
+    const insertion_codes = input.insertion_code orelse return error.MissingInsertionCodeInfo;
+
+    var residue_count: usize = 0;
+    var i: usize = 0;
+    while (i < n) {
+        const start = i;
+        residue_count += 1;
+        i += 1;
+        while (i < n and sameResidue(chain_ids, residue_names, residue_nums, insertion_codes, start, i)) : (i += 1) {}
+    }
+
+    const residue_chain = try allocator.alloc(types.FixedString4, residue_count);
+    errdefer allocator.free(residue_chain);
+    const residue_name = try allocator.alloc(types.FixedString5, residue_count);
+    errdefer allocator.free(residue_name);
+    const residue_number = try allocator.alloc(i32, residue_count);
+    errdefer allocator.free(residue_number);
+    const residue_insertion_code = try allocator.alloc(types.FixedString4, residue_count);
+    errdefer allocator.free(residue_insertion_code);
+    const residue_atom_start = try allocator.alloc(usize, residue_count);
+    errdefer allocator.free(residue_atom_start);
+    const residue_atom_count = try allocator.alloc(usize, residue_count);
+    errdefer allocator.free(residue_atom_count);
+    const residue_sasa = try allocator.alloc(f64, residue_count);
+    errdefer allocator.free(residue_sasa);
+
+    i = 0;
+    var residue_idx: usize = 0;
+    while (i < n) : (residue_idx += 1) {
+        const start = i;
+        var sasa = atom_areas[i];
+        i += 1;
+        while (i < n and sameResidue(chain_ids, residue_names, residue_nums, insertion_codes, start, i)) : (i += 1) {
+            sasa += atom_areas[i];
+        }
+
+        residue_chain[residue_idx] = chain_ids[start];
+        residue_name[residue_idx] = residue_names[start];
+        residue_number[residue_idx] = residue_nums[start];
+        residue_insertion_code[residue_idx] = insertion_codes[start];
+        residue_atom_start[residue_idx] = start;
+        residue_atom_count[residue_idx] = i - start;
+        residue_sasa[residue_idx] = sasa;
+    }
+
+    return .{
+        .allocator = allocator,
+        .residue_chain = residue_chain,
+        .residue_name = residue_name,
+        .residue_number = residue_number,
+        .residue_insertion_code = residue_insertion_code,
+        .residue_atom_start = residue_atom_start,
+        .residue_atom_count = residue_atom_count,
+        .residue_sasa = residue_sasa,
+    };
+}
+
 /// Serialize a single batch result as a JSONL line: {"filename":"...","total_area":...,"atom_areas":[...]}
 pub fn fileResultToJsonlLine(allocator: Allocator, filename: []const u8, total_area: f64, atom_areas: []const f64) ![]u8 {
     const JsonlEntry = struct {
@@ -201,7 +305,210 @@ pub fn fileResultToJsonlLine(allocator: Allocator, filename: []const u8, total_a
     return std.json.Stringify.valueAlloc(allocator, entry, .{});
 }
 
+pub fn fileResultWithResidueMapToJsonlLine(
+    allocator: Allocator,
+    filename: []const u8,
+    total_area: f64,
+    atom_areas: []const f64,
+    residue_map: ResidueMap,
+) ![]u8 {
+    const residue_chain = try allocator.alloc([]const u8, residue_map.len());
+    defer allocator.free(residue_chain);
+    const residue_name = try allocator.alloc([]const u8, residue_map.len());
+    defer allocator.free(residue_name);
+    const residue_insertion_code = try allocator.alloc([]const u8, residue_map.len());
+    defer allocator.free(residue_insertion_code);
+
+    for (0..residue_map.len()) |i| {
+        residue_chain[i] = residue_map.residue_chain[i].slice();
+        residue_name[i] = residue_map.residue_name[i].slice();
+        residue_insertion_code[i] = residue_map.residue_insertion_code[i].slice();
+    }
+
+    const JsonlEntry = struct {
+        filename: []const u8,
+        total_area: f64,
+        atom_areas: []const f64,
+        residue_chain: []const []const u8,
+        residue_name: []const []const u8,
+        residue_number: []const i32,
+        residue_insertion_code: []const []const u8,
+        residue_atom_start: []const usize,
+        residue_atom_count: []const usize,
+        residue_sasa: []const f64,
+    };
+
+    const entry = JsonlEntry{
+        .filename = filename,
+        .total_area = total_area,
+        .atom_areas = atom_areas,
+        .residue_chain = residue_chain,
+        .residue_name = residue_name,
+        .residue_number = residue_map.residue_number,
+        .residue_insertion_code = residue_insertion_code,
+        .residue_atom_start = residue_map.residue_atom_start,
+        .residue_atom_count = residue_map.residue_atom_count,
+        .residue_sasa = residue_map.residue_sasa,
+    };
+
+    return std.json.Stringify.valueAlloc(allocator, entry, .{});
+}
+
 // Tests
+test "buildResidueMap groups consecutive atoms" {
+    const allocator = std.testing.allocator;
+
+    const x = [_]f64{ 0, 1, 2, 3, 4 };
+    const y = [_]f64{ 0, 0, 0, 0, 0 };
+    const z = [_]f64{ 0, 0, 0, 0, 0 };
+    var r = [_]f64{ 1, 1, 1, 1, 1 };
+    const chain = [_]types.FixedString4{
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("B"),
+    };
+    const residue = [_]types.FixedString5{
+        types.FixedString5.fromSlice("MET"),
+        types.FixedString5.fromSlice("MET"),
+        types.FixedString5.fromSlice("GLY"),
+        types.FixedString5.fromSlice("GLY"),
+        types.FixedString5.fromSlice("ALA"),
+    };
+    const residue_num = [_]i32{ 1, 1, 2, 2, 7 };
+    const insertion = [_]types.FixedString4{
+        types.FixedString4.fromSlice(""),
+        types.FixedString4.fromSlice(""),
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice(""),
+    };
+    const atom_areas = [_]f64{ 10.0, 2.5, 4.0, 6.0, 1.25 };
+
+    const input = types.AtomInput{
+        .x = x[0..],
+        .y = y[0..],
+        .z = z[0..],
+        .r = r[0..],
+        .chain_id = chain[0..],
+        .residue = residue[0..],
+        .residue_num = residue_num[0..],
+        .insertion_code = insertion[0..],
+        .allocator = allocator,
+    };
+
+    var map = try buildResidueMap(allocator, input, atom_areas[0..]);
+    defer map.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), map.len());
+    try std.testing.expectEqualStrings("A", map.residue_chain[0].slice());
+    try std.testing.expectEqualStrings("MET", map.residue_name[0].slice());
+    try std.testing.expectEqual(@as(i32, 1), map.residue_number[0]);
+    try std.testing.expectEqualStrings("", map.residue_insertion_code[0].slice());
+    try std.testing.expectEqual(@as(usize, 0), map.residue_atom_start[0]);
+    try std.testing.expectEqual(@as(usize, 2), map.residue_atom_count[0]);
+    try std.testing.expectApproxEqAbs(@as(f64, 12.5), map.residue_sasa[0], 1e-9);
+
+    try std.testing.expectEqualStrings("A", map.residue_chain[1].slice());
+    try std.testing.expectEqualStrings("GLY", map.residue_name[1].slice());
+    try std.testing.expectEqual(@as(i32, 2), map.residue_number[1]);
+    try std.testing.expectEqualStrings("A", map.residue_insertion_code[1].slice());
+    try std.testing.expectEqual(@as(usize, 2), map.residue_atom_start[1]);
+    try std.testing.expectEqual(@as(usize, 2), map.residue_atom_count[1]);
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), map.residue_sasa[1], 1e-9);
+}
+
+test "buildResidueMap keeps non-contiguous repeated residues as separate ranges" {
+    const allocator = std.testing.allocator;
+
+    const x = [_]f64{ 0, 1, 2 };
+    const y = [_]f64{ 0, 0, 0 };
+    const z = [_]f64{ 0, 0, 0 };
+    var r = [_]f64{ 1, 1, 1 };
+    const chain = [_]types.FixedString4{
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("A"),
+    };
+    const residue = [_]types.FixedString5{
+        types.FixedString5.fromSlice("MET"),
+        types.FixedString5.fromSlice("GLY"),
+        types.FixedString5.fromSlice("MET"),
+    };
+    const residue_num = [_]i32{ 1, 2, 1 };
+    const insertion = [_]types.FixedString4{
+        types.FixedString4.fromSlice(""),
+        types.FixedString4.fromSlice(""),
+        types.FixedString4.fromSlice(""),
+    };
+    const atom_areas = [_]f64{ 1.0, 2.0, 3.0 };
+
+    const input = types.AtomInput{
+        .x = x[0..],
+        .y = y[0..],
+        .z = z[0..],
+        .r = r[0..],
+        .chain_id = chain[0..],
+        .residue = residue[0..],
+        .residue_num = residue_num[0..],
+        .insertion_code = insertion[0..],
+        .allocator = allocator,
+    };
+
+    var map = try buildResidueMap(allocator, input, atom_areas[0..]);
+    defer map.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), map.len());
+    try std.testing.expectEqual(@as(usize, 0), map.residue_atom_start[0]);
+    try std.testing.expectEqual(@as(usize, 1), map.residue_atom_count[0]);
+    try std.testing.expectEqual(@as(usize, 2), map.residue_atom_start[2]);
+    try std.testing.expectEqual(@as(usize, 1), map.residue_atom_count[2]);
+    try std.testing.expectEqualStrings("MET", map.residue_name[0].slice());
+    try std.testing.expectEqualStrings("MET", map.residue_name[2].slice());
+}
+
+test "fileResultWithResidueMapToJsonlLine serializes columnar residue arrays" {
+    const allocator = std.testing.allocator;
+
+    const atom_areas = [_]f64{ 10.0, 2.5, 1.25 };
+    const residue_chain = [_]types.FixedString4{
+        types.FixedString4.fromSlice("A"),
+        types.FixedString4.fromSlice("B"),
+    };
+    const residue_name = [_]types.FixedString5{
+        types.FixedString5.fromSlice("MET"),
+        types.FixedString5.fromSlice("ALA"),
+    };
+    const residue_number = [_]i32{ 1, 7 };
+    const residue_insertion_code = [_]types.FixedString4{
+        types.FixedString4.fromSlice(""),
+        types.FixedString4.fromSlice(""),
+    };
+    const residue_atom_start = [_]usize{ 0, 2 };
+    const residue_atom_count = [_]usize{ 2, 1 };
+    const residue_sasa = [_]f64{ 12.5, 1.25 };
+
+    const map = ResidueMap{
+        .allocator = allocator,
+        .residue_chain = residue_chain[0..],
+        .residue_name = residue_name[0..],
+        .residue_number = residue_number[0..],
+        .residue_insertion_code = residue_insertion_code[0..],
+        .residue_atom_start = residue_atom_start[0..],
+        .residue_atom_count = residue_atom_count[0..],
+        .residue_sasa = residue_sasa[0..],
+    };
+
+    const line = try fileResultWithResidueMapToJsonlLine(allocator, "example.cif", 13.75, atom_areas[0..], map);
+    defer allocator.free(line);
+
+    try std.testing.expectEqualStrings(
+        "{\"filename\":\"example.cif\",\"total_area\":13.75,\"atom_areas\":[10,2.5,1.25],\"residue_chain\":[\"A\",\"B\"],\"residue_name\":[\"MET\",\"ALA\"],\"residue_number\":[1,7],\"residue_insertion_code\":[\"\",\"\"],\"residue_atom_start\":[0,2],\"residue_atom_count\":[2,1],\"residue_sasa\":[12.5,1.25]}",
+        line,
+    );
+}
+
 test "sasaResultToJson basic" {
     const allocator = std.testing.allocator;
 

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -51,6 +51,7 @@ version = 1
 input_dir = "structures"
 output_dir = "results"
 format = "jsonl"
+residue_map = true
 use_bitmask = true
 n_points = 128
 classifier = "ccd"
@@ -71,6 +72,8 @@ chains = ["A", "B"]
 For `format = "jsonl"`, each job writes one file such as `results/chain_A.jsonl`. For `json`, `compact`, and `csv`, each job writes a directory such as `results/chain_A/`.
 
 Precedence is: built-in defaults < manifest globals < job settings < explicit CLI options. `--chain` is for non-manifest single-job batch mode; manifest jobs should use `[[jobs]].chains`.
+
+Set `residue_map = true` in a manifest, or pass `--residue-map` with `--format=jsonl`, to add compact residue-level mapping arrays (`residue_chain`, `residue_name`, `residue_number`, `residue_insertion_code`, `residue_atom_start`, `residue_atom_count`, `residue_sasa`) to each JSONL row. The default JSONL schema remains unchanged unless this option is enabled.
 
 ### `traj` - Trajectory Analysis
 
@@ -160,7 +163,8 @@ See [Output & Analysis](output.md#analysis-features) for detailed output descrip
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-o, --output=FILE` | Output file path | `output.json` |
-| `--format=FMT` | Output format: `json`, `compact`, `csv` | `json` |
+| `--format=FMT` | Output format: `json`, `compact`, `csv`, `jsonl` | `json` |
+| `--residue-map` | Add compact residue map arrays to batch JSONL output (`--format=jsonl` only) | off |
 | `--timing` | Show timing breakdown (for benchmarking) | off |
 | `-q, --quiet` | Suppress progress output, including standard progress bars shown by `batch` and `traj` | off |
 | `--validate` | Validate input only, do not calculate | off |


### PR DESCRIPTION
## Summary
- Add an opt-in `--residue-map` / `residue_map = true` path for batch JSONL output.
- Emit compact columnar residue arrays with residue identifiers, atom ranges, and residue SASA while preserving the default JSONL schema.
- Document the new batch JSONL option and capture the design rationale for Issue #363.

## Test Plan
- `git diff --check main...HEAD`
- `zig build test --summary all`
- `zig build`
- Smoke: `zig build run -- batch /tmp/zsasa-residue-map-smoke/in -o /tmp/zsasa-residue-map-smoke/out.jsonl --format=jsonl --residue-map --quiet`
- Verified smoke JSONL includes `residue_chain`, `residue_name`, `residue_number`, `residue_insertion_code`, `residue_atom_start`, `residue_atom_count`, and `residue_sasa` arrays.