### PR TITLE
feat: reuse parsed inputs across workflow jobs

### DIFF
--- a/docs/superpowers/plans/2026-05-20-workflow-file-first.md
+++ b/docs/superpowers/plans/2026-05-20-workflow-file-first.md
@@ -1,0 +1,895 @@
+# Workflow File-First Batch Execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `zsasa batch --workflow` process each input file once and reuse the parsed/classified structure across `[[jobs]]` chain selections.
+
+**Architecture:** Keep the workflow TOML schema and public outputs unchanged. Add a workflow-specific file-first path in `src/batch.zig`: scan once, prepare shared LUTs once, parse/classify each non-SDF file once, derive job-specific `AtomInput` copies, then run the existing SASA dispatcher for each job. Preserve the existing job-first workflow path as a fallback for SDF inputs and as a reference during implementation.
+
+**Tech Stack:** Zig 0.16, existing `src/batch.zig` batch runner, existing parsers/classifiers, existing `json_writer` output functions, `zig build test`.
+
+---
+
+## File Structure
+
+- Modify: `src/batch.zig`
+  - Add `copySelectedAtomInput` and small helpers for chain-filtered `AtomInput` copies.
+  - Extract the calculation/output part of `processOneFile` into a reusable helper that accepts an already prepared `AtomInput`.
+  - Rename the current workflow loop to `runWorkflowJobFirst` and add a new `runWorkflowFileFirst` path for non-SDF workflow directories.
+  - Add focused unit tests in the existing test section.
+- Modify: `website/docs/guide/workflows.md`
+  - Add one short note that workflow batch jobs reuse parsed input internally and still compute each chain selection independently.
+- Optionally modify: `website/docs/guide/batch.md`
+  - Add one sentence pointing dimer/complex named jobs to workflow files if the workflows page note feels insufficient.
+
+## Task 1: Add chain-selected AtomInput copy helper
+
+**Files:**
+- Modify: `src/batch.zig`
+
+- [ ] **Step 1: Add failing tests for chain selection**
+
+Add these tests near existing `src/batch.zig` tests. Use owned arrays so `AtomInput.deinit()` can free them.
+
+```zig
+test "copySelectedAtomInput filters one chain" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B", "A" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, &.{"A"});
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), selected.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected.x[0], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.0), selected.x[1], 1e-12);
+    try std.testing.expectEqualStrings("A", selected.chain_id.?[0].slice());
+    try std.testing.expectEqualStrings("A", selected.chain_id.?[1].slice());
+}
+
+test "copySelectedAtomInput filters multiple chains in source order" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B", "C", "A" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, &.{ "C", "A" });
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), selected.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected.x[0], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.0), selected.x[1], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 3.0), selected.x[2], 1e-12);
+}
+
+test "copySelectedAtomInput null chains duplicates all atoms" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, null);
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), selected.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected.x[0], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), selected.x[1], 1e-12);
+}
+
+test "copySelectedAtomInput no matching chains returns empty input" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, &.{"Z"});
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), selected.atomCount());
+    try std.testing.expect(selected.chain_id != null);
+    try std.testing.expectEqual(@as(usize, 0), selected.chain_id.?.len);
+}
+```
+
+Also add this test fixture helper above those tests:
+
+```zig
+fn makeTestAtomInput(allocator: Allocator, chains: []const []const u8) !AtomInput {
+    const n = chains.len;
+    const x = try allocator.alloc(f64, n);
+    errdefer allocator.free(x);
+    const y = try allocator.alloc(f64, n);
+    errdefer allocator.free(y);
+    const z = try allocator.alloc(f64, n);
+    errdefer allocator.free(z);
+    const r = try allocator.alloc(f64, n);
+    errdefer allocator.free(r);
+    const residue = try allocator.alloc(types.FixedString5, n);
+    errdefer allocator.free(residue);
+    const atom_name = try allocator.alloc(types.FixedString4, n);
+    errdefer allocator.free(atom_name);
+    const element = try allocator.alloc(u8, n);
+    errdefer allocator.free(element);
+    const chain_id = try allocator.alloc(types.FixedString4, n);
+    errdefer allocator.free(chain_id);
+    const residue_num = try allocator.alloc(i32, n);
+    errdefer allocator.free(residue_num);
+    const insertion_code = try allocator.alloc(types.FixedString4, n);
+    errdefer allocator.free(insertion_code);
+
+    for (chains, 0..) |chain, i| {
+        x[i] = @floatFromInt(i);
+        y[i] = @floatFromInt(i + 10);
+        z[i] = @floatFromInt(i + 20);
+        r[i] = 1.5;
+        residue[i] = types.FixedString5.fromSlice("GLY");
+        atom_name[i] = types.FixedString4.fromSlice("CA");
+        element[i] = 6;
+        chain_id[i] = types.FixedString4.fromSlice(chain);
+        residue_num[i] = @intCast(i + 1);
+        insertion_code[i] = types.FixedString4.fromSlice("");
+    }
+
+    return AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .residue = residue,
+        .atom_name = atom_name,
+        .element = element,
+        .chain_id = chain_id,
+        .residue_num = residue_num,
+        .insertion_code = insertion_code,
+        .allocator = allocator,
+    };
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | rg "copySelectedAtomInput|makeTestAtomInput|error"
+```
+
+Expected: compile failure mentioning `copySelectedAtomInput` is undeclared.
+
+- [ ] **Step 3: Implement the helper**
+
+Add these helpers in `src/batch.zig` near `readInputFile` or before `processOneFile`:
+
+```zig
+fn chainMatchesFilter(chain: types.FixedString4, chains: []const []const u8) bool {
+    for (chains) |target| {
+        if (chain.eqlSlice(target)) return true;
+    }
+    return false;
+}
+
+fn atomSelectedByChains(input: AtomInput, index: usize, chains: ?[]const []const u8) bool {
+    const filter = chains orelse return true;
+    if (filter.len == 0) return true;
+    const chain_ids = input.chain_id orelse return true;
+    return chainMatchesFilter(chain_ids[index], filter);
+}
+
+fn countSelectedAtoms(input: AtomInput, chains: ?[]const []const u8) usize {
+    var count: usize = 0;
+    for (0..input.atomCount()) |i| {
+        if (atomSelectedByChains(input, i, chains)) count += 1;
+    }
+    return count;
+}
+
+fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]const []const u8) !AtomInput {
+    const selected_count = countSelectedAtoms(input, chains);
+
+    const x = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(x);
+    const y = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(y);
+    const z = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(z);
+    const r = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(r);
+
+    const residue = if (input.residue != null) try allocator.alloc(types.FixedString5, selected_count) else null;
+    errdefer if (residue) |v| allocator.free(v);
+    const atom_name = if (input.atom_name != null) try allocator.alloc(types.FixedString4, selected_count) else null;
+    errdefer if (atom_name) |v| allocator.free(v);
+    const element = if (input.element != null) try allocator.alloc(u8, selected_count) else null;
+    errdefer if (element) |v| allocator.free(v);
+    const chain_id = if (input.chain_id != null) try allocator.alloc(types.FixedString4, selected_count) else null;
+    errdefer if (chain_id) |v| allocator.free(v);
+    const residue_num = if (input.residue_num != null) try allocator.alloc(i32, selected_count) else null;
+    errdefer if (residue_num) |v| allocator.free(v);
+    const insertion_code = if (input.insertion_code != null) try allocator.alloc(types.FixedString4, selected_count) else null;
+    errdefer if (insertion_code) |v| allocator.free(v);
+
+    var out_i: usize = 0;
+    for (0..input.atomCount()) |i| {
+        if (!atomSelectedByChains(input, i, chains)) continue;
+        x[out_i] = input.x[i];
+        y[out_i] = input.y[i];
+        z[out_i] = input.z[i];
+        r[out_i] = input.r[i];
+        if (residue) |v| v[out_i] = input.residue.?[i];
+        if (atom_name) |v| v[out_i] = input.atom_name.?[i];
+        if (element) |v| v[out_i] = input.element.?[i];
+        if (chain_id) |v| v[out_i] = input.chain_id.?[i];
+        if (residue_num) |v| v[out_i] = input.residue_num.?[i];
+        if (insertion_code) |v| v[out_i] = input.insertion_code.?[i];
+        out_i += 1;
+    }
+
+    return AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .residue = residue,
+        .atom_name = atom_name,
+        .element = element,
+        .chain_id = chain_id,
+        .residue_num = residue_num,
+        .insertion_code = insertion_code,
+        .allocator = allocator,
+    };
+}
+```
+
+The `input.chain_id == null` path intentionally selects all atoms. That preserves existing JSON behavior because `readInputFile` has never applied `BatchConfig.chain_filter` to JSON inputs.
+
+- [ ] **Step 4: Run tests for the helper**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | rg "copySelectedAtomInput|Build Summary|error"
+```
+
+Expected: helper tests pass and no `copySelectedAtomInput` error remains.
+
+- [ ] **Step 5: Format and commit Task 1**
+
+Run:
+
+```bash
+zig fmt src/batch.zig
+zig build test --summary all
+```
+
+Expected: all tests pass.
+
+Commit:
+
+```bash
+git add src/batch.zig
+git commit -m "test: add workflow chain selection helper"
+```
+
+## Task 2: Extract reusable SASA calculation/output helper
+
+**Files:**
+- Modify: `src/batch.zig`
+
+- [ ] **Step 1: Add a regression test for calculating a prepared input**
+
+Add this test near the new helper tests:
+
+```zig
+test "calculatePreparedInputResult computes total for selected input" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "A" });
+    defer input.deinit();
+
+    var result = calculatePreparedInputResult(
+        f64,
+        allocator,
+        std.testing.io,
+        allocator,
+        input,
+        null,
+        "prepared.pdb",
+        BatchConfig{ .n_points = 16, .quiet = true },
+        1,
+        null,
+        null,
+        null,
+    );
+    defer if (result.atom_areas) |areas| allocator.free(areas);
+    defer if (result.error_msg) |msg| allocator.free(msg);
+
+    try std.testing.expectEqual(.ok, result.status);
+    try std.testing.expectEqual(@as(usize, 2), result.n_atoms);
+    try std.testing.expect(result.total_sasa > 0.0);
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | rg "calculatePreparedInputResult|error"
+```
+
+Expected: compile failure mentioning `calculatePreparedInputResult` is undeclared.
+
+- [ ] **Step 3: Extract f64/f32 calculation body into helper**
+
+Add this generic helper above `processOneFile`:
+
+```zig
+fn calculatePreparedInputResult(
+    comptime T: type,
+    arena: Allocator,
+    io: std.Io,
+    result_allocator: Allocator,
+    input: AtomInput,
+    output_dir: ?[]const u8,
+    filename: []const u8,
+    config: BatchConfig,
+    n_threads: usize,
+    lut: ?*const bitmask_lut.BitmaskLutGen(T),
+    coarse_lut: ?*const bitmask_lut.BitmaskLutGen(T),
+    fine_lut: ?*const bitmask_lut.BitmaskLutGen(T),
+) FileResult {
+    var result = FileResult{
+        .filename = filename,
+        .n_atoms = input.atomCount(),
+        .sasa_time_ns = 0,
+        .total_sasa = 0,
+        .status = .ok,
+    };
+
+    var sasa_timer = std.Io.Timestamp.now(io, .awake);
+    const probe_radius: T = if (T == f64) config.probe_radius else @as(T, @floatCast(config.probe_radius));
+    var sasa_result = calculateSasaDispatch(
+        T,
+        arena,
+        input,
+        config,
+        probe_radius,
+        n_threads,
+        lut,
+        coarse_lut,
+        fine_lut,
+    ) catch |err| {
+        result.status = .err;
+        result.error_msg = std.fmt.allocPrint(result_allocator, "SASA calculation failed: {s}", .{@errorName(err)}) catch null;
+        return result;
+    };
+    defer sasa_result.deinit();
+    result.sasa_time_ns = @intCast(sasa_timer.untilNow(io, .awake).nanoseconds);
+    result.total_sasa = if (T == f64) sasa_result.total_area else @as(f64, @floatCast(sasa_result.total_area));
+
+    if (config.store_atom_areas) {
+        if (T == f64) {
+            result.atom_areas = arena.dupe(f64, sasa_result.atom_areas) catch {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                return result;
+            };
+        } else {
+            const areas_f64 = arena.alloc(f64, sasa_result.atom_areas.len) catch {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                return result;
+            };
+            for (sasa_result.atom_areas, 0..) |v, j| areas_f64[j] = @floatCast(v);
+            result.atom_areas = areas_f64;
+        }
+    }
+
+    if (config.residue_map) {
+        const areas = result.atom_areas orelse blk: {
+            if (T == f64) break :blk sasa_result.atom_areas;
+            const areas_f64 = arena.alloc(f64, sasa_result.atom_areas.len) catch {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                return result;
+            };
+            for (sasa_result.atom_areas, 0..) |v, j| areas_f64[j] = @floatCast(v);
+            break :blk areas_f64;
+        };
+        if (!attachResidueMap(arena, result_allocator, input, areas, &result)) return result;
+    }
+
+    if (output_dir) |out_dir| {
+        if (!config.store_atom_areas) {
+            writeSasaOutput(T, arena, io, &sasa_result, out_dir, filename, config.output_format) catch |err| {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "output write failed: {s}", .{@errorName(err)}) catch null;
+                return result;
+            };
+        }
+    }
+
+    return result;
+}
+```
+
+Then replace the duplicated f64 and f32 blocks in `processOneFile` with calls to `calculatePreparedInputResult`. Preserve the parse and classifier code above it.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+zig fmt src/batch.zig
+zig build test --summary all
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src/batch.zig
+git commit -m "refactor: reuse prepared batch SASA calculation"
+```
+
+## Task 3: Add workflow file-first runner for non-SDF inputs
+
+**Files:**
+- Modify: `src/batch.zig`
+
+- [ ] **Step 1: Preserve old workflow runner under a new name**
+
+Rename the current `runWorkflow` function to `runWorkflowJobFirst` without changing its body. Then add a new small dispatcher named `runWorkflow`:
+
+```zig
+fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    if (try workflowInputContainsSdf(allocator, io, args)) {
+        return runWorkflowJobFirst(allocator, io, args);
+    }
+    return runWorkflowFileFirst(allocator, io, args);
+}
+```
+
+Add the new helper declaration with a temporary body that delegates to job-first:
+
+```zig
+fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    return runWorkflowJobFirst(allocator, io, args);
+}
+```
+
+- [ ] **Step 2: Add SDF fallback detector**
+
+Add:
+
+```zig
+fn workflowInputContainsSdf(allocator: Allocator, io: std.Io, args: BatchArgs) !bool {
+    const workflow_path = args.workflow_path orelse return false;
+    var workflow = try parseWorkflowFile(allocator, io, workflow_path);
+    defer workflow.deinit();
+    const input_dir = args.input_path orelse workflow.input.dir orelse return false;
+    const files = try scanDirectory(allocator, io, input_dir);
+    defer {
+        for (files) |f| allocator.free(f);
+        allocator.free(files);
+    }
+    for (files) |filename| {
+        if (format_detect.detectInputFormat(filename) == .sdf) return true;
+    }
+    return false;
+}
+```
+
+This helper can parse the workflow once before the real runner parses it again. That overhead only happens once and keeps the fallback simple.
+
+- [ ] **Step 3: Run tests to ensure rename is safe**
+
+Run:
+
+```bash
+zig fmt src/batch.zig
+zig build test --summary all
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Implement workflow result accumulation types**
+
+Add these small structs near `BatchResult`:
+
+```zig
+const WorkflowJobState = struct {
+    name: []const u8,
+    config: BatchConfig,
+    output_dir: ?[]const u8 = null,
+    jsonl_output_path: ?[]const u8 = null,
+    successful: usize = 0,
+    failed: usize = 0,
+    total_sasa_time_ns: u64 = 0,
+
+    fn deinit(self: *WorkflowJobState, allocator: Allocator) void {
+        if (self.output_dir) |path| allocator.free(path);
+        if (self.jsonl_output_path) |path| allocator.free(path);
+    }
+};
+```
+
+Add a JSONL write helper that writes one result to a path by creating/appending through the existing JSONL serializer. Use truncation only when initializing each job output path, not for every result.
+
+```zig
+fn truncateJsonlOutput(io: std.Io, path: []const u8) !void {
+    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
+    file.close(io);
+}
+
+fn appendJsonlResultToFile(io: std.Io, file: std.Io.File, allocator: Allocator, result: *FileResult) !void {
+    var write_buf: [64 * 1024]u8 = undefined;
+    var writer = std.Io.File.Writer.initStreaming(file, io, &write_buf);
+    const line = try fileResultToJsonlLine(allocator, result);
+    defer allocator.free(line);
+    try writer.interface.writeAll(line);
+    try writer.interface.writeByte('\n');
+    try writer.interface.flush();
+}
+```
+
+If Zig's `std.Io.File.Writer.initStreaming` cannot be re-created safely for the same file handle, replace this helper with a `WorkflowJsonlWriter` struct that owns `file`, `buffer`, and `writer` for the full workflow run.
+
+- [ ] **Step 5: Implement shared workflow setup in `runWorkflowFileFirst`**
+
+Replace the temporary body with setup equivalent to `runWorkflowJobFirst`:
+
+```zig
+fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    if (args.chain_filter != null) {
+        std.debug.print("Error: --workflow cannot be combined with --chain; --manifest is a compatibility alias for --workflow; use [[jobs]].chains in the workflow\n", .{});
+        return error.InvalidArgument;
+    }
+
+    const workflow_path = args.workflow_path.?;
+    var workflow = parseWorkflowFile(allocator, io, workflow_path) catch |err| {
+        std.debug.print("Error reading workflow file '{s}': {s}\n", .{ workflow_path, @errorName(err) });
+        return err;
+    };
+    defer workflow.deinit();
+
+    if (workflow.jobs.len == 0) {
+        std.debug.print("Error: batch workflow requires at least one [[jobs]] entry\n", .{});
+        return error.NoJobs;
+    }
+
+    const input_dir = args.input_path orelse workflow.input.dir orelse {
+        std.debug.print("Error: Missing input directory (provide positional input_dir or [input].dir in workflow)\n", .{});
+        return error.MissingArgument;
+    };
+    const output_dir = args.output_path orelse workflow.output.dir;
+    if (workflow.jobs.len > 1 and output_dir == null) {
+        std.debug.print("Error: workflow with multiple jobs requires an output directory\n", .{});
+        return error.InvalidArgument;
+    }
+
+    // Copy resource loading logic from runWorkflowJobFirst exactly:
+    // load_quiet, resource_config, ext_ccd, sdf_ccd, custom_classifier.
+    // Then build WorkflowJobState entries with per-job config and output paths.
+}
+```
+
+When building `WorkflowJobState` entries, use the same rules as `runWorkflowJobFirst`:
+
+```zig
+var states = try allocator.alloc(WorkflowJobState, workflow.jobs.len);
+errdefer allocator.free(states);
+for (workflow.jobs, 0..) |job, i| {
+    var config = BatchConfig{};
+    try applyWorkflowToBatchConfig(&config, args, workflow.calculation, workflow.output, workflow.classifier);
+    applyCliOverrides(&config, args);
+    config.include_hetatm = config.include_hetatm or (config.classifier_type == .ccd);
+    config.store_atom_areas = (config.output_format == .jsonl);
+    config.external_ccd = if (ext_ccd != null) &ext_ccd.? else null;
+    config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
+    if (custom_classifier) |*c| config.custom_classifier = c;
+    applyWorkflowJobOverrides(&config, args, job);
+    try validateResidueMapFormat(config.output_format, config.residue_map);
+
+    var job_output_dir: ?[]const u8 = null;
+    var jsonl_output_path: ?[]const u8 = null;
+    if (config.output_format == .jsonl) {
+        if (output_dir) |out| {
+            try std.Io.Dir.cwd().createDirPath(io, out);
+            jsonl_output_path = try workflowJsonlOutputPath(allocator, out, job.name);
+            try truncateJsonlOutput(io, jsonl_output_path.?);
+        }
+    } else if (output_dir) |out| {
+        job_output_dir = try workflowPerFileOutputDir(allocator, out, job.name);
+        try std.Io.Dir.cwd().createDirPath(io, job_output_dir.?);
+    }
+
+    states[i] = .{
+        .name = job.name,
+        .config = config,
+        .output_dir = job_output_dir,
+        .jsonl_output_path = jsonl_output_path,
+    };
+}
+defer {
+    for (states) |*state| state.deinit(allocator);
+    allocator.free(states);
+}
+```
+
+- [ ] **Step 6: Add the file-first processing loop**
+
+Inside `runWorkflowFileFirst`, after state setup:
+
+```zig
+const files = try scanDirectory(allocator, io, input_dir);
+defer {
+    for (files) |f| allocator.free(f);
+    allocator.free(files);
+}
+
+var luts = try BatchLuts.init(allocator, resource_config);
+defer luts.deinit();
+
+var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+defer arena.deinit();
+
+for (files) |filename| {
+    const input_path = try std.fs.path.join(arena.allocator(), &.{ input_dir, filename });
+
+    var source_config = resource_config;
+    source_config.chain_filter = null;
+    var source_input = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
+        for (states) |*state| {
+            state.failed += 1;
+            std.debug.print("Error running workflow job '{s}' on '{s}': read/parse failed: {s}\n", .{ state.name, filename, @errorName(err) });
+        }
+        _ = arena.reset(.retain_capacity);
+        continue;
+    };
+    defer source_input.deinit();
+
+    if (source_config.custom_classifier) |custom_classifier| {
+        if (source_input.hasClassificationInfo()) try applyCustomClassifier(&source_input, custom_classifier, source_config.quiet);
+    } else if (source_config.classifier_type) |ct| {
+        const format = format_detect.detectInputFormat(input_path);
+        if (format != .json and source_input.hasClassificationInfo()) try applyBuiltinClassifier(&source_input, ct, source_config.sdf_ccd, source_config.external_ccd);
+    }
+
+    for (workflow.jobs, 0..) |job, job_index| {
+        var state = &states[job_index];
+        if (!state.config.quiet) std.debug.print("Workflow job: {s}\n", .{state.name});
+
+        const selected_chains: ?[]const []const u8 = if (format_detect.detectInputFormat(input_path) == .json) null else job.chains;
+        var selected_input = copySelectedAtomInput(arena.allocator(), source_input, selected_chains) catch |err| {
+            state.failed += 1;
+            std.debug.print("Error running workflow job '{s}' on '{s}': selection failed: {s}\n", .{ state.name, filename, @errorName(err) });
+            continue;
+        };
+        defer selected_input.deinit();
+
+        var result = switch (state.config.precision) {
+            .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, 1, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+            .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, 1, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+        };
+
+        if (result.status == .ok) {
+            state.successful += 1;
+            state.total_sasa_time_ns += result.sasa_time_ns;
+        } else {
+            state.failed += 1;
+        }
+
+        if (state.config.output_format == .jsonl) {
+            if (state.jsonl_output_path) |path| {
+                // Prefer a persistent file handle if implemented in Step 4.
+                const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+                defer file.close(io);
+                try appendJsonlResultToFile(io, file, arena.allocator(), &result);
+            } else {
+                var stdout_writer = std.Io.File.Writer.initStreaming(std.Io.File.stdout(), io, &[_]u8{});
+                writeJsonlResult(&stdout_writer, arena.allocator(), &result);
+            }
+        }
+
+        result.atom_areas = null;
+        result.residue_map = null;
+    }
+
+    _ = arena.reset(.retain_capacity);
+}
+
+var successful: usize = 0;
+var failed: usize = 0;
+for (states) |state| {
+    successful += state.successful;
+    failed += state.failed;
+}
+std.debug.print("Workflow complete: {d} successful, {d} failed\n", .{ successful, failed });
+```
+
+Adjust the JSONL file handling to the exact Zig file open flags available in this repository. The required behavior is: create/truncate each job JSONL file once, then append one line per successful or failed file result in deterministic scan order.
+
+- [ ] **Step 7: Run tests and fix compile errors**
+
+Run:
+
+```bash
+zig fmt src/batch.zig
+zig build test --summary all
+```
+
+Expected: all tests pass. If the JSONL helper requires persistent writer state, implement `WorkflowJsonlWriter` before proceeding.
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add src/batch.zig
+git commit -m "feat: process workflow batch files once"
+```
+
+## Task 4: Add output compatibility tests for workflow jobs
+
+**Files:**
+- Modify: `src/batch.zig`
+- Create test fixtures under `test_data/` only if existing examples are insufficient.
+
+- [ ] **Step 1: Add a focused test for job state output path generation**
+
+Add this unit test if no direct file-first integration test is practical:
+
+```zig
+test "workflow job state keeps existing output layout" {
+    const allocator = std.testing.allocator;
+
+    const jsonl_path = try workflowJsonlOutputPath(allocator, "results", "chain_a");
+    defer allocator.free(jsonl_path);
+    try std.testing.expectEqualStrings("results/chain_a.jsonl", jsonl_path);
+
+    const per_file_dir = try workflowPerFileOutputDir(allocator, "results", "complex_ab");
+    defer allocator.free(per_file_dir);
+    try std.testing.expectEqualStrings("results/complex_ab", per_file_dir);
+}
+```
+
+- [ ] **Step 2: Add a file-first vs job-first smoke script command to manual verification**
+
+Use existing workflow fixture first:
+
+```bash
+rm -rf zig-out/workflow-smoke
+zig build -Doptimize=ReleaseFast
+./zig-out/bin/zsasa batch --workflow test_data/workflow-batch.toml
+ls zig-out/workflow-smoke/batch
+```
+
+Expected: command succeeds and creates `zig-out/workflow-smoke/batch/all.jsonl` for the existing fixture.
+
+- [ ] **Step 3: Add a temporary local dimer workflow for manual comparison**
+
+Create `/tmp/zsasa-workflow-ab.toml` during verification, not committed:
+
+```toml
+version = 1
+kind = "workflow"
+
+[input]
+dir = "examples"
+
+[output]
+dir = "zig-out/workflow-ab"
+format = "jsonl"
+
+[calculation]
+n_points = 32
+quiet = true
+residue_map = true
+
+[classifier]
+type = "ccd"
+
+[[jobs]]
+name = "chain_a"
+chains = ["A"]
+
+[[jobs]]
+name = "chain_b"
+chains = ["B"]
+
+[[jobs]]
+name = "complex_ab"
+chains = ["A", "B"]
+```
+
+Run:
+
+```bash
+rm -rf zig-out/workflow-ab
+./zig-out/bin/zsasa batch --workflow /tmp/zsasa-workflow-ab.toml
+find zig-out/workflow-ab -type f -maxdepth 1 -print | sort
+```
+
+Expected: `chain_a.jsonl`, `chain_b.jsonl`, and `complex_ab.jsonl` exist. If the examples directory has no B chain, `chain_b` and `complex_ab` should still behave consistently with the previous chain-filtered parser behavior for the fixture.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+zig fmt --check src/
+zig build test --summary all
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/batch.zig
+git commit -m "test: cover workflow file-first outputs"
+```
+
+## Task 5: Document workflow execution reuse
+
+**Files:**
+- Modify: `website/docs/guide/workflows.md`
+
+- [ ] **Step 1: Add documentation note**
+
+In `website/docs/guide/workflows.md`, after the batch workflow example, add:
+
+```markdown
+Workflow batch runs reuse parsed structures across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; zsasa will parse each input structure once and then compute each requested chain selection independently.
+```
+
+- [ ] **Step 2: Run docs-adjacent check**
+
+Run:
+
+```bash
+rg -n "reuse parsed structures|chain A, chain B" website/docs/guide/workflows.md
+```
+
+Expected: the new note appears exactly once.
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add website/docs/guide/workflows.md
+git commit -m "docs: note workflow job reuse"
+```
+
+## Task 6: Final verification and cleanup
+
+**Files:**
+- No new files unless previous tasks require test fixtures.
+
+- [ ] **Step 1: Run required verification**
+
+```bash
+zig fmt --check src/
+zig build test --summary all
+zig build -Doptimize=ReleaseFast
+./zig-out/bin/zsasa batch --workflow test_data/workflow-batch.toml
+```
+
+Expected: all commands pass. The workflow command prints `Workflow complete:` and returns exit code 0.
+
+- [ ] **Step 2: Inspect git state**
+
+```bash
+git status --short --branch
+git log --oneline --decorate -6
+```
+
+Expected: branch is `perf/workflow-file-first`; working tree is clean after commits.
+
+- [ ] **Step 3: Prepare final summary**
+
+Summarize:
+
+- Behavior unchanged for workflow schema and outputs.
+- `batch --workflow` now uses file-first processing for non-SDF workflow inputs.
+- SDF workflows use the preserved job-first fallback.
+- Verification commands and results.
+
+## Self-Review
+
+- Spec coverage: The plan keeps `[[jobs]]`, preserves output layout, shares scan/LUT/parse/classifier work, keeps SASA per job, avoids `[[complexes]]`, and includes tests/docs.
+- Placeholder scan: No placeholder markers or unspecified edge-case steps remain.
+- Type consistency: Helper names used consistently: `copySelectedAtomInput`, `calculatePreparedInputResult`, `runWorkflowJobFirst`, `runWorkflowFileFirst`, `WorkflowJobState`.

