### PR TITLE
ci: ignore gitignore-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths-ignore:
       - '*.md'
+      - '.gitignore'
       - 'docs/**'
       - 'plans/**'
       - 'benchmarks/**'


### PR DESCRIPTION
## Summary

- Add `.gitignore` to the CI workflow `paths-ignore` list so gitignore-only changes do not run the main CI workflow.

## Validation

- Ran `git diff --check`.
- Parsed `.github/workflows/ci.yml` with Ruby YAML loader.