### PR TITLE
test: cover batch JSONL and FFI concurrency

### DIFF
--- a/python/tests/test_batch_dir.py
+++ b/python/tests/test_batch_dir.py
@@ -101,9 +101,7 @@ class TestProcessDirectory:
 
     def test_process_directory_naccess_classifier(self) -> None:
         """Process with NACCESS classifier."""
-        result = process_directory(
-            TEST_DATA_DIR, classifier=ClassifierType.NACCESS
-        )
+        result = process_directory(TEST_DATA_DIR, classifier=ClassifierType.NACCESS)
 
         assert result.successful > 0
 
@@ -133,6 +131,43 @@ class TestProcessDirectory:
         result = process_directory(TEST_DATA_DIR, n_threads=1)
 
         assert result.successful > 0
+
+    def test_process_directory_parallel_matches_single_thread(self) -> None:
+        """Parallel directory processing should match single-thread results."""
+        result_1 = process_directory(TEST_DATA_DIR, n_threads=1)
+        result_4 = process_directory(TEST_DATA_DIR, n_threads=4)
+
+        assert result_4.total_files == result_1.total_files
+        assert result_4.successful == result_1.successful
+        assert result_4.failed == result_1.failed
+
+        by_name_1 = {
+            filename: (n_atoms, total_sasa, status)
+            for filename, n_atoms, total_sasa, status in zip(
+                result_1.filenames,
+                result_1.n_atoms,
+                result_1.total_sasa,
+                result_1.status,
+                strict=True,
+            )
+        }
+        by_name_4 = {
+            filename: (n_atoms, total_sasa, status)
+            for filename, n_atoms, total_sasa, status in zip(
+                result_4.filenames,
+                result_4.n_atoms,
+                result_4.total_sasa,
+                result_4.status,
+                strict=True,
+            )
+        }
+        assert by_name_4.keys() == by_name_1.keys()
+        for filename, (n_atoms_1, total_sasa_1, status_1) in by_name_1.items():
+            n_atoms_4, total_sasa_4, status_4 = by_name_4[filename]
+            assert n_atoms_4 == n_atoms_1
+            assert status_4 == status_1
+            if status_1 == 1:
+                assert total_sasa_4 == pytest.approx(total_sasa_1)
 
     def test_process_directory_repr(self) -> None:
         """BatchDirResult repr shows summary counts."""

--- a/python/tests/test_thread_stress.py
+++ b/python/tests/test_thread_stress.py
@@ -1,0 +1,86 @@
+"""Thread-stress tests for Python FFI entry points."""
+
+from __future__ import annotations
+
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from zsasa import calculate_sasa, process_directory
+from zsasa.xtc import XtcReader
+
+TEST_DATA_DIR = Path(__file__).parent.parent.parent / "test_data"
+PDB_FILE = TEST_DATA_DIR / "1l2y.pdb"
+XTC_FILE = TEST_DATA_DIR / "1l2y.xtc"
+
+
+def test_calculate_sasa_is_stable_from_multiple_python_threads() -> None:
+    """Concurrent calculate_sasa calls should not crash or drift."""
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [3.0, 0.0, 0.0],
+            [0.0, 3.0, 0.0],
+            [0.0, 0.0, 3.0],
+        ],
+        dtype=np.float64,
+    )
+    radii = np.full(4, 1.7, dtype=np.float64)
+    baseline = calculate_sasa(coords, radii, n_points=64, n_threads=1)
+
+    def worker(_: int) -> tuple[float, np.ndarray]:
+        last = baseline
+        for _ in range(20):
+            last = calculate_sasa(coords, radii, n_points=64, n_threads=2)
+        return last.total_area, last.atom_areas.copy()
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(worker, range(4)))
+
+    for total_area, atom_areas in results:
+        assert total_area == pytest.approx(baseline.total_area)
+        np.testing.assert_allclose(atom_areas, baseline.atom_areas)
+
+
+def test_xtc_readers_can_open_and_read_concurrently() -> None:
+    """Independent XtcReader handles should work from multiple Python threads."""
+    if not XTC_FILE.exists():
+        pytest.skip("XTC fixture not available")
+
+    def worker(_: int) -> list[int]:
+        steps: list[int] = []
+        with XtcReader(XTC_FILE) as reader:
+            for _ in range(3):
+                frame = reader.read_frame()
+                assert frame is not None
+                steps.append(frame.step)
+        return steps
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(worker, range(4)))
+
+    assert results == [[1, 2, 3]] * 4
+
+
+def test_process_directory_can_run_concurrently(tmp_path: Path) -> None:
+    """Independent process_directory calls should be safe in parallel."""
+    input_a = tmp_path / "a"
+    input_b = tmp_path / "b"
+    input_a.mkdir()
+    input_b.mkdir()
+    shutil.copy(PDB_FILE, input_a / "1l2y-a.pdb")
+    shutil.copy(PDB_FILE, input_b / "1l2y-b.pdb")
+
+    def worker(path: Path) -> tuple[int, int, int, float]:
+        result = process_directory(path, n_threads=2)
+        return result.total_files, result.successful, result.failed, result.total_sasa[0]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        result_a, result_b = list(executor.map(worker, [input_a, input_b]))
+
+    assert result_a[:3] == (1, 1, 0)
+    assert result_b[:3] == (1, 1, 0)
+    assert result_a[3] == pytest.approx(result_b[3])

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -4155,6 +4155,121 @@ test "FileResult JSONL uses residue map serializer when present" {
     try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_sasa\":[3]") != null);
 }
 