--- a/docs/superpowers/specs/2026-05-20-workflow-file-first-design.md
+++ b/docs/superpowers/specs/2026-05-20-workflow-file-first-design.md
@@ -1,0 +1,104 @@
+# Workflow File-First Batch Execution Design
+
+Date: 2026-05-20
+Status: Approved design
+
+## Problem
+
+Workflow batch jobs currently execute job-first: each `[[jobs]]` entry calls the normal batch runner over the full input directory. For common dimer workflows such as chain A, chain B, and chain AB, the same files are scanned, parsed, classified, and prepared repeatedly. This is wasteful because only the chain subset changes between jobs.
+
+## Goals
+
+- Keep the existing workflow TOML schema unchanged.
+- Preserve `[[jobs]].chains` semantics and all existing output layouts.
+- Avoid repeated directory scans, structure parsing, classifier application, and SR bitmask/LUT preparation across jobs in one workflow run.
+- Keep SASA calculations scientifically equivalent to the existing behavior: each job computes SASA on its selected atom set, not by subtracting or approximating from another job.
+- Keep the non-workflow batch path as unchanged as practical.
+
+## Non-goals
+
+- Add a new `[[complexes]]` schema.
+- Auto-generate pairwise or all-subset chain combinations.
+- Share occlusion or neighbor-list state between different chain selections.
+- Change JSON, JSONL, CSV, residue-map, or per-file output schemas.
+
+## Proposed Architecture
+
+Add a workflow-specific file-first runner for `zsasa batch --workflow`.
+
+Current execution order:
+
+```text
+for each job:
+  runBatch(input_dir, job_config)
+```
+
+New workflow execution order:
+
+```text
+scan input directory once
+prepare shared calculation resources once
+open one output stream per JSONL job when needed
+for each input file:
+  parse once
+  apply classifier once
+  build reusable chain-selection metadata
+  for each workflow job:
+    derive a selected AtomInput view/copy for the job chains
+    run SASA for that selected atom set
+    write to the same output destination as today
+```
+
+The runner should still produce per-job summaries compatible with the existing workflow completion counts.
+
+## Component Boundaries
+
+### Parsed input preparation
+
+Create a helper that reads and classifies a structure once using a base `BatchConfig` without any job chain filter. For PDB, mmCIF, and BinaryCIF inputs, this preserves the full parsed structure for all workflow jobs. Classifier resources such as external CCD, SDF-derived CCD, and custom classifiers remain loaded once per workflow run.
+
+### Chain selection
+
+Create a helper that builds a job-specific `AtomInput` from a parsed/classified source `AtomInput` and a `[]const []const u8` chain filter.
+
+The selected input owns its arrays and can be deinitialized normally. This is more allocation-heavy than a zero-copy indexed view, but it avoids changing the SASA algorithm interfaces and keeps the first implementation low-risk. If `job.chains` is null, the helper can either duplicate the full input or use a clearly documented fast path that does not mutate the source.
+
+### SASA calculation
+
+Reuse the existing `calculateSasaDispatch` path. Each job still computes SASA independently on its selected atoms. This preserves the current result for chain A, chain B, and chain AB jobs because each job's occluder set remains exactly the selected atom set.
+
+### Output
+
+Keep existing output layout:
+
+- JSONL workflows write one file per job under the workflow output directory, such as `results/chain_a.jsonl`.
+- Non-JSONL workflows write per-file outputs under one subdirectory per job, such as `results/chain_a/1abc.json`.
+- Stdout behavior for single-job/no-output workflows should remain compatible where practical.
+
+For JSONL, open and maintain one writer per job during the workflow run so the file-first loop can append each file's result to the correct job output.
+
+### SDF handling
+
+SDF does not naturally participate in chain-filtered dimer workflows. The first implementation should keep SDF behavior correct but does not need to optimize SDF molecule parsing across workflow jobs. A safe fallback is acceptable for SDF inputs if it preserves existing outputs.
+
+## Error Handling
+
+- A parse/classifier error for one input file should produce failed results for the affected file while allowing the workflow to continue, matching batch behavior.
+- A job that selects no atoms should follow the existing behavior for an empty parsed input if one exists; otherwise return a clear per-file job error.
+- Output write failures should mark the affected job/file as failed and include the error name in the result message.
+- Invalid workflow configuration remains rejected before file processing begins.
+
+## Testing Plan
+
+- Add unit tests for the AtomInput chain-subset helper, including single chain, multiple chains, null chains, and no matching atoms.
+- Add workflow-level tests comparing file-first outputs against the existing job-first behavior for chain A, chain B, and chain AB on a small fixture.
+- Cover JSONL residue-map output for a chain-filtered workflow job.
+- Run:
+  - `zig fmt --check src/`
+  - `zig build test`
+
+## Compatibility and Performance Notes
+
+This change should be behavior-preserving. The main expected speedup comes from doing parse/classifier work once per file instead of once per job. LUT preparation is also shared once per workflow run. SASA itself still runs once per job because each chain selection has a different occluder set.
+
+The design intentionally avoids automatic complex generation. Users continue to list only the jobs they want, preventing combinatorial explosion for trimers and larger assemblies.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -443,6 +443,84 @@ pub const BatchResult = struct {
     }
 };
 
