### PR TITLE
feat: add ztraj trajectory formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ High-performance Solvent Accessible Surface Area (SASA) calculator in Zig.
 ## Features
 
 - **Two algorithms**: Shrake-Rupley and Lee-Richards, with bitmask LUT optimization
-- **Multiple input formats**: mmCIF, BinaryCIF (`.bcif`), PDB, SDF/MOL, JSON, XTC, DCD
+- **Multiple input formats**: mmCIF, BinaryCIF (`.bcif`), PDB, SDF/MOL, JSON, XTC, TRR, DCD, AMBER NetCDF
 - **Batch & trajectory**: Proteome-scale directory processing, MD trajectory analysis
 - **Python bindings**: NumPy, Gemmi, BioPython, Biotite, MDTraj, MDAnalysis
 - **Four classifiers**: ProtOr, NACCESS, OONS, and CCD (bond-topology-based radii for any chemical component)

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -1,5 +1,5 @@
 // Trajectory analysis mode
-// Calculates SASA for each frame in an XTC or DCD trajectory
+// Calculates SASA for each frame in a molecular dynamics trajectory
 //
 // Supports two parallelism strategies:
 //   - Sequential (1 thread): processes frames one at a time
@@ -9,6 +9,8 @@ const std = @import("std");
 const ztraj = @import("ztraj");
 const xtc = ztraj.io.xtc;
 const dcd = ztraj.io.dcd;
+const trr = ztraj.io.trr;
+const nc = ztraj.io.nc;
 const shrake_rupley = @import("shrake_rupley.zig");
 const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
 const bitmask_lut = @import("bitmask_lut.zig");
@@ -41,8 +43,10 @@ pub const Algorithm = enum {
 
 /// Trajectory file format
 pub const TrajectoryFormat = enum {
-    xtc, // GROMACS XTC (compressed, coordinates in nm)
-    dcd, // NAMD/CHARMM DCD (uncompressed, coordinates in Angstroms)
+    xtc, // GROMACS XTC
+    dcd, // NAMD/CHARMM DCD
+    trr, // GROMACS TRR
+    nc, // AMBER NetCDF
 };
 
 /// Detect trajectory format from file extension
@@ -51,6 +55,10 @@ pub fn detectTrajectoryFormat(path: []const u8) ?TrajectoryFormat {
         return .xtc;
     } else if (std.mem.endsWith(u8, path, ".dcd")) {
         return .dcd;
+    } else if (std.mem.endsWith(u8, path, ".trr")) {
+        return .trr;
+    } else if (std.mem.endsWith(u8, path, ".nc") or std.mem.endsWith(u8, path, ".ncdf")) {
+        return .nc;
     }
     return null;
 }
@@ -66,10 +74,12 @@ const TrajectoryFrame = struct {
     }
 };
 
