### PR TITLE
docs: recommend pyztraj for Python trajectory I/O

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -48,7 +48,7 @@ print(f"Total: {result.total_area:.1f} Å²")
 - **Atom classification**: NACCESS, ProtOr, OONS classifiers
 - **Analysis**: Per-residue aggregation, RSA, polar/nonpolar classification
 - **Batch processing**: `process_directory()` for proteome-scale datasets
-- **MD trajectory**: Native XTC/DCD readers, [MDTraj](https://github.com/mdtraj/mdtraj) and [MDAnalysis](https://github.com/MDAnalysis/mdanalysis) integration
+- **MD trajectory**: [MDTraj](https://github.com/mdtraj/mdtraj) and [MDAnalysis](https://github.com/MDAnalysis/mdanalysis) integrations; use [pyztraj](https://github.com/N283T/ztraj) for direct trajectory-file I/O
 - **Integrations**: Gemmi, BioPython, Biotite
 
 See the [full API reference](https://n283t.github.io/zsasa/docs/python-api) for details.

--- a/python/zsasa/__init__.py
+++ b/python/zsasa/__init__.py
@@ -58,29 +58,19 @@ MDAnalysis Integration:
     >>> sasa.run()
     >>> print(sasa.results.total_area)  # Returns per-frame SASA in Å²
 
-Native XTC Reader:
-    For standalone XTC reading without MDTraj/MDAnalysis dependencies:
+Trajectory File I/O:
+    For direct trajectory-file I/O and trajectory-native analysis in Python,
+    prefer pyztraj (the Python bindings for ztraj). zsasa keeps the legacy
+    zsasa.xtc and zsasa.dcd modules for compatibility, but new trajectory
+    formats are centralized in pyztraj.
 
-    >>> from zsasa.xtc import XtcReader, compute_sasa_trajectory
-    >>> # Low-level reader API
-    >>> with XtcReader("trajectory.xtc") as reader:
+    >>> # pip install pyztraj
+    >>> import pyztraj
+    >>> structure = pyztraj.load_pdb("topology.pdb")
+    >>> with pyztraj.open_trr("trajectory.trr", structure.n_atoms) as reader:
     ...     for frame in reader:
-    ...         print(f"Step {frame.step}")
-    >>>
-    >>> # High-level SASA calculation (radii from topology)
-    >>> result = compute_sasa_trajectory("trajectory.xtc", radii)
-    >>> print(result.total_areas)  # Per-frame SASA in Å²
-
-Native DCD Reader:
-    For standalone DCD reading (NAMD/CHARMM format):
-
-    >>> from zsasa.dcd import DcdReader, compute_sasa_trajectory
-    >>> with DcdReader("trajectory.dcd") as reader:
-    ...     for frame in reader:
-    ...         print(f"Step {frame.step}, {frame.natoms} atoms")
-    >>>
-    >>> result = compute_sasa_trajectory("trajectory.dcd", radii)
-    >>> print(result.total_areas)  # Per-frame SASA in Å²
+    ...         sasa = pyztraj.compute_sasa(structure, frame.coords)
+    ...         print(sasa.total_area)
 """
 
 from zsasa._ffi import get_version

--- a/website/docs/guide/trajectory.md
+++ b/website/docs/guide/trajectory.md
@@ -107,35 +107,21 @@ A drop-in replacement for `mdtraj.shrake_rupley()`.
 
 See [MDTraj Integration](../integrations/mdtraj.md) for full API details.
 
-## Python: Native XTC Reader
+## Python: Direct Trajectory I/O with pyztraj
 
-For simple XTC reading without MDTraj or MDAnalysis dependencies:
-
-```python
-from zsasa.xtc import XtcReader
-
-reader = XtcReader("trajectory.xtc")
-for frame in reader:
-    print(f"Step {frame.step}, Time {frame.time:.1f} ps")
-    coords = frame.coords  # numpy array (n_atoms, 3) in nm
-```
-
-See [Native XTC Reader](../python-api/xtc.md) for full API details.
-
-## Python: Native DCD Reader
-
-For DCD trajectories without external dependencies:
+For Python workflows that read trajectory files directly, use [pyztraj](https://github.com/N283T/ztraj). pyztraj centralizes trajectory I/O and trajectory-native analysis for XTC, TRR, DCD, and AMBER NetCDF. zsasa keeps `zsasa.xtc` and `zsasa.dcd` for compatibility, but new trajectory formats are handled in pyztraj.
 
 ```python
-from zsasa.dcd import DcdReader
+import pyztraj
 
-reader = DcdReader("trajectory.dcd")
-for frame in reader:
-    print(f"Step {frame.step}, Time {frame.time:.1f}")
-    coords = frame.coords  # numpy array (n_atoms, 3) in Å
+structure = pyztraj.load_pdb("topology.pdb")
+with pyztraj.open_trr("trajectory.trr", structure.n_atoms) as reader:
+    for frame in reader:
+        sasa = pyztraj.compute_sasa(structure, frame.coords)
+        print(frame.step, sasa.total_area)
 ```
 
-DCD coordinates are already in Angstroms (no unit conversion needed, unlike XTC).
+See [Legacy Native XTC Reader](../python-api/xtc.md) for the compatibility XTC API.
 
 ## Choosing an Approach
 
@@ -144,5 +130,5 @@ DCD coordinates are already in Angstroms (no unit conversion needed, unlike XTC)
 | CLI `traj` | Quick analysis, scripting | XTC, TRR, DCD, AMBER NetCDF | None (Zig binary) |
 | MDAnalysis | Complex selections, multi-format | XTC, DCD, + many more | `MDAnalysis` |
 | MDTraj | Drop-in replacement for `mdtraj.shrake_rupley` | XTC, DCD, + many more | `mdtraj` |
-| Native XTC | Simple XTC reading, no extra deps | XTC | None |
-| Native DCD | Simple DCD reading, no extra deps | DCD | None |
+| pyztraj | Direct trajectory-file I/O and trajectory-native analysis | XTC, TRR, DCD, AMBER NetCDF | `pyztraj` |
+| Legacy `zsasa.xtc`/`zsasa.dcd` | Existing compatibility code | XTC, DCD | None |

--- a/website/docs/python-api/index.md
+++ b/website/docs/python-api/index.md
@@ -21,6 +21,7 @@ The Python bindings provide:
 - **Per-residue aggregation**: Aggregate atom SASA to residue level
 - **Directory batch processing**: Process entire directories of structure files
 - **Library integrations**: gemmi, BioPython, Biotite, MDTraj, MDAnalysis (see [Integrations](../integrations/))
+- **Trajectory-file guidance**: use [pyztraj](https://github.com/N283T/ztraj) for direct Python trajectory I/O and trajectory-native analysis; `zsasa.xtc` is retained for legacy compatibility
 
 ## Contents
 
@@ -29,7 +30,7 @@ The Python bindings provide:
 | [Core API](core.md) | `calculate_sasa`, batch API, directory processing |
 | [Classifier](classifier.md) | Atom classification, RSA calculation |
 | [Analysis](analysis.md) | Per-residue aggregation, examples |
-| [Native XTC Reader](xtc.md) | Standalone XTC reading, no dependencies |
+| [Legacy Native XTC Reader](xtc.md) | Compatibility XTC reader; prefer pyztraj for new trajectory-file workflows |
 
 For structure file parsing and MD trajectory integrations, see [Integrations](../integrations/).
 
@@ -66,8 +67,9 @@ pip install zsasa[biopython] # BioPython
 pip install zsasa[biotite]   # Biotite (also works with AtomWorks)
 
 # For MD trajectory analysis
-pip install mdtraj                   # MDTraj
-pip install MDAnalysis               # MDAnalysis
+pip install mdtraj                   # MDTraj integration
+pip install MDAnalysis               # MDAnalysis integration
+pip install pyztraj                  # Direct trajectory-file I/O (XTC/TRR/DCD/NC)
 
 # All integrations
 pip install zsasa[all]

--- a/website/docs/python-api/xtc.md
+++ b/website/docs/python-api/xtc.md
@@ -1,14 +1,18 @@
-# Native XTC Reader
+# Legacy Native XTC Reader
 
-The `zsasa.xtc` module provides a standalone XTC trajectory reader using zsasa's high-performance Zig implementation. This module doesn't require MDTraj or MDAnalysis, potentially offering better performance for simple XTC reading workflows.
+The `zsasa.xtc` module provides a standalone XTC trajectory reader kept for compatibility with existing zsasa users. For new Python workflows that read trajectory files directly, prefer [pyztraj](https://github.com/N283T/ztraj), which centralizes trajectory I/O and trajectory-native analysis across XTC, TRR, DCD, and AMBER NetCDF.
 
 ## When to Use
 
 | Use Case | Recommended Module |
 |----------|-------------------|
-| Simple XTC reading, no dependencies | `zsasa.xtc` |
-| Need topology parsing, selections | `zsasa.mdanalysis` or `zsasa.mdtraj` |
-| Complex analysis, multiple formats | `zsasa.mdanalysis` or `zsasa.mdtraj` |
+| Direct trajectory-file I/O or trajectory-native analysis | `pyztraj` |
+| Existing code already using `zsasa.xtc` | `zsasa.xtc` |
+| Need MDTraj/MDAnalysis ecosystem objects | `zsasa.mdtraj` or `zsasa.mdanalysis` |
+
+## Compatibility Status
+
+`zsasa.xtc` remains supported for existing users, but new trajectory formats are not planned for zsasa Python modules. Use pyztraj for new direct trajectory-file workflows.
 
 ## XtcReader
 
@@ -235,24 +239,26 @@ Result container for trajectory SASA calculation.
 
 ## Comparison with MDTraj/MDAnalysis Integration
 
-| Feature | zsasa.xtc | zsasa.mdtraj | zsasa.mdanalysis |
-|---------|-----------|--------------|------------------|
-| Dependencies | None (only NumPy) | mdtraj | MDAnalysis |
-| Trajectory formats | XTC only | Many (XTC, TRR, DCD, ...) | Many |
-| Topology support | Manual radii | From topology | From topology |
-| Atom selection | No | Yes | Yes |
-| Performance | Potentially faster | Good | Good |
+| Feature | pyztraj | zsasa.xtc | zsasa.mdtraj | zsasa.mdanalysis |
+|---------|---------|-----------|--------------|------------------|
+| Dependencies | pyztraj | None (only NumPy) | mdtraj | MDAnalysis |
+| Trajectory formats | XTC, TRR, DCD, AMBER NetCDF | XTC only | Many (XTC, TRR, DCD, ...) | Many |
+| Topology support | From ztraj loaders | Manual radii | From topology | From topology |
+| Atom selection | Yes | No | Yes | Yes |
+| Status | Preferred for direct trajectory files | Legacy compatibility | Ecosystem integration | Ecosystem integration |
+
+### When to Use pyztraj
+
+- You need direct trajectory-file I/O in Python
+- You work with TRR, DCD, AMBER NetCDF, or multiple trajectory formats
+- You want trajectory-native analysis such as SASA near the I/O layer
 
 ### When to Use zsasa.xtc
 
-- You only have XTC files
-- You want minimal dependencies
-- You have radii from another source
-- Performance is critical
+- You are maintaining existing code that already imports `zsasa.xtc`
+- You only need the legacy XTC compatibility API
 
 ### When to Use MDTraj/MDAnalysis
 
-- You need topology parsing
-- You need atom selection
-- You work with multiple trajectory formats
-- You need additional analysis tools
+- You need MDTraj or MDAnalysis topology/selection objects
+- You already use those ecosystems for upstream trajectory handling


### PR DESCRIPTION
## Summary
- Clarify that new Python direct trajectory-file workflows should use pyztraj.
- Reframe `zsasa.xtc` / `zsasa.dcd` as legacy compatibility APIs rather than the place to add new trajectory formats.
- Update Python README, package docstring, and website Python/trajectory docs accordingly.

## Validation
- `cd python && uv run ruff format --check zsasa/__init__.py`
- `cd python && uv run ruff check zsasa/__init__.py`
- `git diff --check`