+fn chainMatchesFilter(chain: types.FixedString4, chains: []const []const u8) bool {
+    for (chains) |target| {
+        if (chain.eqlSlice(target)) return true;
+    }
+    return false;
+}
+
+fn atomSelectedByChains(input: AtomInput, index: usize, chains: ?[]const []const u8) bool {
+    const filter = chains orelse return true;
+    if (filter.len == 0) return true;
+    const chain_ids = input.chain_id orelse return true;
+    return chainMatchesFilter(chain_ids[index], filter);
+}
+
+fn countSelectedAtoms(input: AtomInput, chains: ?[]const []const u8) usize {
+    var count: usize = 0;
+    for (0..input.atomCount()) |i| {
+        if (atomSelectedByChains(input, i, chains)) count += 1;
+    }
+    return count;
+}
+
+fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]const []const u8) !AtomInput {
+    const selected_count = countSelectedAtoms(input, chains);
+
+    const x = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(x);
+    const y = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(y);
+    const z = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(z);
+    const r = try allocator.alloc(f64, selected_count);
+    errdefer allocator.free(r);
+
+    const residue = if (input.residue != null) try allocator.alloc(types.FixedString5, selected_count) else null;
+    errdefer if (residue) |v| allocator.free(v);
+    const atom_name = if (input.atom_name != null) try allocator.alloc(types.FixedString4, selected_count) else null;
+    errdefer if (atom_name) |v| allocator.free(v);
+    const element = if (input.element != null) try allocator.alloc(u8, selected_count) else null;
+    errdefer if (element) |v| allocator.free(v);
+    const chain_id = if (input.chain_id != null) try allocator.alloc(types.FixedString4, selected_count) else null;
+    errdefer if (chain_id) |v| allocator.free(v);
+    const residue_num = if (input.residue_num != null) try allocator.alloc(i32, selected_count) else null;
+    errdefer if (residue_num) |v| allocator.free(v);
+    const insertion_code = if (input.insertion_code != null) try allocator.alloc(types.FixedString4, selected_count) else null;
+    errdefer if (insertion_code) |v| allocator.free(v);
+
+    var out_i: usize = 0;
+    for (0..input.atomCount()) |i| {
+        if (!atomSelectedByChains(input, i, chains)) continue;
+        x[out_i] = input.x[i];
+        y[out_i] = input.y[i];
+        z[out_i] = input.z[i];
+        r[out_i] = input.r[i];
+        if (residue) |v| v[out_i] = input.residue.?[i];
+        if (atom_name) |v| v[out_i] = input.atom_name.?[i];
+        if (element) |v| v[out_i] = input.element.?[i];
+        if (chain_id) |v| v[out_i] = input.chain_id.?[i];
+        if (residue_num) |v| v[out_i] = input.residue_num.?[i];
+        if (insertion_code) |v| v[out_i] = input.insertion_code.?[i];
+        out_i += 1;
+    }
+
+    return AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .residue = residue,
+        .atom_name = atom_name,
+        .element = element,
+        .chain_id = chain_id,
+        .residue_num = residue_num,
+        .insertion_code = insertion_code,
+        .allocator = allocator,
+    };
+}
+
 /// Read input file with auto-format detection
 fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: BatchConfig) !AtomInput {
     const format = format_detect.detectInputFormat(path);
@@ -2984,6 +3062,112 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
 test "scanDirectory finds json files" {
     // This test requires a test directory - skip in automated testing
     // Manual testing: create a directory with .json files and test
+}
+
+fn makeTestAtomInput(allocator: Allocator, chains: []const []const u8) !AtomInput {
+    const n = chains.len;
+    const x = try allocator.alloc(f64, n);
+    errdefer allocator.free(x);
+    const y = try allocator.alloc(f64, n);
+    errdefer allocator.free(y);
+    const z = try allocator.alloc(f64, n);
+    errdefer allocator.free(z);
+    const r = try allocator.alloc(f64, n);
+    errdefer allocator.free(r);
+    const residue = try allocator.alloc(types.FixedString5, n);
+    errdefer allocator.free(residue);
+    const atom_name = try allocator.alloc(types.FixedString4, n);
+    errdefer allocator.free(atom_name);
+    const element = try allocator.alloc(u8, n);
+    errdefer allocator.free(element);
+    const chain_id = try allocator.alloc(types.FixedString4, n);
+    errdefer allocator.free(chain_id);
+    const residue_num = try allocator.alloc(i32, n);
+    errdefer allocator.free(residue_num);
+    const insertion_code = try allocator.alloc(types.FixedString4, n);
+    errdefer allocator.free(insertion_code);
+
+    for (chains, 0..) |chain, i| {
+        x[i] = @floatFromInt(i);
+        y[i] = @floatFromInt(i + 10);
+        z[i] = @floatFromInt(i + 20);
+        r[i] = 1.5;
+        residue[i] = types.FixedString5.fromSlice("GLY");
+        atom_name[i] = types.FixedString4.fromSlice("CA");
+        element[i] = 6;
+        chain_id[i] = types.FixedString4.fromSlice(chain);
+        residue_num[i] = @intCast(i + 1);
+        insertion_code[i] = types.FixedString4.fromSlice("");
+    }
+
+    return AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .residue = residue,
+        .atom_name = atom_name,
+        .element = element,
+        .chain_id = chain_id,
+        .residue_num = residue_num,
+        .insertion_code = insertion_code,
+        .allocator = allocator,
+    };
+}
+
+test "copySelectedAtomInput filters one chain" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B", "A" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, &.{"A"});
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), selected.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected.x[0], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.0), selected.x[1], 1e-12);
+    try std.testing.expectEqualStrings("A", selected.chain_id.?[0].slice());
+    try std.testing.expectEqualStrings("A", selected.chain_id.?[1].slice());
+}
+
+test "copySelectedAtomInput filters multiple chains in source order" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B", "C", "A" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, &.{ "C", "A" });
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), selected.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected.x[0], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.0), selected.x[1], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 3.0), selected.x[2], 1e-12);
+}
+
+test "copySelectedAtomInput null chains duplicates all atoms" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, null);
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), selected.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected.x[0], 1e-12);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), selected.x[1], 1e-12);
+}
+
+test "copySelectedAtomInput no matching chains returns empty input" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "B" });
+    defer input.deinit();
+
+    var selected = try copySelectedAtomInput(allocator, input, &.{"Z"});
+    defer selected.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), selected.atomCount());
+    try std.testing.expect(selected.chain_id != null);
+    try std.testing.expectEqual(@as(usize, 0), selected.chain_id.?.len);
 }
 
 test "BatchConfig default values" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -2852,6 +2852,9 @@ fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     if (workflowFilesContainSdf(files)) {
         return runWorkflowJobFirst(allocator, io, args);
     }