+test "JsonlStreamWriter writes many parseable JSONL lines" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const output_path = try std.fs.path.join(allocator, &.{ root_buf[0..root_len], "stream.jsonl" });
+    defer allocator.free(output_path);
+
+    const file = try std.Io.Dir.cwd().createFile(std.testing.io, output_path, .{});
+    var stream = JsonlStreamWriter{ .file = file, .io = std.testing.io };
+
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    const atom_areas = [_]f64{ 1.0, 2.0, 3.0 };
+    var name_buf: [32]u8 = undefined;
+    for (0..50) |i| {
+        _ = arena.reset(.retain_capacity);
+        const name = try std.fmt.bufPrint(&name_buf, "file-{d}.pdb", .{i});
+        var result = FileResult{
+            .filename = name,
+            .n_atoms = atom_areas.len,
+            .sasa_time_ns = 1,
+            .total_sasa = 6.0,
+            .status = .ok,
+            .atom_areas = atom_areas[0..],
+        };
+        stream.writeResult(arena.allocator(), &result);
+        try std.testing.expect(!stream.hasError());
+    }
+    file.close(std.testing.io);
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(64 * 1024));
+    defer allocator.free(content);
+    try std.testing.expectEqual(@as(usize, 50), std.mem.count(u8, content, "\n"));
+
+    var lines = std.mem.tokenizeScalar(u8, content, '\n');
+    var count: usize = 0;
+    while (lines.next()) |line| {
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const object = parsed.value.object;
+        try std.testing.expect(object.get("filename") != null);
+        try std.testing.expect(object.get("atom_areas") != null);
+        count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 50), count);
+}
+
+test "runBatchParallel writes parseable JSONL with multiple threads" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root_path = root_buf[0..root_len];
+
+    const input_dir = try std.fs.path.join(allocator, &.{ root_path, "input" });
+    defer allocator.free(input_dir);
+    const output_path = try std.fs.path.join(allocator, &.{ root_path, "results.jsonl" });
+    defer allocator.free(output_path);
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+
+    const pdb_data =
+        "ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00 20.00           N\n" ++
+        "ATOM      2  CA  ALA A   1       1.500   0.000   0.000  1.00 20.00           C\n" ++
+        "ATOM      3  C   ALA A   1       3.000   0.000   0.000  1.00 20.00           C\n" ++
+        "END\n";
+
+    var name_buf: [32]u8 = undefined;
+    for (0..10) |i| {
+        const filename = try std.fmt.bufPrint(&name_buf, "tiny-{d}.pdb", .{i});
+        const path = try std.fs.path.join(allocator, &.{ input_dir, filename });
+        defer allocator.free(path);
+        try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = path, .data = pdb_data });
+    }
+
+    var result = try runBatchParallel(allocator, std.testing.io, input_dir, null, .{
+        .n_threads = 4,
+        .algorithm = .sr,
+        .n_points = 8,
+        .quiet = true,
+        .show_progress = false,
+        .output_format = .jsonl,
+        .store_atom_areas = true,
+        .classifier_type = .naccess,
+    }, output_path);
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 10), result.total_files);
+    try std.testing.expectEqual(@as(usize, 10), result.successful);
+    try std.testing.expectEqual(@as(usize, 0), result.failed);
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(64 * 1024));
+    defer allocator.free(content);
+    try std.testing.expectEqual(@as(usize, 10), std.mem.count(u8, content, "\n"));
+
+    var lines = std.mem.tokenizeScalar(u8, content, '\n');
+    var count: usize = 0;
+    while (lines.next()) |line| {
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const object = parsed.value.object;
+        try std.testing.expect(object.get("filename") != null);
+        try std.testing.expect(object.get("total_area") != null);
+        try std.testing.expect(object.get("atom_areas") != null);
+        try std.testing.expectEqual(@as(usize, 3), object.get("atom_areas").?.array.items.len);
+        count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 10), count);
+}
+
 test "BatchArgs explicit option flags" {
     const args = [_][]const u8{
         "zsasa", "batch", "--threads=8", "--n-points=128", "--format=jsonl", "--use-bitmask", "input_dir/",

--- a/src/ccd_binary.zig
+++ b/src/ccd_binary.zig
@@ -121,10 +121,15 @@ pub fn isBinaryDict(data: []const u8) bool {
     return std.mem.eql(u8, data[0..4], &MAGIC);
 }
 
+fn componentIdLessThan(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
 /// Write a ComponentDict to binary ZSDC format.
 pub fn writeDict(writer: *std.Io.Writer, dict: *const ccd_parser.ComponentDict) !void {
     // Count components
-    const comp_count: u32 = @intCast(dict.components.count());
+    const comp_count_usize = dict.components.count();
+    const comp_count: u32 = @intCast(comp_count_usize);
 
     // Write header
     try writer.writeAll(&MAGIC);
@@ -132,11 +137,22 @@ pub fn writeDict(writer: *std.Io.Writer, dict: *const ccd_parser.ComponentDict) 
     try writer.writeAll(&[3]u8{ 0, 0, 0 }); // reserved
     try writer.writeAll(&std.mem.toBytes(std.mem.nativeToLittle(u32, comp_count)));
 
-    // Write each component
+    // Hash-map iteration order is intentionally not stable, but compiled ZSDC
+    // bytes are build artifacts and should be reproducible. Write components in
+    // component-ID order instead of raw map iteration order.
+    const comp_ids = try dict.allocator.alloc([]const u8, comp_count_usize);
+    defer dict.allocator.free(comp_ids);
+
+    var idx: usize = 0;
     var it = dict.components.iterator();
-    while (it.next()) |entry| {
-        const comp_id = entry.key_ptr.*;
-        const stored = entry.value_ptr;
+    while (it.next()) |entry| : (idx += 1) {
+        comp_ids[idx] = entry.key_ptr.*;
+    }
+    std.mem.sort([]const u8, comp_ids, {}, componentIdLessThan);
+
+    // Write each component
+    for (comp_ids) |comp_id| {
+        const stored = dict.components.getPtr(comp_id) orelse return error.InvalidDict;
 
         // Component ID
         const cid_len: u8 = @intCast(@min(comp_id.len, 255));
@@ -371,6 +387,110 @@ test "round-trip: empty dictionary" {
     defer read_dict.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), read_dict.components.count());
+}
+
+fn addTestComponent(allocator: Allocator, dict: *ccd_parser.ComponentDict, comp_id: []const u8) !void {
+    const atoms = try allocator.alloc(CompAtom, 1);
+    atoms[0] = CompAtom.init("C1", "C");
+
+    const bonds = try allocator.alloc(CompBond, 0);
+    const key = try allocator.dupe(u8, comp_id);
+    errdefer allocator.free(key);
+
+    var stored_id = [_]u8{ 0, 0, 0, 0, 0 };
+    const id_len = @min(comp_id.len, stored_id.len);
+    @memcpy(stored_id[0..id_len], comp_id[0..id_len]);
+
+    const stored = ccd_parser.StoredComponent{
+        .comp_id = stored_id,
+        .comp_id_len = @intCast(id_len),
+        .atoms = atoms,
+        .bonds = bonds,
+        .allocator = allocator,
+    };
+    try dict.components.put(allocator, key, stored);
+    try dict.owned_keys.append(allocator, key);
+}
+
+fn writeTestDictAlloc(allocator: Allocator, dict: *const ccd_parser.ComponentDict) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    try writeDict(&out.writer, dict);
+    return out.toOwnedSlice();
+}
+
+test "writeDict emits deterministic bytes independent of insertion order" {
+    const allocator = std.testing.allocator;
+    const ids = [_][]const u8{ "ZZZ", "AAA", "MSE", "HOH", "ATP", "GLY" };
+
+    var forward = ccd_parser.ComponentDict.init(allocator);
+    defer forward.deinit();
+    for (ids) |id| try addTestComponent(allocator, &forward, id);
+
+    var reverse = ccd_parser.ComponentDict.init(allocator);
+    defer reverse.deinit();
+    var i = ids.len;
+    while (i > 0) {
+        i -= 1;
+        try addTestComponent(allocator, &reverse, ids[i]);
+    }
+
+    const forward_bytes = try writeTestDictAlloc(allocator, &forward);
+    defer allocator.free(forward_bytes);
+    const reverse_bytes = try writeTestDictAlloc(allocator, &reverse);
+    defer allocator.free(reverse_bytes);
+
+    try std.testing.expectEqualSlices(u8, forward_bytes, reverse_bytes);
+}
+
+test "writeDict emits components sorted by component ID" {
+    const allocator = std.testing.allocator;
+    const ids = [_][]const u8{ "ZZZ", "AAA", "MSE", "HOH", "ATP", "GLY" };
+
+    var dict = ccd_parser.ComponentDict.init(allocator);
+    defer dict.deinit();
+    for (ids) |id| try addTestComponent(allocator, &dict, id);
+
+    const bytes = try writeTestDictAlloc(allocator, &dict);
+    defer allocator.free(bytes);
+
+    var reader = std.Io.Reader.fixed(bytes);
+    var loaded = try readDict(allocator, &reader);
+    defer loaded.deinit();
+
+    const sorted_ids = [_][]const u8{ "AAA", "ATP", "GLY", "HOH", "MSE", "ZZZ" };
+    var offset: usize = HEADER_SIZE;
+    for (sorted_ids) |expected_id| {
+        const actual_len = bytes[offset];
+        offset += 1;
+        try std.testing.expectEqual(expected_id.len, actual_len);
+        try std.testing.expectEqualStrings(expected_id, bytes[offset .. offset + actual_len]);
+        offset += actual_len;
+        const atom_count = std.mem.littleToNative(u16, std.mem.bytesToValue(u16, bytes[offset .. offset + 2]));
+        offset += 2 + (@as(usize, atom_count) * @sizeOf(PackedAtom));
+        const bond_count = std.mem.littleToNative(u16, std.mem.bytesToValue(u16, bytes[offset .. offset + 2]));
+        offset += 2 + (@as(usize, bond_count) * @sizeOf(PackedBond));
+    }
+    try std.testing.expectEqual(bytes.len, offset);
+    try std.testing.expectEqual(@as(usize, sorted_ids.len), loaded.components.count());
+}
+
+test "writeDict synthetic fixture hash is stable" {
+    const allocator = std.testing.allocator;
+    const ids = [_][]const u8{ "ZZZ", "AAA", "MSE", "HOH", "ATP", "GLY" };
+
+    var dict = ccd_parser.ComponentDict.init(allocator);
+    defer dict.deinit();
+    for (ids) |id| try addTestComponent(allocator, &dict, id);
+
+    const bytes = try writeTestDictAlloc(allocator, &dict);
+    defer allocator.free(bytes);
+
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+    var digest: [Sha256.digest_length]u8 = undefined;
+    Sha256.hash(bytes, &digest, .{});
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    try std.testing.expectEqualStrings("3f759a9f4de717c8d3232694cfaca01bddf48a2ca041591064c6b035e2e10913", &hex);
 }
 
 test "loadDict — auto-detect binary" {


### PR DESCRIPTION
## Summary

- Add Zig coverage for `JsonlStreamWriter` and `runBatchParallel` JSONL output with multiple worker threads.
- Add Python thread-stress tests for concurrent `calculate_sasa`, independent `XtcReader` handles, and concurrent `process_directory` calls.
- Make compiled CCD dictionary output deterministic by writing components sorted by component ID, with insertion-order and fixture-hash regression tests.

## Motivation

Closes #346, #347, and #348. These were follow-up test coverage gaps from the Zig 0.16 migration around parallel JSONL output, FFI concurrency, and HashMap iteration order in compiled ZSDC files.

## Validation

- `zig build test --summary all`
- `zig fmt --check src/`
- `zig build -Doptimize=ReleaseFast`
- `cd python && uv run ruff format --check tests/test_batch_dir.py tests/test_thread_stress.py`
- `cd python && uv run ruff check tests/test_batch_dir.py tests/test_thread_stress.py`
- `cd python && uv run pytest tests/test_batch_dir.py tests/test_thread_stress.py -q`
- `git diff --check`