-/// Unified trajectory reader wrapping either XTC or DCD readers
+/// Unified trajectory reader wrapping ztraj trajectory readers
 const TrajectoryReader = struct {
     xtc_reader: ?*xtc.XtcReader = null,
     dcd_reader: ?*dcd.DcdReader = null,
+    trr_reader: ?*trr.TrrReader = null,
+    nc_reader: ?*nc.NcReader = null,
     format: TrajectoryFormat,
 
     /// Coordinate scale factor. ztraj readers yield coordinates in Å.
@@ -83,6 +93,8 @@ const TrajectoryReader = struct {
         const frame = switch (self.format) {
             .xtc => try self.xtc_reader.?.next() orelse return error.EndOfFile,
             .dcd => try self.dcd_reader.?.next() orelse return error.EndOfFile,
+            .trr => try self.trr_reader.?.next() orelse return error.EndOfFile,
+            .nc => try self.nc_reader.?.next() orelse return error.EndOfFile,
         };
 
         const natoms = frame.x.len;
@@ -330,11 +342,11 @@ pub fn printHelp(program_name: []const u8) void {
         \\Usage: {s} traj <trajectory> <topology> [options]
         \\
         \\Calculate SASA for each frame in a trajectory.
-        \\Supported formats: XTC (GROMACS), DCD (NAMD/CHARMM).
+        \\Supported formats: XTC, TRR (GROMACS), DCD (NAMD/CHARMM), AMBER NetCDF.
         \\Format is auto-detected from file extension.
         \\
         \\ARGUMENTS:
-        \\    <trajectory> Trajectory file (.xtc or .dcd)
+        \\    <trajectory> Trajectory file (.xtc, .trr, .dcd, .nc, or .ncdf)
         \\    <topology>   Topology file (PDB or mmCIF) for atom names and radii
         \\
         \\OPTIONS:
@@ -374,13 +386,15 @@ pub fn printHelp(program_name: []const u8) void {
         \\EXAMPLES:
         \\    {s} traj trajectory.xtc topology.pdb
         \\    {s} traj trajectory.dcd topology.pdb
+        \\    {s} traj trajectory.trr topology.pdb
+        \\    {s} traj trajectory.nc topology.pdb
         \\    {s} traj trajectory.xtc topology.pdb -o sasa.csv
         \\    {s} traj trajectory.xtc topology.pdb --stride=10
         \\    {s} traj trajectory.xtc topology.pdb --classifier=naccess
         \\    {s} traj trajectory.xtc topology.pdb --algorithm=lr --n-slices=50
         \\    {s} traj trajectory.xtc topology.pdb --threads=8
         \\
-    , .{ program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name });
+    , .{ program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name });
 }
 
 /// Detect topology file format
@@ -666,7 +680,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
 
     // Detect trajectory format
     const traj_format = detectTrajectoryFormat(traj_path) orelse {
-        std.debug.print("Error: Unknown trajectory format. Supported: .xtc, .dcd\n", .{});
+        std.debug.print("Error: Unknown trajectory format. Supported: .xtc, .trr, .dcd, .nc, .ncdf\n", .{});
         return error.UnsupportedFormat;
     };
 
@@ -743,13 +757,17 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
         const format_name: []const u8 = switch (traj_format) {
             .xtc => "XTC",
             .dcd => "DCD",
+            .trr => "TRR",
+            .nc => "AMBER NetCDF",
         };
         std.debug.print("Opening trajectory ({s}): {s}\n", .{ format_name, traj_path });
     }
 
-    // Open XTC or DCD reader and verify atom count
+    // Open trajectory reader and verify atom count
     var xtc_reader: ?xtc.XtcReader = null;
     var dcd_reader: ?dcd.DcdReader = null;
+    var trr_reader: ?trr.TrrReader = null;
+    var nc_reader: ?nc.NcReader = null;
     const traj_natoms: i32 = switch (traj_format) {
         .xtc => blk: {
             xtc_reader = try xtc.XtcReader.open(io, allocator, traj_path);
@@ -759,10 +777,20 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
             dcd_reader = try dcd.DcdReader.open(io, allocator, traj_path);
             break :blk @intCast(dcd_reader.?.nAtoms());
         },
+        .trr => blk: {
+            trr_reader = try trr.TrrReader.open(io, allocator, traj_path);
+            break :blk @intCast(trr_reader.?.nAtoms());
+        },
+        .nc => blk: {
+            nc_reader = try nc.NcReader.open(io, allocator, traj_path);
+            break :blk @intCast(nc_reader.?.nAtoms());
+        },
     };
     defer {
         if (xtc_reader) |*r| r.deinit();
         if (dcd_reader) |*r| r.deinit();
+        if (trr_reader) |*r| r.deinit();
+        if (nc_reader) |*r| r.deinit();
     }
 
     // Verify atom count matches
@@ -831,6 +859,8 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
     var traj_reader = TrajectoryReader{
         .xtc_reader = if (xtc_reader) |*r| r else null,
         .dcd_reader = if (dcd_reader) |*r| r else null,
+        .trr_reader = if (trr_reader) |*r| r else null,
+        .nc_reader = if (nc_reader) |*r| r else null,
         .format = traj_format,
     };
 