+    if (workflowRequiresJobFirstForLongChainFormats(files, workflow)) {
+        return runWorkflowJobFirst(allocator, io, args);
+    }
     return runWorkflowFileFirst(allocator, io, args, files);
 }
 
@@ -2863,6 +2866,27 @@ fn freeScannedFiles(allocator: Allocator, files: []const []const u8) void {
 fn workflowFilesContainSdf(files: []const []const u8) bool {
     for (files) |filename| {
         if (format_detect.detectInputFormat(filename) == .sdf) return true;
+    }
+    return false;
+}
+
+fn workflowRequiresJobFirstForLongChainFormats(files: []const []const u8, workflow: workflow_manifest.Workflow) bool {
+    var has_chain_filter = false;
+    for (workflow.jobs) |job| {
+        if (job.chains) |chains| {
+            if (chains.len > 0) {
+                has_chain_filter = true;
+                break;
+            }
+        }
+    }
+    if (!has_chain_filter) return false;
+
+    for (files) |filename| {
+        switch (format_detect.detectInputFormat(filename)) {
+            .mmcif, .bcif => return true,
+            else => {},
+        }
     }
     return false;
 }
@@ -3880,6 +3904,92 @@ test "workflow file-first keeps existing output layout" {
     try std.testing.expect(std.mem.indexOf(u8, chain_a_json_content, "\"total_area\"") != null);
 }
 
+test "workflow mmCIF chain filters preserve long chain IDs" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root_path = root_buf[0..root_len];
+
+    const input_dir = try std.fs.path.join(allocator, &.{ root_path, "input" });
+    defer allocator.free(input_dir);
+    const output_dir = try std.fs.path.join(allocator, &.{ root_path, "output" });
+    defer allocator.free(output_dir);
+    const workflow_path = try std.fs.path.join(allocator, &.{ root_path, "workflow.toml" });
+    defer allocator.free(workflow_path);
+    const input_path = try std.fs.path.join(allocator, &.{ input_dir, "long-chain.cif" });
+    defer allocator.free(input_path);
+
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = input_path,
+        .data =
+        \\data_LONG_CHAIN
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM 1 N N ALA ABCDE 1 0.000 0.000 0.000
+        \\ATOM 2 C CA ALA ABCDE 1 1.500 0.000 0.000
+        \\#
+        \\
+        ,
+    });
+
+    const workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "jsonl"
+        \\
+        \\[calculation]
+        \\n_points = 1
+        \\quiet = true
+        \\
+        \\[classifier]
+        \\type = "naccess"
+        \\
+        \\[[jobs]]
+        \\name = "long_chain"
+        \\chains = ["ABCDE"]
+        \\
+        \\[[jobs]]
+        \\name = "truncated_prefix"
+        \\chains = ["ABCD"]
+        \\
+    , .{ input_dir, output_dir });
+    defer allocator.free(workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = workflow_path });
+
+    const long_chain_jsonl = try std.fs.path.join(allocator, &.{ output_dir, "long_chain.jsonl" });
+    defer allocator.free(long_chain_jsonl);
+    const prefix_jsonl = try std.fs.path.join(allocator, &.{ output_dir, "truncated_prefix.jsonl" });
+    defer allocator.free(prefix_jsonl);
+    const long_chain_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, long_chain_jsonl, allocator, .limited(4096));
+    defer allocator.free(long_chain_content);
+    const prefix_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, prefix_jsonl, allocator, .limited(4096));
+    defer allocator.free(prefix_content);
+
+    try std.testing.expect(std.mem.indexOf(u8, long_chain_content, "\"filename\":\"long-chain.cif\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, prefix_content, "\"filename\":\"long-chain.cif\"") == null);
+}
+
 test "workflowJsonlOutputPath uses job file under output dir" {
     const path = try workflowJsonlOutputPath(std.testing.allocator, "results", "chain_A");
     defer std.testing.allocator.free(path);
@@ -3895,6 +4005,46 @@ test "workflowPerFileOutputDir uses job directory under output dir" {
 test "workflowFilesContainSdf detects SDF in pre-scanned files" {
     const files = [_][]const u8{ "protein.pdb", "ligand.sdf", "other.cif" };
     try std.testing.expect(workflowFilesContainSdf(files[0..]));
+}
+
+test "workflowRequiresJobFirstForLongChainFormats detects chain-filtered mmCIF and BinaryCIF" {
+    const mmcif_files = [_][]const u8{"long-chain.cif"};
+    const bcif_files = [_][]const u8{"long-chain.bcif"};
+    const pdb_json_files = [_][]const u8{ "chain.pdb", "atoms.json" };
+
+    var long_chain_jobs = [_]workflow_manifest.Job{
+        .{ .name = "long", .chains = &.{"ABCDE"} },
+    };
+    const long_chain_workflow = workflow_manifest.Workflow{
+        .allocator = std.testing.allocator,
+        .content = "",
+        .jobs = long_chain_jobs[0..],
+    };
+    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(mmcif_files[0..], long_chain_workflow));
+    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(bcif_files[0..], long_chain_workflow));
+    try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(pdb_json_files[0..], long_chain_workflow));
+
+    var prefix_chain_jobs = [_]workflow_manifest.Job{
+        .{ .name = "prefix", .chains = &.{"ABCD"} },
+    };
+    const prefix_chain_workflow = workflow_manifest.Workflow{
+        .allocator = std.testing.allocator,
+        .content = "",
+        .jobs = prefix_chain_jobs[0..],
+    };
+    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(mmcif_files[0..], prefix_chain_workflow));
+    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(bcif_files[0..], prefix_chain_workflow));
+
+    var unfiltered_jobs = [_]workflow_manifest.Job{
+        .{ .name = "all" },
+    };
+    const unfiltered_workflow = workflow_manifest.Workflow{
+        .allocator = std.testing.allocator,
+        .content = "",
+        .jobs = unfiltered_jobs[0..],
+    };
+    try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(mmcif_files[0..], unfiltered_workflow));
+    try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(bcif_files[0..], unfiltered_workflow));
 }
 
 test "workflowRequiresJobFirstForAuthChain detects job-level auth-chain mismatch" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -3767,16 +3767,117 @@ test "batch resource resolver only loads CCD resources for CCD classifiers" {
     try std.testing.expectEqualStrings("cli.sdf", resolved_sdf_paths[0]);
 }
 
