### PR TITLE
chore: use ztraj for trajectory readers

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,7 +4,7 @@ zsasa includes code derived from the following projects.
 
 ## libxdrfile (via chemfiles/xdrfile)
 
-- **Used in**: `zxdrfile` dependency (https://github.com/N283T/zxdrfile) — Zig port of XTC trajectory reader
+- **Used in**: `ztraj` dependency (https://github.com/N283T/ztraj) — Zig molecular trajectory toolkit used by zsasa trajectory mode
 - **Source**: https://github.com/chemfiles/xdrfile
 - **Original**: GROMACS libxdrfile 1.1.4
 - **License**: BSD-2-Clause

--- a/build.zig
+++ b/build.zig
@@ -12,11 +12,11 @@ pub fn build(b: *std.Build) void {
         .target = target,
     });
 
-    const zxdrfile_dep = b.dependency("zxdrfile", .{
+    const ztraj_dep = b.dependency("ztraj", .{
         .target = target,
         .optimize = optimize,
     });
-    const zxdrfile_mod = zxdrfile_dep.module("zxdrfile");
+    const ztraj_mod = ztraj_dep.module("ztraj");
 
     // CLI executable
     const options = b.addOptions();
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "zsasa", .module = mod },
             .{ .name = "build_options", .module = options_mod },
-            .{ .name = "zxdrfile", .module = zxdrfile_mod },
+            .{ .name = "ztraj", .module = ztraj_mod },
         },
     });
 