@@ -1215,6 +1245,19 @@ test "TrajArgs quiet suppresses progress even when show_progress defaults true" 
 test "TrajectoryReader uses angstrom coordinates from ztraj readers" {
     const xtc_reader = TrajectoryReader{ .format = .xtc };
     const dcd_reader = TrajectoryReader{ .format = .dcd };
+    const trr_reader = TrajectoryReader{ .format = .trr };
+    const nc_reader = TrajectoryReader{ .format = .nc };
     try std.testing.expectEqual(@as(f64, 1.0), xtc_reader.coordScale());
     try std.testing.expectEqual(@as(f64, 1.0), dcd_reader.coordScale());
+    try std.testing.expectEqual(@as(f64, 1.0), trr_reader.coordScale());
+    try std.testing.expectEqual(@as(f64, 1.0), nc_reader.coordScale());
+}
+
+test "detectTrajectoryFormat recognizes ztraj-backed formats" {
+    try std.testing.expectEqual(TrajectoryFormat.xtc, detectTrajectoryFormat("traj.xtc").?);
+    try std.testing.expectEqual(TrajectoryFormat.dcd, detectTrajectoryFormat("traj.dcd").?);
+    try std.testing.expectEqual(TrajectoryFormat.trr, detectTrajectoryFormat("traj.trr").?);
+    try std.testing.expectEqual(TrajectoryFormat.nc, detectTrajectoryFormat("traj.nc").?);
+    try std.testing.expectEqual(TrajectoryFormat.nc, detectTrajectoryFormat("traj.ncdf").?);
+    try std.testing.expectEqual(@as(?TrajectoryFormat, null), detectTrajectoryFormat("traj.gro"));
 }

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -54,7 +54,7 @@ For task-oriented examples, see [Batch Processing](../guide/batch.md) and [Workf
 
 ### `traj` - Trajectory Analysis
 
-Calculate SASA for each frame in a trajectory file (XTC or DCD).
+Calculate SASA for each frame in a trajectory file (XTC, TRR, DCD, or AMBER NetCDF).
 
 ```bash
 zsasa traj trajectory.xtc topology.pdb --output=sasa.csv
@@ -183,7 +183,7 @@ The `traj` subcommand has additional options specific to trajectory processing.
 
 | Argument | Description |
 |----------|-------------|
-| `<trajectory>` | Trajectory file (`.xtc` for GROMACS, `.dcd` for NAMD/CHARMM) |
+| `<trajectory>` | Trajectory file (`.xtc`/`.trr` for GROMACS, `.dcd` for NAMD/CHARMM, `.nc`/`.ncdf` for AMBER NetCDF) |
 | `<topology>` | Topology file (PDB or mmCIF) for atom names and radii |
 
 ### Options
@@ -203,11 +203,11 @@ Most [common options](#common-options) apply, plus the trajectory-specific optio
 
 ### Notes
 
-- Supported trajectory formats: **XTC** (GROMACS) and **DCD** (NAMD/CHARMM), auto-detected from extension
-- XTC coordinates are in nm; automatically converted to Å. DCD coordinates are already in Å.
+- Supported trajectory formats: **XTC** and **TRR** (GROMACS), **DCD** (NAMD/CHARMM), and **AMBER NetCDF** (`.nc`, `.ncdf`), auto-detected from extension
+- Coordinates are normalized to Å internally by the ztraj readers before SASA calculation.
 - Hydrogen atoms are **included** by default in trajectory mode; use `--no-hydrogens` to exclude them
 - Topology file provides atom names for radius classification
-- The number of atoms in XTC must match the topology
+- The number of atoms in the trajectory must match the topology
 - Default precision is `f32` (faster for trajectory processing)
 
 ---

--- a/website/docs/comparison.md
+++ b/website/docs/comparison.md
@@ -16,7 +16,7 @@ For performance numbers, see [Benchmarks](benchmarks/single-file.md).
 | Language | Zig | C | Rust | C++ |
 | Algorithms | SR + LR | SR + LR | SR only | SR only |
 | Input formats | mmCIF, PDB, JSON | PDB, mmCIF | PDB (via pdbtbx) | AF2 model (CIF/PDB) |
-| MD trajectory | Native (XTC, DCD) | — | △ (mdsasa-bolt) | — |
+| MD trajectory | Native (XTC, TRR, DCD, AMBER NetCDF) | — | △ (mdsasa-bolt) | — |
 | Python API | ✅ (multi-threaded) | ✅ (single-threaded) | △ (separate package) | ❌ |
 | Bitmask range | 1–1024 | — | — | 64/128/256 |
 | External deps | None | None | pdbtbx, pulp, mimalloc | 13+ (Boost, Eigen, gemmi, Highway, RDKit, lmdb, ...) |

--- a/website/docs/guide/trajectory.md
+++ b/website/docs/guide/trajectory.md
@@ -7,8 +7,12 @@ sidebar_position: 4
 zsasa supports SASA calculation over MD trajectory frames using the CLI or Python bindings.
 
 Supported trajectory formats:
-- **XTC** (GROMACS) — compressed, coordinates in nm (auto-converted to Å)
-- **DCD** (NAMD/CHARMM) — uncompressed, coordinates in Å
+- **XTC** (GROMACS) — compressed trajectory
+- **TRR** (GROMACS) — full-precision trajectory with coordinates
+- **DCD** (NAMD/CHARMM) — uncompressed trajectory
+- **AMBER NetCDF** (`.nc`, `.ncdf`) — AMBER convention NetCDF trajectory
+
+Coordinates are normalized to Å internally by the ztraj readers before SASA calculation.
 
 Format is auto-detected from file extension.
 
@@ -28,6 +32,12 @@ zsasa traj trajectory.xtc topology.pdb
 
 # DCD trajectory (NAMD/CHARMM)
 zsasa traj trajectory.dcd topology.pdb
+
+# TRR trajectory (GROMACS)
+zsasa traj trajectory.trr topology.pdb
+
+# AMBER NetCDF trajectory
+zsasa traj trajectory.nc topology.pdb
 
 # With classifier and frame selection
 zsasa traj trajectory.xtc topology.pdb \
@@ -131,7 +141,7 @@ DCD coordinates are already in Angstroms (no unit conversion needed, unlike XTC)
 
 | Approach | Best For | Formats | Dependencies |
 |----------|----------|---------|-------------|
-| CLI `traj` | Quick analysis, scripting | XTC, DCD | None (Zig binary) |
+| CLI `traj` | Quick analysis, scripting | XTC, TRR, DCD, AMBER NetCDF | None (Zig binary) |
 | MDAnalysis | Complex selections, multi-format | XTC, DCD, + many more | `MDAnalysis` |
 | MDTraj | Drop-in replacement for `mdtraj.shrake_rupley` | XTC, DCD, + many more | `mdtraj` |
 | Native XTC | Simple XTC reading, no extra deps | XTC | None |


### PR DESCRIPTION
## Summary
- Add CLI `zsasa traj` support for ztraj-backed TRR (`.trr`) trajectories.
- Add CLI `zsasa traj` support for AMBER NetCDF (`.nc`, `.ncdf`) trajectories.
- Update CLI help and docs to list the expanded native trajectory format set.

## Notes
- This only extends CLI trajectory mode; Python native reader APIs are unchanged.
- ztraj readers normalize coordinates to Å before SASA calculation.

## Validation
- `zig fmt --check src/ build.zig`
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa traj --help 2>&1 | rg -n "TRR|NetCDF|\\.trr|\\.ncdf"`
- `./zig-out/bin/zsasa traj /Users/nagaet/ghq/github.com/N283T/ztraj/test_data/frame0.trr /tmp/zsasa_top22.pdb -o /tmp/zsasa-trr.csv --end=0 --quiet`
- `./zig-out/bin/zsasa traj /Users/nagaet/ghq/github.com/N283T/ztraj/test_data/cpptraj_traj.nc /tmp/zsasa_top80.pdb -o /tmp/zsasa-nc.csv --end=0 --quiet`