-test "workflow job state keeps existing output layout" {
+test "workflow file-first keeps existing output layout" {
     const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
 
-    const jsonl_path = try workflowJsonlOutputPath(allocator, "results", "chain_a");
-    defer allocator.free(jsonl_path);
-    try std.testing.expectEqualStrings("results/chain_a.jsonl", jsonl_path);
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root_path = root_buf[0..root_len];
 
-    const per_file_dir = try workflowPerFileOutputDir(allocator, "results", "complex_ab");
-    defer allocator.free(per_file_dir);
-    try std.testing.expectEqualStrings("results/complex_ab", per_file_dir);
+    const input_dir = try std.fs.path.join(allocator, &.{ root_path, "input" });
+    defer allocator.free(input_dir);
+    const jsonl_output_dir = try std.fs.path.join(allocator, &.{ root_path, "jsonl-output" });
+    defer allocator.free(jsonl_output_dir);
+    const json_output_dir = try std.fs.path.join(allocator, &.{ root_path, "json-output" });
+    defer allocator.free(json_output_dir);
+    const jsonl_workflow_path = try std.fs.path.join(allocator, &.{ root_path, "workflow-jsonl.toml" });
+    defer allocator.free(jsonl_workflow_path);
+    const json_workflow_path = try std.fs.path.join(allocator, &.{ root_path, "workflow-json.toml" });
+    defer allocator.free(json_workflow_path);
+    const input_path = try std.fs.path.join(allocator, &.{ input_dir, "tiny.pdb" });
+    defer allocator.free(input_path);
+
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = input_path,
+        .data =
+        \\ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00 20.00           N
+        \\ATOM      2  CA  ALA A   1       1.500   0.000   0.000  1.00 20.00           C
+        \\ATOM      3  N   GLY B   1       5.000   0.000   0.000  1.00 20.00           N
+        \\ATOM      4  CA  GLY B   1       6.500   0.000   0.000  1.00 20.00           C
+        \\END
+        \\
+        ,
+    });
+
+    const jsonl_workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "jsonl"
+        \\
+        \\[calculation]
+        \\n_points = 1
+        \\quiet = true
+        \\
+        \\[classifier]
+        \\type = "naccess"
+        \\
+        \\[[jobs]]
+        \\name = "chain_a"
+        \\chains = ["A"]
+        \\
+        \\[[jobs]]
+        \\name = "chain_b"
+        \\chains = ["B"]
+        \\
+    , .{ input_dir, jsonl_output_dir });
+    defer allocator.free(jsonl_workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = jsonl_workflow_path, .data = jsonl_workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = jsonl_workflow_path });
+
+    const chain_a_jsonl = try std.fs.path.join(allocator, &.{ jsonl_output_dir, "chain_a.jsonl" });
+    defer allocator.free(chain_a_jsonl);
+    const chain_b_jsonl = try std.fs.path.join(allocator, &.{ jsonl_output_dir, "chain_b.jsonl" });
+    defer allocator.free(chain_b_jsonl);
+    const chain_a_jsonl_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, chain_a_jsonl, allocator, .limited(4096));
+    defer allocator.free(chain_a_jsonl_content);
+    const chain_b_jsonl_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, chain_b_jsonl, allocator, .limited(4096));
+    defer allocator.free(chain_b_jsonl_content);
+    try std.testing.expect(std.mem.indexOf(u8, chain_a_jsonl_content, "\"filename\":\"tiny.pdb\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, chain_b_jsonl_content, "\"filename\":\"tiny.pdb\"") != null);
+
+    const json_workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "json"
+        \\
+        \\[calculation]
+        \\n_points = 1
+        \\quiet = true
+        \\
+        \\[classifier]
+        \\type = "naccess"
+        \\
+        \\[[jobs]]
+        \\name = "chain_a"
+        \\chains = ["A"]
+        \\
+    , .{ input_dir, json_output_dir });
+    defer allocator.free(json_workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = json_workflow_path, .data = json_workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = json_workflow_path });
+
+    const chain_a_json = try std.fs.path.join(allocator, &.{ json_output_dir, "chain_a", "tiny.json" });
+    defer allocator.free(chain_a_json);
+    const chain_a_json_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, chain_a_json, allocator, .limited(4096));
+    defer allocator.free(chain_a_json_content);
+    try std.testing.expect(std.mem.indexOf(u8, chain_a_json_content, "\"total_area\"") != null);
 }
 
 test "workflowJsonlOutputPath uses job file under output dir" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -2826,24 +2826,53 @@ fn loadCustomClassifier(allocator: Allocator, io: std.Io, path: []const u8) !cla
 }
 
 fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
-    if (try workflowInputContainsSdf(allocator, io, args)) {
+    if (args.chain_filter != null) return runWorkflowJobFirst(allocator, io, args);
+
+    const workflow_path = args.workflow_path orelse return runWorkflowFileFirst(allocator, io, args, null);
+    var workflow = parseWorkflowFile(allocator, io, workflow_path) catch {
+        return runWorkflowFileFirst(allocator, io, args, null);
+    };
+    defer workflow.deinit();
+
+    if (workflow.jobs.len == 0) return runWorkflowFileFirst(allocator, io, args, null);
+    const input_dir = args.input_path orelse workflow.input.dir orelse return runWorkflowFileFirst(allocator, io, args, null);
+    const output_dir = args.output_path orelse workflow.output.dir;
+    if (workflow.jobs.len > 1 and output_dir == null) return runWorkflowFileFirst(allocator, io, args, null);
+
+    var resource_config = BatchConfig{};
+    try applyWorkflowToBatchConfig(&resource_config, args, workflow.calculation, workflow.output, workflow.classifier);
+    applyCliOverrides(&resource_config, args);
+    if (workflowRequiresJobFirstForAuthChain(args, workflow, resource_config)) {
         return runWorkflowJobFirst(allocator, io, args);
     }
-    return runWorkflowFileFirst(allocator, io, args);
+
+    const files = try scanDirectory(allocator, io, input_dir);
+    defer freeScannedFiles(allocator, files);
+
+    if (workflowFilesContainSdf(files)) {
+        return runWorkflowJobFirst(allocator, io, args);
+    }
+    return runWorkflowFileFirst(allocator, io, args, files);
 }
 
-fn workflowInputContainsSdf(allocator: Allocator, io: std.Io, args: BatchArgs) !bool {
-    const workflow_path = args.workflow_path orelse return false;
-    var workflow = try parseWorkflowFile(allocator, io, workflow_path);
-    defer workflow.deinit();
-    const input_dir = args.input_path orelse workflow.input.dir orelse return false;
-    const files = try scanDirectory(allocator, io, input_dir);
-    defer {
-        for (files) |f| allocator.free(f);
-        allocator.free(files);
-    }
+fn freeScannedFiles(allocator: Allocator, files: []const []const u8) void {
+    for (files) |f| allocator.free(f);
+    allocator.free(files);
+}
+
+fn workflowFilesContainSdf(files: []const []const u8) bool {
     for (files) |filename| {
         if (format_detect.detectInputFormat(filename) == .sdf) return true;
+    }
+    return false;
+}
+
+fn workflowRequiresJobFirstForAuthChain(args: BatchArgs, workflow: workflow_manifest.Workflow, shared_config: BatchConfig) bool {
+    for (workflow.jobs) |job| {
+        var job_use_auth_chain = shared_config.use_auth_chain;
+        if (job.auth_chain) |v| job_use_auth_chain = v;
+        if (args.use_auth_chain) job_use_auth_chain = true;
+        if (job_use_auth_chain != shared_config.use_auth_chain) return true;
     }
     return false;
 }
@@ -2968,7 +2997,7 @@ fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void 
     std.debug.print("Workflow complete: {d} successful, {d} failed\n", .{ successful, failed });
 }
 
-fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_scanned_files: ?[]const []const u8) !void {
     if (args.chain_filter != null) {
         std.debug.print("Error: --workflow cannot be combined with --chain; --manifest is a compatibility alias for --workflow; use [[jobs]].chains in the workflow\n", .{});
         return error.InvalidArgument;
@@ -3092,11 +3121,8 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void
         allocator.free(states);
     }
 
-    const files = try scanDirectory(allocator, io, input_dir);
-    defer {
-        for (files) |f| allocator.free(f);
-        allocator.free(files);
-    }
+    const files = pre_scanned_files orelse try scanDirectory(allocator, io, input_dir);
+    defer if (pre_scanned_files == null) freeScannedFiles(allocator, files);
 
     var luts = try BatchLuts.init(allocator, resource_config);
     defer luts.deinit();
@@ -3742,39 +3768,25 @@ test "workflowPerFileOutputDir uses job directory under output dir" {
     try std.testing.expectEqualStrings("results/complex_AB", path);
 }
 
-test "workflowInputContainsSdf detects SDF files in workflow input directory" {
-    const allocator = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
+test "workflowFilesContainSdf detects SDF in pre-scanned files" {
+    const files = [_][]const u8{ "protein.pdb", "ligand.sdf", "other.cif" };
+    try std.testing.expect(workflowFilesContainSdf(files[0..]));
+}
 
-    try tmp_dir.dir.createDir(std.testing.io, "inputs", .default_dir);
-    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "inputs/protein.pdb", .data = "" });
-    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "inputs/ligand.sdf", .data = "" });
+test "workflowRequiresJobFirstForAuthChain detects job-level auth-chain mismatch" {
+    var jobs = [_]workflow_manifest.Job{
+        .{ .name = "label", .chains = &.{"A"}, .auth_chain = false },
+        .{ .name = "auth", .chains = &.{"A"}, .auth_chain = true },
+    };
+    const workflow = workflow_manifest.Workflow{
+        .allocator = std.testing.allocator,
+        .content = "",
+        .calculation = .{ .auth_chain = false },
+        .jobs = jobs[0..],
+    };
 
-    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
-    const root = root_buf[0..root_len];
-    const input_path = try std.fs.path.join(allocator, &.{ root, "inputs" });
-    defer allocator.free(input_path);
-    const workflow_path = try std.fs.path.join(allocator, &.{ root, "workflow.toml" });
-    defer allocator.free(workflow_path);
-
-    const workflow_text = try std.fmt.allocPrint(allocator,
-        \\version = 1
-        \\kind = "workflow"
-        \\
-        \\[input]
-        \\dir = "{s}"
-        \\
-        \\[[jobs]]
-        \\name = "all"
-        \\
-    , .{input_path});
-    defer allocator.free(workflow_text);
-    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow_text });
-
-    const args = BatchArgs{ .workflow_path = workflow_path };
-    try std.testing.expect(try workflowInputContainsSdf(allocator, std.testing.io, args));
+    try std.testing.expect(workflowRequiresJobFirstForAuthChain(BatchArgs{}, workflow, BatchConfig{ .use_auth_chain = false }));
+    try std.testing.expect(!workflowRequiresJobFirstForAuthChain(BatchArgs{ .use_auth_chain = true }, workflow, BatchConfig{ .use_auth_chain = true }));
 }
 
 test "appendJsonlResultToFile appends without truncating existing JSONL content" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -731,6 +731,95 @@ pub fn scanDirectory(allocator: Allocator, io: std.Io, dir_path: []const u8) ![]
     return files.toOwnedSlice(allocator);
 }
 
+/// Calculate SASA and optionally write output for an already prepared input.
+fn calculatePreparedInputResult(
+    comptime T: type,
+    arena: Allocator,
+    io: std.Io,
+    result_allocator: Allocator,
+    input: AtomInput,
+    output_dir: ?[]const u8,
+    filename: []const u8,
+    config: BatchConfig,
+    n_threads: usize,
+    lut: ?*const bitmask_lut.BitmaskLutGen(T),
+    coarse_lut: ?*const bitmask_lut.BitmaskLutGen(T),
+    fine_lut: ?*const bitmask_lut.BitmaskLutGen(T),
+) FileResult {
+    var result = FileResult{
+        .filename = filename,
+        .n_atoms = input.atomCount(),
+        .sasa_time_ns = 0,
+        .total_sasa = 0,
+        .status = .ok,
+    };
+
+    var sasa_timer = std.Io.Timestamp.now(io, .awake);
+    const probe_radius: T = if (T == f64) config.probe_radius else @as(T, @floatCast(config.probe_radius));
+    var sasa_result = calculateSasaDispatch(
+        T,
+        arena,
+        input,
+        config,
+        probe_radius,
+        n_threads,
+        lut,
+        coarse_lut,
+        fine_lut,
+    ) catch |err| {
+        result.status = .err;
+        result.error_msg = std.fmt.allocPrint(result_allocator, "SASA calculation failed: {s}", .{@errorName(err)}) catch null;
+        return result;
+    };
+    defer sasa_result.deinit();
+    result.sasa_time_ns = @intCast(sasa_timer.untilNow(io, .awake).nanoseconds);
+    result.total_sasa = if (T == f64) sasa_result.total_area else @as(f64, @floatCast(sasa_result.total_area));
+
+    if (config.store_atom_areas) {
+        if (T == f64) {
+            result.atom_areas = arena.dupe(f64, sasa_result.atom_areas) catch {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                return result;
+            };
+        } else {
+            const areas_f64 = arena.alloc(f64, sasa_result.atom_areas.len) catch {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                return result;
+            };
+            for (sasa_result.atom_areas, 0..) |v, j| areas_f64[j] = @floatCast(v);
+            result.atom_areas = areas_f64;
+        }
+    }
+
+    if (config.residue_map) {
+        const areas = result.atom_areas orelse blk: {
+            if (T == f64) break :blk sasa_result.atom_areas;
+            const areas_f64 = arena.alloc(f64, sasa_result.atom_areas.len) catch {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
+                return result;
+            };
+            for (sasa_result.atom_areas, 0..) |v, j| areas_f64[j] = @floatCast(v);
+            break :blk areas_f64;
+        };
+        if (!attachResidueMap(arena, result_allocator, input, areas, &result)) return result;
+    }
+
+    if (output_dir) |out_dir| {
+        if (!config.store_atom_areas) {
+            writeSasaOutput(T, arena, io, &sasa_result, out_dir, filename, config.output_format) catch |err| {
+                result.status = .err;
+                result.error_msg = std.fmt.allocPrint(result_allocator, "output write failed: {s}", .{@errorName(err)}) catch null;
+                return result;
+            };
+        }
+    }
+
+    return result;
+}
+
 /// Process a single file and return result
 /// Uses provided arena allocator for temporary allocations
 /// result_allocator: used for data that must outlive the arena (error messages)
@@ -796,113 +885,36 @@ fn processOneFile(
         }
     }
 
-    result.n_atoms = input.atomCount();
-
-    // Time SASA calculation only
-    var sasa_timer = std.Io.Timestamp.now(io, .awake);
-
-    // Calculate SASA using generic dispatcher
-    var total_area: f64 = 0;
-    switch (config.precision) {
-        .f64 => {
-            var sasa_result = calculateSasaDispatch(
-                f64,
-                arena,
-                input,
-                config,
-                config.probe_radius,
-                n_threads,
-                lut_f64,
-                coarse_lut_f64,
-                fine_lut_f64,
-            ) catch |err| {
-                result.status = .err;
-                result.error_msg = std.fmt.allocPrint(result_allocator, "SASA calculation failed: {s}", .{@errorName(err)}) catch null;
-                return result;
-            };
-            defer sasa_result.deinit();
-            result.sasa_time_ns = @intCast(sasa_timer.untilNow(io, .awake).nanoseconds);
-            total_area = sasa_result.total_area;
-
-            if (config.store_atom_areas) {
-                result.atom_areas = arena.dupe(f64, sasa_result.atom_areas) catch {
-                    result.status = .err;
-                    result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
-                    return result;
-                };
-            }
-            if (config.residue_map) {
-                const areas = result.atom_areas orelse sasa_result.atom_areas;
-                if (!attachResidueMap(arena, result_allocator, input, areas, &result)) return result;
-            }
-
-            if (output_dir) |out_dir| {
-                if (!config.store_atom_areas) {
-                    writeSasaOutput(f64, arena, io, &sasa_result, out_dir, filename, config.output_format) catch |err| {
-                        result.status = .err;
-                        result.error_msg = std.fmt.allocPrint(result_allocator, "output write failed: {s}", .{@errorName(err)}) catch null;
-                        return result;
-                    };
-                }
-            }
-        },
-        .f32 => {
-            var sasa_result = calculateSasaDispatch(
-                f32,
-                arena,
-                input,
-                config,
-                @as(f32, @floatCast(config.probe_radius)),
-                n_threads,
-                lut_f32,
-                coarse_lut_f32,
-                fine_lut_f32,
-            ) catch |err| {
-                result.status = .err;
-                result.error_msg = std.fmt.allocPrint(result_allocator, "SASA calculation failed: {s}", .{@errorName(err)}) catch null;
-                return result;
-            };
-            defer sasa_result.deinit();
-            result.sasa_time_ns = @intCast(sasa_timer.untilNow(io, .awake).nanoseconds);
-            total_area = @floatCast(sasa_result.total_area);
-
-            if (config.store_atom_areas) {
-                const areas_f32 = sasa_result.atom_areas;
-                const areas_f64 = arena.alloc(f64, areas_f32.len) catch {
-                    result.status = .err;
-                    result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
-                    return result;
-                };
-                for (areas_f32, 0..) |v, j| areas_f64[j] = @floatCast(v);
-                result.atom_areas = areas_f64;
-            }
-            if (config.residue_map) {
-                const areas = result.atom_areas orelse blk: {
-                    const areas_f64 = arena.alloc(f64, sasa_result.atom_areas.len) catch {
-                        result.status = .err;
-                        result.error_msg = std.fmt.allocPrint(result_allocator, "atom_areas allocation failed", .{}) catch null;
-                        return result;
-                    };
-                    for (sasa_result.atom_areas, 0..) |v, j| areas_f64[j] = @floatCast(v);
-                    break :blk areas_f64;
-                };
-                if (!attachResidueMap(arena, result_allocator, input, areas, &result)) return result;
-            }
-
-            if (output_dir) |out_dir| {
-                if (!config.store_atom_areas) {
-                    writeSasaOutput(f32, arena, io, &sasa_result, out_dir, filename, config.output_format) catch |err| {
-                        result.status = .err;
-                        result.error_msg = std.fmt.allocPrint(result_allocator, "output write failed: {s}", .{@errorName(err)}) catch null;
-                        return result;
-                    };
-                }
-            }
-        },
-    }
-
-    result.total_sasa = total_area;
-    return result;
+    return switch (config.precision) {
+        .f64 => calculatePreparedInputResult(
+            f64,
+            arena,
+            io,
+            result_allocator,
+            input,
+            output_dir,
+            filename,
+            config,
+            n_threads,
+            lut_f64,
+            coarse_lut_f64,
+            fine_lut_f64,
+        ),
+        .f32 => calculatePreparedInputResult(
+            f32,
+            arena,
+            io,
+            result_allocator,
+            input,
+            output_dir,
+            filename,
+            config,
+            n_threads,
+            lut_f32,
+            coarse_lut_f32,
+            fine_lut_f32,
+        ),
+    };
 }
 
 /// Process a single SDF molecule and return result.
@@ -3168,6 +3180,33 @@ test "copySelectedAtomInput no matching chains returns empty input" {
     try std.testing.expectEqual(@as(usize, 0), selected.atomCount());
     try std.testing.expect(selected.chain_id != null);
     try std.testing.expectEqual(@as(usize, 0), selected.chain_id.?.len);
+}
+
+test "calculatePreparedInputResult computes total for selected input" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "A", "A" });
+    defer input.deinit();
+
+    const result = calculatePreparedInputResult(
+        f64,
+        allocator,
+        std.testing.io,
+        allocator,
+        input,
+        null,
+        "prepared.pdb",
+        BatchConfig{ .n_points = 16, .quiet = true },
+        1,
+        null,
+        null,
+        null,
+    );
+    defer if (result.atom_areas) |areas| allocator.free(areas);
+    defer if (result.error_msg) |msg| allocator.free(msg);
+
+    try std.testing.expectEqual(.ok, result.status);
+    try std.testing.expectEqual(@as(usize, 2), result.n_atoms);
+    try std.testing.expect(result.total_sasa > 0.0);
 }
 
 test "BatchConfig default values" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -3767,6 +3767,18 @@ test "batch resource resolver only loads CCD resources for CCD classifiers" {
     try std.testing.expectEqualStrings("cli.sdf", resolved_sdf_paths[0]);
 }
 