@@ -52,7 +52,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
         .imports = &.{
-            .{ .name = "zxdrfile", .module = zxdrfile_mod },
+            .{ .name = "ztraj", .module = ztraj_mod },
         },
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,9 +32,9 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        .zxdrfile = .{
-            .url = "git+https://github.com/N283T/zxdrfile.git?ref=v0.4.0#47d8c42cff9b098febd1990cc50438c26987f85c",
-            .hash = "zxdrfile-0.4.0-JIaQ9mIfAgAHB9bW-_p9g6_gfd0tyG3-MmA0LYJKB8rb",
+        .ztraj = .{
+            .url = "git+https://github.com/N283T/ztraj.git?ref=main#b18c4e3ddf8f07ae348a1f0ce0aaaa36c98e227f",
+            .hash = "ztraj-0.8.0-gW3cDGFrDwD-nnp9izIfabX81qKC4bCm0uW0dOTZMGRs",
         },
     },
     .paths = .{

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -15,8 +15,9 @@ const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
 const analysis = @import("analysis.zig");
-const xtc = @import("zxdrfile").xtc;
-const dcd = @import("dcd.zig");
+const ztraj = @import("ztraj");
+const xtc = ztraj.io.xtc;
+const dcd = ztraj.io.dcd;
 const batch = @import("batch.zig");
 
 const AtomInput = types.AtomInput;
@@ -1469,15 +1470,15 @@ export fn zsasa_xtc_open(
     handle.reader = xtc.XtcReader.open(cIo(), c_allocator, path_slice) catch |err| {
         c_allocator.destroy(handle);
         error_code.* = switch (err) {
-            xtc.XtcError.FileNotFound => ZSASA_ERROR_INVALID_INPUT,
-            xtc.XtcError.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
-            xtc.XtcError.OutOfMemory => ZSASA_ERROR_OUT_OF_MEMORY,
+            error.FileNotFound => ZSASA_ERROR_INVALID_INPUT,
+            error.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
+            error.OutOfMemory => ZSASA_ERROR_OUT_OF_MEMORY,
             else => ZSASA_ERROR_CALCULATION,
         };
         return null;
     };
 
-    natoms_out.* = handle.reader.getNumAtoms();
+    natoms_out.* = @intCast(handle.reader.nAtoms());
     error_code.* = ZSASA_OK;
     return handle;
 }
@@ -1491,7 +1492,7 @@ export fn zsasa_xtc_close(
 ) callconv(.c) void {
     if (handle) |h| {
         const xtc_handle: *XtcHandle = @ptrCast(@alignCast(h));
-        xtc_handle.reader.close();
+        xtc_handle.reader.deinit();
         c_allocator.destroy(xtc_handle);
     }
 }
@@ -1524,31 +1525,41 @@ export fn zsasa_xtc_read_frame(
 
     const xtc_handle: *XtcHandle = @ptrCast(@alignCast(handle.?));
 
-    var frame = xtc_handle.reader.readFrame() catch |err| {
+    const frame = (xtc_handle.reader.next() catch |err| {
         return switch (err) {
-            xtc.XtcError.EndOfFile => ZSASA_XTC_END_OF_FILE,
-            xtc.XtcError.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
-            xtc.XtcError.DecompressionError => ZSASA_ERROR_CALCULATION,
+            error.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
+            error.DecompressionError => ZSASA_ERROR_CALCULATION,
             else => ZSASA_ERROR_CALCULATION,
         };
-    };
-    defer frame.deinit(c_allocator);
+    }) orelse return ZSASA_XTC_END_OF_FILE;
 
-    // Copy step, time, precision
+    // Copy step, time, precision. ztraj's high-level XTC reader normalizes to Å
+    // and does not expose per-frame precision, so preserve the historical C ABI
+    // contract with the default XTC precision.
     step_out.* = frame.step;
     time_out.* = frame.time;
-    precision_out.* = frame.precision;
+    precision_out.* = 1000.0;
 
-    // Copy box (3x3 matrix, row-major)
-    for (0..3) |i| {
-        for (0..3) |j| {
-            box_out[i * 3 + j] = frame.box[i][j];
+    // Copy box (3x3 matrix, row-major) in nm for the public XTC C/Python API.
+    if (frame.box_vectors) |box| {
+        for (0..3) |i| {
+            for (0..3) |j| {
+                box_out[i * 3 + j] = box[i][j] / 10.0;
+            }
+        }
+    } else {
+        for (0..9) |i| {
+            box_out[i] = 0.0;
         }
     }
 
-    // Copy coordinates
-    const natoms: usize = @intCast(xtc_handle.reader.getNumAtoms());
-    @memcpy(coords_out[0 .. natoms * 3], frame.coords);
+    // Copy coordinates in nm for the public XTC C/Python API.
+    const natoms: usize = @intCast(xtc_handle.reader.nAtoms());
+    for (0..natoms) |i| {
+        coords_out[i * 3 + 0] = frame.x[i] / 10.0;
+        coords_out[i * 3 + 1] = frame.y[i] / 10.0;
+        coords_out[i * 3 + 2] = frame.z[i] / 10.0;
+    }
 
     return ZSASA_OK;
 }
@@ -1567,7 +1578,7 @@ export fn zsasa_xtc_get_natoms(
         return -1;
     }
     const xtc_handle: *XtcHandle = @ptrCast(@alignCast(handle.?));
-    return xtc_handle.reader.getNumAtoms();
+    return @intCast(xtc_handle.reader.nAtoms());
 }
 
 // Tests
@@ -2144,18 +2155,18 @@ export fn zsasa_dcd_open(
         return null;
     };
 
-    handle.reader = dcd.DcdReader.open(c_allocator, cIo(), path_slice) catch |err| {
+    handle.reader = dcd.DcdReader.open(cIo(), c_allocator, path_slice) catch |err| {
         c_allocator.destroy(handle);
         error_code.* = switch (err) {
-            dcd.DcdError.FileNotFound => ZSASA_ERROR_INVALID_INPUT,
-            dcd.DcdError.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
-            dcd.DcdError.OutOfMemory => ZSASA_ERROR_OUT_OF_MEMORY,
+            error.FileNotFound => ZSASA_ERROR_INVALID_INPUT,
+            error.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
+            error.OutOfMemory => ZSASA_ERROR_OUT_OF_MEMORY,
             else => ZSASA_ERROR_CALCULATION,
         };
         return null;
     };
 
-    natoms_out.* = handle.reader.getNumAtoms();
+    natoms_out.* = @intCast(handle.reader.nAtoms());
     error_code.* = ZSASA_OK;
     return handle;
 }
@@ -2169,7 +2180,7 @@ export fn zsasa_dcd_close(
 ) callconv(.c) void {
     if (handle) |h| {
         const dcd_handle: *DcdHandle = @ptrCast(@alignCast(h));
-        dcd_handle.reader.close();
+        dcd_handle.reader.deinit();
         c_allocator.destroy(dcd_handle);
     }
 }
@@ -2200,14 +2211,12 @@ export fn zsasa_dcd_read_frame(
 
     const dcd_handle: *DcdHandle = @ptrCast(@alignCast(handle.?));
 
-    var frame = dcd_handle.reader.readFrame() catch |err| {
+    const frame = (dcd_handle.reader.next() catch |err| {
         return switch (err) {
-            dcd.DcdError.EndOfFile => ZSASA_DCD_END_OF_FILE,
-            dcd.DcdError.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
+            error.InvalidMagic => ZSASA_ERROR_INVALID_INPUT,
             else => ZSASA_ERROR_CALCULATION,
         };
-    };
-    defer frame.deinit(c_allocator);
+    }) orelse return ZSASA_DCD_END_OF_FILE;
 
     // Copy step, time
     step_out.* = frame.step;
@@ -2215,10 +2224,13 @@ export fn zsasa_dcd_read_frame(
 
     // Copy unitcell if present and output buffer provided
     if (unitcell_out) |uc_out| {
-        if (frame.unitcell) |uc| {
-            for (0..6) |i| {
-                uc_out[i] = uc[i];
-            }
+        if (frame.box_vectors) |box| {
+            uc_out[0] = box[0][0];
+            uc_out[1] = 90.0;
+            uc_out[2] = box[1][1];
+            uc_out[3] = 90.0;
+            uc_out[4] = 90.0;
+            uc_out[5] = box[2][2];
         } else {
             for (0..6) |i| {
                 uc_out[i] = 0.0;
@@ -2227,8 +2239,12 @@ export fn zsasa_dcd_read_frame(
     }
 
     // Copy coordinates
-    const natoms: usize = @intCast(dcd_handle.reader.getNumAtoms());
-    @memcpy(coords_out[0 .. natoms * 3], frame.coords);
+    const natoms: usize = @intCast(dcd_handle.reader.nAtoms());
+    for (0..natoms) |i| {
+        coords_out[i * 3 + 0] = frame.x[i];
+        coords_out[i * 3 + 1] = frame.y[i];
+        coords_out[i * 3 + 2] = frame.z[i];
+    }
 
     return ZSASA_OK;
 }
@@ -2247,7 +2263,7 @@ export fn zsasa_dcd_get_natoms(
         return -1;
     }
     const dcd_handle: *DcdHandle = @ptrCast(@alignCast(handle.?));
-    return dcd_handle.reader.getNumAtoms();
+    return @intCast(dcd_handle.reader.nAtoms());
 }
 
 // =============================================================================

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -6,8 +6,9 @@
 //   - Batch parallel (N threads): reads batches of frames, distributes across threads
 //
 const std = @import("std");
-const xtc = @import("zxdrfile").xtc;
-const dcd = @import("dcd.zig");
+const ztraj = @import("ztraj");
+const xtc = ztraj.io.xtc;
+const dcd = ztraj.io.dcd;
 const shrake_rupley = @import("shrake_rupley.zig");
 const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
 const bitmask_lut = @import("bitmask_lut.zig");
@@ -60,14 +61,8 @@ const TrajectoryFrame = struct {
     time: f32,
     coords: []f32, // flat array of x,y,z coordinates (length = natoms * 3)
 
-    /// The underlying frame owns the coords allocation.
-    /// Track which reader type produced it so we can free correctly.
-    _xtc_frame: ?xtc.XtcFrame = null,
-    _dcd_frame: ?dcd.DcdFrame = null,
-
     fn deinit(self: *TrajectoryFrame, allocator: Allocator) void {
-        if (self._xtc_frame) |*f| f.deinit(allocator);
-        if (self._dcd_frame) |*f| f.deinit(allocator);
+        allocator.free(self.coords);
     }
 };
 
@@ -77,44 +72,40 @@ const TrajectoryReader = struct {
     dcd_reader: ?*dcd.DcdReader = null,
     format: TrajectoryFormat,
 
-    /// Coordinate scale factor: 10.0 for XTC (nm→Å), 1.0 for DCD (already Å)
+    /// Coordinate scale factor. ztraj readers yield coordinates in Å.
     fn coordScale(self: *const TrajectoryReader) f64 {
-        return switch (self.format) {
-            .xtc => 10.0,
-            .dcd => 1.0,
-        };
+        _ = self;
+        return 1.0;
     }
 
     /// Read next frame, returning null-like via EndOfFile error
-    fn readFrame(self: *TrajectoryReader) !TrajectoryFrame {
-        switch (self.format) {
-            .xtc => {
-                const frame = try self.xtc_reader.?.readFrame();
-                return TrajectoryFrame{
-                    .step = frame.step,
-                    .time = frame.time,
-                    .coords = frame.coords,
-                    ._xtc_frame = frame,
-                };
-            },
-            .dcd => {
-                const frame = try self.dcd_reader.?.readFrame();
-                return TrajectoryFrame{
-                    .step = frame.step,
-                    .time = frame.time,
-                    .coords = frame.coords,
-                    ._dcd_frame = frame,
-                };
-            },
+    fn readFrame(self: *TrajectoryReader, allocator: Allocator) !TrajectoryFrame {
+        const frame = switch (self.format) {
+            .xtc => try self.xtc_reader.?.next() orelse return error.EndOfFile,
+            .dcd => try self.dcd_reader.?.next() orelse return error.EndOfFile,
+        };
+
+        const natoms = frame.x.len;
+        const coords = try allocator.alloc(f32, natoms * 3);
+        errdefer allocator.free(coords);
+
+        for (0..natoms) |i| {
+            coords[i * 3 + 0] = frame.x[i];
+            coords[i * 3 + 1] = frame.y[i];
+            coords[i * 3 + 2] = frame.z[i];
         }
+
+        return .{
+            .step = frame.step,
+            .time = frame.time,
+            .coords = coords,
+        };
     }
 
     /// Check if a read error is an EOF condition
     fn isEof(self: *const TrajectoryReader, err: anyerror) bool {
-        return switch (self.format) {
-            .xtc => err == xtc.XtcError.EndOfFile,
-            .dcd => err == dcd.DcdError.EndOfFile,
-        };
+        _ = self;
+        return err == error.EndOfFile;
     }
 };
 
@@ -472,7 +463,7 @@ const BatchWorkerArgs = struct {
     probe_radius: f64,
     n_points: u32,
     n_slices: u32,
-    coord_scale: f64, // 10.0 for XTC (nm→Å), 1.0 for DCD (already Å)
+    coord_scale: f64, // ztraj readers already yield Å; kept for reader abstraction
     bitmask_lut_f64: ?*const bitmask_lut.BitmaskLut = null,
     bitmask_lut_f32: ?*const bitmask_lut.BitmaskLutGen(f32) = null,
 };
@@ -518,7 +509,7 @@ fn batchWorkerFn(args: BatchWorkerArgs) void {
 
         const coord_offset = batch_idx * args.natoms * 3;
 
-        // Convert f32 coordinates to f64 with unit scaling (nm→Å for XTC, no-op for DCD)
+        // Convert f32 coordinates to f64. ztraj readers already yield Å.
         const scale = args.coord_scale;
         for (0..args.natoms) |i| {
             x[i] = @as(f64, args.coord_pool[coord_offset + i * 3 + 0]) * scale;
@@ -620,7 +611,7 @@ fn readBatch(
     var batch_count: usize = 0;
 
     while (batch_count < batch_size) {
-        var frame = reader.readFrame() catch |err| {
+        var frame = reader.readFrame(allocator) catch |err| {
             if (reader.isEof(err)) return .{ .count = batch_count, .eof = true };
             return err;
         };
@@ -762,16 +753,16 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
     const traj_natoms: i32 = switch (traj_format) {
         .xtc => blk: {
             xtc_reader = try xtc.XtcReader.open(io, allocator, traj_path);
-            break :blk xtc_reader.?.getNumAtoms();
+            break :blk @intCast(xtc_reader.?.nAtoms());
         },
         .dcd => blk: {
-            dcd_reader = try dcd.DcdReader.open(allocator, io, traj_path);
-            break :blk dcd_reader.?.natoms;
+            dcd_reader = try dcd.DcdReader.open(io, allocator, traj_path);
+            break :blk @intCast(dcd_reader.?.nAtoms());
         },
     };
     defer {
-        if (xtc_reader) |*r| r.close();
-        if (dcd_reader) |*r| r.close();
+        if (xtc_reader) |*r| r.deinit();
+        if (dcd_reader) |*r| r.deinit();
     }
 
     // Verify atom count matches
@@ -914,7 +905,7 @@ fn runSequential(
     const scale = reader.coordScale();
 
     while (true) {
-        var frame = reader.readFrame() catch |err| {
+        var frame = reader.readFrame(allocator) catch |err| {
             if (reader.isEof(err)) break;
             return err;
         };
@@ -935,7 +926,7 @@ fn runSequential(
             continue;
         }
 
-        // Update frame coordinates with unit scaling (nm→Å for XTC, no-op for DCD)
+        // Update frame coordinates. ztraj readers already yield Å.
         for (0..natoms) |i| {
             frame_x[i] = @as(f64, frame.coords[i * 3 + 0]) * scale;
             frame_y[i] = @as(f64, frame.coords[i * 3 + 1]) * scale;
@@ -1220,4 +1211,10 @@ test "TrajArgs quiet disables progress" {
 test "TrajArgs quiet suppresses progress even when show_progress defaults true" {
     const args = TrajArgs{ .quiet = true };
     try std.testing.expectEqual(false, shouldShowProgress(args));
+}
+test "TrajectoryReader uses angstrom coordinates from ztraj readers" {
+    const xtc_reader = TrajectoryReader{ .format = .xtc };
+    const dcd_reader = TrajectoryReader{ .format = .dcd };
+    try std.testing.expectEqual(@as(f64, 1.0), xtc_reader.coordScale());
+    try std.testing.expectEqual(@as(f64, 1.0), dcd_reader.coordScale());
 }


### PR DESCRIPTION
## Summary
- Replace the direct `zxdrfile` package dependency with the `ztraj` GitHub dependency.
- Route CLI trajectory mode and C/Python XTC/DCD reader ABI through `ztraj.io.xtc` and `ztraj.io.dcd`.
- Preserve existing public XTC Python/C API units (nm) while using ztraj's Å-normalized frames internally.

## Validation
- `zig fmt --check src/ build.zig`
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa traj test_data/1l2y.xtc test_data/1l2y.pdb -o /tmp/zsasa-ztraj-xtc.csv --end=0 --quiet`
- `./zig-out/bin/zsasa traj test_data/1l2y.dcd test_data/1l2y.pdb -o /tmp/zsasa-ztraj-dcd.csv --end=0 --quiet`
- `cd python && uv run --extra dev pytest tests/test_xtc.py tests/test_dcd.py -q`