+test "workflow job state keeps existing output layout" {
+    const allocator = std.testing.allocator;
+
+    const jsonl_path = try workflowJsonlOutputPath(allocator, "results", "chain_a");
+    defer allocator.free(jsonl_path);
+    try std.testing.expectEqualStrings("results/chain_a.jsonl", jsonl_path);
+
+    const per_file_dir = try workflowPerFileOutputDir(allocator, "results", "complex_ab");
+    defer allocator.free(per_file_dir);
+    try std.testing.expectEqualStrings("results/complex_ab", per_file_dir);
+}
+
 test "workflowJsonlOutputPath uses job file under output dir" {
     const path = try workflowJsonlOutputPath(std.testing.allocator, "results", "chain_A");
     defer std.testing.allocator.free(path);

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -2877,6 +2877,13 @@ fn workflowRequiresJobFirstForAuthChain(args: BatchArgs, workflow: workflow_mani
     return false;
 }
 
+fn effectiveWorkflowSasaThreads(config: BatchConfig) usize {
+    return if (config.n_threads == 0)
+        std.Thread.getCpuCount() catch 1
+    else
+        config.n_threads;
+}
+
 fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     if (args.chain_filter != null) {
         std.debug.print("Error: --workflow cannot be combined with --chain; --manifest is a compatibility alias for --workflow; use [[jobs]].chains in the workflow\n", .{});
@@ -3121,6 +3128,10 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
         allocator.free(states);
     }
 
+    for (states) |state| {
+        if (!state.config.quiet) std.debug.print("Workflow job: {s}\n", .{state.name});
+    }
+
     const files = pre_scanned_files orelse try scanDirectory(allocator, io, input_dir);
     defer if (pre_scanned_files == null) freeScannedFiles(allocator, files);
 
@@ -3173,7 +3184,6 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
 
         for (workflow.jobs, 0..) |job, job_index| {
             var state = &states[job_index];
-            if (!state.config.quiet) std.debug.print("Workflow job: {s}\n", .{state.name});
 
             const selected_chains: ?[]const []const u8 = if (format_detect.detectInputFormat(input_path) == .json) null else job.chains;
             var selected_input = copySelectedAtomInput(arena.allocator(), source_input, selected_chains) catch |err| {
@@ -3183,9 +3193,10 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
             };
             defer selected_input.deinit();
 
+            const n_threads = effectiveWorkflowSasaThreads(state.config);
             var result = switch (state.config.precision) {
-                .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, 1, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
-                .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, 1, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+                .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+                .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
             };
             defer if (result.error_msg) |msg| allocator.free(msg);
 
@@ -3787,6 +3798,11 @@ test "workflowRequiresJobFirstForAuthChain detects job-level auth-chain mismatch
 
     try std.testing.expect(workflowRequiresJobFirstForAuthChain(BatchArgs{}, workflow, BatchConfig{ .use_auth_chain = false }));
     try std.testing.expect(!workflowRequiresJobFirstForAuthChain(BatchArgs{ .use_auth_chain = true }, workflow, BatchConfig{ .use_auth_chain = true }));
+}
+
+test "effectiveWorkflowSasaThreads honors explicit and auto thread counts" {
+    try std.testing.expectEqual(@as(usize, 7), effectiveWorkflowSasaThreads(BatchConfig{ .n_threads = 7 }));
+    try std.testing.expect(effectiveWorkflowSasaThreads(BatchConfig{ .n_threads = 0 }) >= 1);
 }
 
 test "appendJsonlResultToFile appends without truncating existing JSONL content" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -443,6 +443,21 @@ pub const BatchResult = struct {
     }
 };
 
+const WorkflowJobState = struct {
+    name: []const u8,
+    config: BatchConfig,
+    output_dir: ?[]const u8 = null,
+    jsonl_output_path: ?[]const u8 = null,
+    successful: usize = 0,
+    failed: usize = 0,
+    total_sasa_time_ns: u64 = 0,
+
+    fn deinit(self: *WorkflowJobState, allocator: Allocator) void {
+        if (self.output_dir) |path| allocator.free(path);
+        if (self.jsonl_output_path) |path| allocator.free(path);
+    }
+};
+
 fn chainMatchesFilter(chain: types.FixedString4, chains: []const []const u8) bool {
     for (chains) |target| {
         if (chain.eqlSlice(target)) return true;
@@ -1231,6 +1246,26 @@ fn writeJsonlResult(
     jsonl_writer.interface.flush() catch |err| {
         logWarning("JSONL flush failed for {s}: {s}", .{ result.filename, @errorName(err) });
     };
+}
+
+fn truncateJsonlOutput(io: std.Io, path: []const u8) !void {
+    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
+    file.close(io);
+}
+
+fn appendJsonlResultToFile(io: std.Io, file: std.Io.File, allocator: Allocator, result: *FileResult) !void {
+    if (result.status != .ok) return;
+
+    const line = try fileResultToJsonlLine(allocator, result);
+    defer allocator.free(line);
+
+    const file_len = try file.length(io);
+    var write_buf: [64 * 1024]u8 = undefined;
+    var writer = std.Io.File.Writer.init(file, io, &write_buf);
+    try writer.seekTo(file_len);
+    try writer.interface.writeAll(line);
+    try writer.interface.writeByte('\n');
+    try writer.interface.flush();
 }
 
 /// Run batch processing sequentially (single-threaded path, used when n_threads <= 1)
@@ -2791,6 +2826,29 @@ fn loadCustomClassifier(allocator: Allocator, io: std.Io, path: []const u8) !cla
 }
 
 fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    if (try workflowInputContainsSdf(allocator, io, args)) {
+        return runWorkflowJobFirst(allocator, io, args);
+    }
+    return runWorkflowFileFirst(allocator, io, args);
+}
+
+fn workflowInputContainsSdf(allocator: Allocator, io: std.Io, args: BatchArgs) !bool {
+    const workflow_path = args.workflow_path orelse return false;
+    var workflow = try parseWorkflowFile(allocator, io, workflow_path);
+    defer workflow.deinit();
+    const input_dir = args.input_path orelse workflow.input.dir orelse return false;
+    const files = try scanDirectory(allocator, io, input_dir);
+    defer {
+        for (files) |f| allocator.free(f);
+        allocator.free(files);
+    }
+    for (files) |filename| {
+        if (format_detect.detectInputFormat(filename) == .sdf) return true;
+    }
+    return false;
+}
+
+fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     if (args.chain_filter != null) {
         std.debug.print("Error: --workflow cannot be combined with --chain; --manifest is a compatibility alias for --workflow; use [[jobs]].chains in the workflow\n", .{});
         return error.InvalidArgument;
@@ -2907,6 +2965,237 @@ fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         failed += result.failed;
     }
 
+    std.debug.print("Workflow complete: {d} successful, {d} failed\n", .{ successful, failed });
+}
+
+fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
+    if (args.chain_filter != null) {
+        std.debug.print("Error: --workflow cannot be combined with --chain; --manifest is a compatibility alias for --workflow; use [[jobs]].chains in the workflow\n", .{});
+        return error.InvalidArgument;
+    }
+
+    const workflow_path = args.workflow_path.?;
+    var workflow = parseWorkflowFile(allocator, io, workflow_path) catch |err| {
+        std.debug.print("Error reading workflow file '{s}': {s}\n", .{ workflow_path, @errorName(err) });
+        return err;
+    };
+    defer workflow.deinit();
+
+    if (workflow.jobs.len == 0) {
+        std.debug.print("Error: batch workflow requires at least one [[jobs]] entry\n", .{});
+        return error.NoJobs;
+    }
+
+    const input_dir = args.input_path orelse workflow.input.dir orelse {
+        std.debug.print("Error: Missing input directory (provide positional input_dir or [input].dir in workflow)\n", .{});
+        return error.MissingArgument;
+    };
+    const output_dir = args.output_path orelse workflow.output.dir;
+
+    if (workflow.jobs.len > 1 and output_dir == null) {
+        std.debug.print("Error: workflow with multiple jobs requires an output directory\n", .{});
+        return error.InvalidArgument;
+    }
+
+    const load_quiet = if (args.quiet_explicit) args.quiet else (workflow.calculation.quiet orelse args.quiet);
+
+    var resource_config = BatchConfig{};
+    try applyWorkflowToBatchConfig(&resource_config, args, workflow.calculation, workflow.output, workflow.classifier);
+    applyCliOverrides(&resource_config, args);
+    resource_config.include_hetatm = resource_config.include_hetatm or (resource_config.classifier_type == .ccd);
+    const effective_classifier_type = resource_config.classifier_type;
+
+    const ccd_path = resolveWorkflowCcdPath(args, workflow.classifier, effective_classifier_type);
+    var ext_ccd: ?ccd_parser.ComponentDict = null;
+    if (ccd_path) |path| {
+        ext_ccd = try loadExternalCcd(allocator, io, path, load_quiet);
+    }
+    defer if (ext_ccd) |*d| d.deinit();
+
+    const workflow_sdf_paths: []const []const u8 = workflow.classifier.sdf orelse &.{};
+    const sdf_paths = resolveWorkflowSdfPaths(args, workflow_sdf_paths, effective_classifier_type);
+    var sdf_ccd: ?ccd_parser.ComponentDict = null;
+    if (sdf_paths.len > 0) {
+        sdf_ccd = loadSdfComponents(allocator, io, sdf_paths, load_quiet) catch |err| {
+            std.debug.print("Error loading SDF components: {s}\n", .{@errorName(err)});
+            return err;
+        };
+    }
+    defer if (sdf_ccd) |*d| d.deinit();
+
+    var custom_classifier: ?classifier.Classifier = null;
+    const custom_classifier_path: ?[]const u8 = if (!args.classifier_explicit and workflow.classifier.type != null and std.mem.eql(u8, workflow.classifier.type.?, "custom"))
+        workflow.classifier.config
+    else
+        null;
+    if (custom_classifier_path) |path| {
+        custom_classifier = try loadCustomClassifier(allocator, io, path);
+    }
+    defer if (custom_classifier) |*c| c.deinit();
+
+    resource_config.external_ccd = if (ext_ccd != null) &ext_ccd.? else null;
+    resource_config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
+    if (custom_classifier) |*c| resource_config.custom_classifier = c;
+
+    var states = try allocator.alloc(WorkflowJobState, workflow.jobs.len);
+    var states_initialized: usize = 0;
+    errdefer {
+        for (states[0..states_initialized]) |*state| state.deinit(allocator);
+        allocator.free(states);
+    }
+    for (workflow.jobs, 0..) |job, i| {
+        var config = BatchConfig{};
+        try applyWorkflowToBatchConfig(&config, args, workflow.calculation, workflow.output, workflow.classifier);
+        applyCliOverrides(&config, args);
+        config.include_hetatm = config.include_hetatm or (config.classifier_type == .ccd);
+        config.store_atom_areas = (config.output_format == .jsonl);
+        config.external_ccd = if (ext_ccd != null) &ext_ccd.? else null;
+        config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
+        if (custom_classifier) |*c| config.custom_classifier = c;
+        applyWorkflowJobOverrides(&config, args, job);
+        validateResidueMapFormat(config.output_format, config.residue_map) catch {
+            std.debug.print("Error: residue_map is only supported with format = \"jsonl\"\n", .{});
+            return error.InvalidArgument;
+        };
+
+        if ((config.classifier_type == .ccd or config.classifier_type == .protor) and config.include_hydrogens and !config.quiet) {
+            std.debug.print("Warning: --include-hydrogens with CCD classifier may give inaccurate results\n", .{});
+            std.debug.print("         CCD uses united-atom radii that already account for implicit hydrogens\n", .{});
+        }
+
+        var job_output_dir: ?[]const u8 = null;
+        var jsonl_output_path: ?[]const u8 = null;
+        errdefer if (job_output_dir) |path| allocator.free(path);
+        errdefer if (jsonl_output_path) |path| allocator.free(path);
+
+        if (config.output_format == .jsonl) {
+            if (output_dir) |out| {
+                try std.Io.Dir.cwd().createDirPath(io, out);
+                jsonl_output_path = try workflowJsonlOutputPath(allocator, out, job.name);
+                try truncateJsonlOutput(io, jsonl_output_path.?);
+            }
+        } else if (output_dir) |out| {
+            job_output_dir = try workflowPerFileOutputDir(allocator, out, job.name);
+            try std.Io.Dir.cwd().createDirPath(io, job_output_dir.?);
+        }
+
+        states[i] = .{
+            .name = job.name,
+            .config = config,
+            .output_dir = job_output_dir,
+            .jsonl_output_path = jsonl_output_path,
+        };
+        states_initialized += 1;
+    }
+    defer {
+        for (states) |*state| state.deinit(allocator);
+        allocator.free(states);
+    }
+
+    const files = try scanDirectory(allocator, io, input_dir);
+    defer {
+        for (files) |f| allocator.free(f);
+        allocator.free(files);
+    }
+
+    var luts = try BatchLuts.init(allocator, resource_config);
+    defer luts.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    for (files) |filename| {
+        const input_path = try std.fs.path.join(arena.allocator(), &.{ input_dir, filename });
+
+        var source_config = resource_config;
+        source_config.chain_filter = null;
+        var source_input = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
+            for (states) |*state| {
+                state.failed += 1;
+                std.debug.print("Error running workflow job '{s}' on '{s}': read/parse failed: {s}\n", .{ state.name, filename, @errorName(err) });
+            }
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        if (source_config.custom_classifier) |custom| {
+            if (source_input.hasClassificationInfo()) {
+                applyCustomClassifier(&source_input, custom, source_config.quiet) catch |err| {
+                    for (states) |*state| {
+                        state.failed += 1;
+                        std.debug.print("Error running workflow job '{s}' on '{s}': classifier failed: {s}\n", .{ state.name, filename, @errorName(err) });
+                    }
+                    source_input.deinit();
+                    _ = arena.reset(.retain_capacity);
+                    continue;
+                };
+            }
+        } else if (source_config.classifier_type) |ct| {
+            const format = format_detect.detectInputFormat(input_path);
+            if (format != .json and source_input.hasClassificationInfo()) {
+                applyBuiltinClassifier(&source_input, ct, source_config.sdf_ccd, source_config.external_ccd) catch |err| {
+                    for (states) |*state| {
+                        state.failed += 1;
+                        std.debug.print("Error running workflow job '{s}' on '{s}': classifier failed: {s}\n", .{ state.name, filename, @errorName(err) });
+                    }
+                    source_input.deinit();
+                    _ = arena.reset(.retain_capacity);
+                    continue;
+                };
+            }
+        }
+
+        for (workflow.jobs, 0..) |job, job_index| {
+            var state = &states[job_index];
+            if (!state.config.quiet) std.debug.print("Workflow job: {s}\n", .{state.name});
+
+            const selected_chains: ?[]const []const u8 = if (format_detect.detectInputFormat(input_path) == .json) null else job.chains;
+            var selected_input = copySelectedAtomInput(arena.allocator(), source_input, selected_chains) catch |err| {
+                state.failed += 1;
+                std.debug.print("Error running workflow job '{s}' on '{s}': selection failed: {s}\n", .{ state.name, filename, @errorName(err) });
+                continue;
+            };
+            defer selected_input.deinit();
+
+            var result = switch (state.config.precision) {
+                .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, 1, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+                .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, allocator, selected_input, state.output_dir, filename, state.config, 1, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+            };
+            defer if (result.error_msg) |msg| allocator.free(msg);
+
+            if (result.status == .ok) {
+                state.successful += 1;
+                state.total_sasa_time_ns += result.sasa_time_ns;
+            } else {
+                state.failed += 1;
+            }
+
+            if (state.config.output_format == .jsonl) {
+                if (state.jsonl_output_path) |path| {
+                    const file = try std.Io.Dir.cwd().openFile(io, path, .{ .mode = .write_only });
+                    defer file.close(io);
+                    try appendJsonlResultToFile(io, file, arena.allocator(), &result);
+                } else {
+                    var stdout_write_buf: [64 * 1024]u8 = undefined;
+                    var stdout_writer = std.Io.File.Writer.initStreaming(std.Io.File.stdout(), io, &stdout_write_buf);
+                    writeJsonlResult(&stdout_writer, arena.allocator(), &result);
+                }
+            }
+
+            result.atom_areas = null;
+            result.residue_map = null;
+        }
+
+        source_input.deinit();
+        _ = arena.reset(.retain_capacity);
+    }
+
+    var successful: usize = 0;
+    var failed: usize = 0;
+    for (states) |state| {
+        successful += state.successful;
+        failed += state.failed;
+    }
     std.debug.print("Workflow complete: {d} successful, {d} failed\n", .{ successful, failed });
 }
 
@@ -3451,6 +3740,89 @@ test "workflowPerFileOutputDir uses job directory under output dir" {
     const path = try workflowPerFileOutputDir(std.testing.allocator, "results", "complex_AB");
     defer std.testing.allocator.free(path);
     try std.testing.expectEqualStrings("results/complex_AB", path);
+}
+
+test "workflowInputContainsSdf detects SDF files in workflow input directory" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDir(std.testing.io, "inputs", .default_dir);
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "inputs/protein.pdb", .data = "" });
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "inputs/ligand.sdf", .data = "" });
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+    const input_path = try std.fs.path.join(allocator, &.{ root, "inputs" });
+    defer allocator.free(input_path);
+    const workflow_path = try std.fs.path.join(allocator, &.{ root, "workflow.toml" });
+    defer allocator.free(workflow_path);
+
+    const workflow_text = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[[jobs]]
+        \\name = "all"
+        \\
+    , .{input_path});
+    defer allocator.free(workflow_text);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow_text });
+
+    const args = BatchArgs{ .workflow_path = workflow_path };
+    try std.testing.expect(try workflowInputContainsSdf(allocator, std.testing.io, args));
+}
+
+test "appendJsonlResultToFile appends without truncating existing JSONL content" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const output_path = try std.fs.path.join(allocator, &.{ root_buf[0..root_len], "results.jsonl" });
+    defer allocator.free(output_path);
+
+    try truncateJsonlOutput(std.testing.io, output_path);
+
+    const areas = [_]f64{1.0};
+    var first = FileResult{
+        .filename = "first.pdb",
+        .n_atoms = 1,
+        .sasa_time_ns = 1,
+        .total_sasa = 1.0,
+        .status = .ok,
+        .atom_areas = areas[0..],
+    };
+    var second = FileResult{
+        .filename = "second.pdb",
+        .n_atoms = 1,
+        .sasa_time_ns = 1,
+        .total_sasa = 1.0,
+        .status = .ok,
+        .atom_areas = areas[0..],
+    };
+
+    {
+        const file = try std.Io.Dir.cwd().openFile(std.testing.io, output_path, .{ .mode = .write_only });
+        defer file.close(std.testing.io);
+        try appendJsonlResultToFile(std.testing.io, file, allocator, &first);
+    }
+    {
+        const file = try std.Io.Dir.cwd().openFile(std.testing.io, output_path, .{ .mode = .write_only });
+        defer file.close(std.testing.io);
+        try appendJsonlResultToFile(std.testing.io, file, allocator, &second);
+    }
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(4096));
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"filename\":\"first.pdb\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"filename\":\"second.pdb\"") != null);
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, content, "\n"));
 }
 
 test "FileResult JSONL uses residue map serializer when present" {

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -98,7 +98,7 @@ Run it with:
 zsasa batch --workflow bsa.toml
 ```
 
-For ordinary PDB/mmCIF/BinaryCIF workflow batch runs with compatible chain-ID settings, zsasa reuses each parsed input structure across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; eligible runs parse each input structure once and then compute each requested chain selection independently. Some inputs or settings, such as SDF files or per-job `auth_chain` changes, use the compatibility job-first path instead.
+For ordinary PDB, JSON, and unfiltered mmCIF/BinaryCIF workflow batch runs with compatible chain-ID settings, zsasa reuses each parsed input structure across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; eligible runs parse each input structure once and then compute each requested chain selection independently. Some inputs or settings, such as SDF files, per-job `auth_chain` changes, or mmCIF/BinaryCIF workflows with chain filters, use the compatibility job-first path instead so full chain-ID selection matches parser behavior.
 
 ## Override Precedence
 

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -98,7 +98,7 @@ Run it with:
 zsasa batch --workflow bsa.toml
 ```
 
-Workflow batch runs reuse parsed structures across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; zsasa will parse each input structure once and then compute each requested chain selection independently.
+For ordinary PDB/mmCIF/BinaryCIF workflow batch runs with compatible chain-ID settings, zsasa reuses each parsed input structure across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; eligible runs parse each input structure once and then compute each requested chain selection independently. Some inputs or settings, such as SDF files or per-job `auth_chain` changes, use the compatibility job-first path instead.
 
 ## Override Precedence
 

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -98,6 +98,8 @@ Run it with:
 zsasa batch --workflow bsa.toml
 ```
 
+Workflow batch runs reuse parsed structures across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; zsasa will parse each input structure once and then compute each requested chain selection independently.
+
 ## Override Precedence
 
 When the same setting appears in multiple places, zsasa applies this order:


### PR DESCRIPTION
## Summary
- Add workflow-specific file-first batch execution for eligible non-SDF inputs so named chain jobs can reuse parsed/classified structures across jobs.
- Preserve compatibility with job-first fallbacks for SDF inputs, per-job `auth_chain` changes, and mmCIF/BinaryCIF chain-filtered workflows with long chain IDs.
- Add regression coverage for workflow output layouts and long-chain filtering, plus docs clarifying reuse eligibility.

## Test Plan
- [x] `zig fmt --check src/`
- [x] `zig build test --summary all` (`900/902 tests passed`, 2 skipped)
- [x] `zig build -Doptimize=ReleaseFast`
- [x] `./zig-out/bin/zsasa batch --workflow test_data/workflow-batch.toml` (`Workflow complete: 5 successful, 0 failed`)
