### PR TITLE
fix: optimize multichain workflow parsing

### DIFF
--- a/src/batch.zig
+++ b/src/batch.zig
@@ -470,7 +470,34 @@ const WorkflowJobState = struct {
     }
 };
 
+const WorkflowJobCounter = struct {
+    successful: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    failed: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    total_sasa_time_ns: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+};
+
+const WorkflowJobRuntime = struct {
+    state: *WorkflowJobState,
+    jsonl_stream: ?JsonlStreamWriter = null,
+    jsonl_file: ?std.Io.File = null,
+    jsonl_file_needs_close: bool = false,
+    counter: WorkflowJobCounter = .{},
+
+    fn close(self: *WorkflowJobRuntime, io: std.Io) void {
+        if (self.jsonl_file_needs_close) {
+            if (self.jsonl_file) |file| file.close(io);
+        }
+    }
+};
+
 fn chainMatchesFilter(chain: types.FixedString4, chains: []const []const u8) bool {
+    for (chains) |target| {
+        if (chain.eqlSlice(target)) return true;
+    }
+    return false;
+}
+
+fn chainFullMatchesFilter(chain: types.FixedString32, chains: []const []const u8) bool {
     for (chains) |target| {
         if (chain.eqlSlice(target)) return true;
     }
@@ -480,6 +507,9 @@ fn chainMatchesFilter(chain: types.FixedString4, chains: []const []const u8) boo
 fn atomSelectedByChains(input: AtomInput, index: usize, chains: ?[]const []const u8) bool {
     const filter = chains orelse return true;
     if (filter.len == 0) return true;
+    if (input.chain_id_full) |chain_ids_full| {
+        return chainFullMatchesFilter(chain_ids_full[index], filter);
+    }
     const chain_ids = input.chain_id orelse return true;
     return chainMatchesFilter(chain_ids[index], filter);
 }
@@ -512,6 +542,8 @@ fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]cons
     errdefer if (element) |v| allocator.free(v);
     const chain_id = if (input.chain_id != null) try allocator.alloc(types.FixedString4, selected_count) else null;
     errdefer if (chain_id) |v| allocator.free(v);
+    const chain_id_full = if (input.chain_id_full != null) try allocator.alloc(types.FixedString32, selected_count) else null;
+    errdefer if (chain_id_full) |v| allocator.free(v);
     const residue_num = if (input.residue_num != null) try allocator.alloc(i32, selected_count) else null;
     errdefer if (residue_num) |v| allocator.free(v);
     const insertion_code = if (input.insertion_code != null) try allocator.alloc(types.FixedString4, selected_count) else null;
@@ -528,6 +560,7 @@ fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]cons
         if (atom_name) |v| v[out_i] = input.atom_name.?[i];
         if (element) |v| v[out_i] = input.element.?[i];
         if (chain_id) |v| v[out_i] = input.chain_id.?[i];
+        if (chain_id_full) |v| v[out_i] = input.chain_id_full.?[i];
         if (residue_num) |v| v[out_i] = input.residue_num.?[i];
         if (insertion_code) |v| v[out_i] = input.insertion_code.?[i];
         out_i += 1;
@@ -542,6 +575,7 @@ fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]cons
         .atom_name = atom_name,
         .element = element,
         .chain_id = chain_id,
+        .chain_id_full = chain_id_full,
         .residue_num = residue_num,
         .insertion_code = insertion_code,
         .allocator = allocator,
@@ -2920,23 +2954,8 @@ fn workflowFilesContainSdf(files: []const []const u8) bool {
 }
 
 fn workflowRequiresJobFirstForLongChainFormats(files: []const []const u8, workflow: workflow_manifest.Workflow) bool {
-    var has_chain_filter = false;
-    for (workflow.jobs) |job| {
-        if (job.chains) |chains| {
-            if (chains.len > 0) {
-                has_chain_filter = true;
-                break;
-            }
-        }
-    }
-    if (!has_chain_filter) return false;
-
-    for (files) |filename| {
-        switch (format_detect.detectInputFormat(filename)) {
-            .mmcif, .bcif => return true,
-            else => {},
-        }
-    }
+    _ = files;
+    _ = workflow;
     return false;
 }
 
@@ -2955,6 +2974,131 @@ fn effectiveWorkflowSasaThreads(config: BatchConfig) usize {
         std.Thread.getCpuCount() catch 1
     else
         config.n_threads;
+}
+
+fn effectiveWorkflowFileThreads(config: BatchConfig, file_count: usize) usize {
+    const cpu_count = std.Thread.getCpuCount() catch 1;
+    return @min(resolveBatchThreadCount(config.n_threads, cpu_count), file_count);
+}
+
+const WorkflowParallelContext = struct {
+    files: []const []const u8,
+    input_dir: []const u8,
+    jobs: []const workflow_manifest.Job,
+    runtimes: []WorkflowJobRuntime,
+    resource_config: BatchConfig,
+    result_allocator: Allocator,
+    next_file: std.atomic.Value(usize),
+    processed_count: std.atomic.Value(usize),
+    lut_f64: ?*const bitmask_lut.BitmaskLut,
+    lut_f32: ?*const bitmask_lut.BitmaskLutGen(f32),
+    coarse_lut_f64: ?*const bitmask_lut.BitmaskLut,
+    fine_lut_f64: ?*const bitmask_lut.BitmaskLut,
+    coarse_lut_f32: ?*const bitmask_lut.BitmaskLutGen(f32),
+    fine_lut_f32: ?*const bitmask_lut.BitmaskLutGen(f32),
+    io: std.Io,
+};
+
+fn workflowMarkAllJobsFailed(ctx: *WorkflowParallelContext) void {
+    for (ctx.runtimes) |*runtime| {
+        _ = runtime.counter.failed.fetchAdd(1, .monotonic);
+    }
+}
+
+fn workflowClassifySourceInput(
+    input: *AtomInput,
+    input_path: []const u8,
+    config: BatchConfig,
+) !void {
+    if (config.custom_classifier) |custom| {
+        if (input.hasClassificationInfo()) {
+            try applyCustomClassifier(input, custom, config.quiet);
+        }
+    } else if (config.classifier_type) |ct| {
+        const format = format_detect.detectInputFormat(input_path);
+        if (format != .json and input.hasClassificationInfo()) {
+            try applyBuiltinClassifier(input, ct, config.sdf_ccd, config.external_ccd);
+        }
+    }
+}
+
+fn workflowParallelWorker(ctx: *WorkflowParallelContext) void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator);
+    defer arena.deinit();
+
+    while (true) {
+        const file_index = ctx.next_file.fetchAdd(1, .monotonic);
+        if (file_index >= ctx.files.len) break;
+
+        const filename = ctx.files[file_index];
+        const input_path = std.fs.path.join(arena.allocator(), &.{ ctx.input_dir, filename }) catch |err| {
+            workflowMarkAllJobsFailed(ctx);
+            std.debug.print("Error running workflow on '{s}': path join failed: {s}\n", .{ filename, @errorName(err) });
+            _ = ctx.processed_count.fetchAdd(1, .release);
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        var source_config = ctx.resource_config;
+        source_config.chain_filter = null;
+        var source_input = readInputFile(arena.allocator(), ctx.io, input_path, source_config) catch |err| {
+            workflowMarkAllJobsFailed(ctx);
+            for (ctx.runtimes) |runtime| {
+                std.debug.print("Error running workflow job '{s}' on '{s}': read/parse failed: {s}\n", .{ runtime.state.name, filename, @errorName(err) });
+            }
+            _ = ctx.processed_count.fetchAdd(1, .release);
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        workflowClassifySourceInput(&source_input, input_path, source_config) catch |err| {
+            workflowMarkAllJobsFailed(ctx);
+            for (ctx.runtimes) |runtime| {
+                std.debug.print("Error running workflow job '{s}' on '{s}': classifier failed: {s}\n", .{ runtime.state.name, filename, @errorName(err) });
+            }
+            source_input.deinit();
+            _ = ctx.processed_count.fetchAdd(1, .release);
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        const format = format_detect.detectInputFormat(input_path);
+        for (ctx.jobs, 0..) |job, job_index| {
+            var runtime = &ctx.runtimes[job_index];
+            const selected_chains: ?[]const []const u8 = if (format == .json) null else job.chains;
+            var selected_input = copySelectedAtomInput(arena.allocator(), source_input, selected_chains) catch |err| {
+                _ = runtime.counter.failed.fetchAdd(1, .monotonic);
+                std.debug.print("Error running workflow job '{s}' on '{s}': selection failed: {s}\n", .{ runtime.state.name, filename, @errorName(err) });
+                continue;
+            };
+            defer selected_input.deinit();
+
+            const sasa_threads: usize = 1;
+            var result = switch (runtime.state.config.precision) {
+                .f64 => calculatePreparedInputResult(f64, arena.allocator(), ctx.io, ctx.result_allocator, selected_input, runtime.state.output_dir, filename, runtime.state.config, sasa_threads, ctx.lut_f64, ctx.coarse_lut_f64, ctx.fine_lut_f64),
+                .f32 => calculatePreparedInputResult(f32, arena.allocator(), ctx.io, ctx.result_allocator, selected_input, runtime.state.output_dir, filename, runtime.state.config, sasa_threads, ctx.lut_f32, ctx.coarse_lut_f32, ctx.fine_lut_f32),
+            };
+            defer if (result.error_msg) |msg| ctx.result_allocator.free(msg);
+
+            if (result.status == .ok) {
+                _ = runtime.counter.successful.fetchAdd(1, .monotonic);
+                _ = runtime.counter.total_sasa_time_ns.fetchAdd(result.sasa_time_ns, .monotonic);
+            } else {
+                _ = runtime.counter.failed.fetchAdd(1, .monotonic);
+            }
+
+            if (runtime.jsonl_stream) |*stream| {
+                if (result.status == .ok) stream.writeResult(arena.allocator(), &result);
+            }
+
+            result.atom_areas = null;
+            result.residue_map = null;
+        }
+
+        source_input.deinit();
+        _ = ctx.processed_count.fetchAdd(1, .release);
+        _ = arena.reset(.retain_capacity);
+    }
 }
 
 fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
@@ -3218,6 +3362,76 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
 
     var luts = try BatchLuts.init(allocator, resource_config);
     defer luts.deinit();
+
+    const file_threads = effectiveWorkflowFileThreads(resource_config, files.len);
+    if (file_threads > 1 and files.len > 1) {
+        var runtimes = try allocator.alloc(WorkflowJobRuntime, states.len);
+        var runtimes_initialized: usize = 0;
+        errdefer {
+            for (runtimes[0..runtimes_initialized]) |*runtime| runtime.close(io);
+            allocator.free(runtimes);
+        }
+        for (states, 0..) |*state, i| {
+            runtimes[i] = .{ .state = state };
+            if (state.config.output_format == .jsonl) {
+                if (state.jsonl_output_path) |path| {
+                    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
+                    runtimes[i].jsonl_file = file;
+                    runtimes[i].jsonl_file_needs_close = true;
+                    runtimes[i].jsonl_stream = JsonlStreamWriter{ .file = file, .io = io };
+                } else {
+                    const file = std.Io.File.stdout();
+                    runtimes[i].jsonl_file = file;
+                    runtimes[i].jsonl_stream = JsonlStreamWriter{ .file = file, .io = io };
+                }
+            }
+            runtimes_initialized += 1;
+        }
+        defer {
+            for (runtimes) |*runtime| runtime.close(io);
+            allocator.free(runtimes);
+        }
+
+        var ctx = WorkflowParallelContext{
+            .files = files,
+            .input_dir = input_dir,
+            .jobs = workflow.jobs,
+            .runtimes = runtimes,
+            .resource_config = resource_config,
+            .result_allocator = allocator,
+            .next_file = std.atomic.Value(usize).init(0),
+            .processed_count = std.atomic.Value(usize).init(0),
+            .lut_f64 = luts.f64Ptr(),
+            .lut_f32 = luts.f32Ptr(),
+            .coarse_lut_f64 = luts.coarseF64Ptr(),
+            .fine_lut_f64 = luts.fineF64Ptr(),
+            .coarse_lut_f32 = luts.coarseF32Ptr(),
+            .fine_lut_f32 = luts.fineF32Ptr(),
+            .io = io,
+        };
+
+        const threads = try allocator.alloc(std.Thread, file_threads);
+        defer allocator.free(threads);
+        var spawned_count: usize = 0;
+        errdefer joinSpawnedThreads(threads, spawned_count);
+        for (threads) |*thread| {
+            thread.* = try std.Thread.spawn(.{}, workflowParallelWorker, .{&ctx});
+            spawned_count += 1;
+        }
+        joinSpawnedThreads(threads, spawned_count);
+
+        var successful: usize = 0;
+        var failed: usize = 0;
+        for (runtimes) |*runtime| {
+            runtime.state.successful = runtime.counter.successful.load(.monotonic);
+            runtime.state.failed = runtime.counter.failed.load(.monotonic);
+            runtime.state.total_sasa_time_ns = runtime.counter.total_sasa_time_ns.load(.monotonic);
+            successful += runtime.state.successful;
+            failed += runtime.state.failed;
+        }
+        std.debug.print("Workflow complete: {d} successful, {d} failed\n", .{ successful, failed });
+        return;
+    }
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -3593,6 +3807,28 @@ test "copySelectedAtomInput no matching chains returns empty input" {
     try std.testing.expectEqual(@as(usize, 0), selected.chain_id.?.len);
 }
 
+test "copySelectedAtomInput prefers extended chain IDs over truncated chain IDs" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "ABCD", "ABCD" });
+    defer input.deinit();
+    const chain_id_full = try allocator.alloc(types.FixedString32, 2);
+    chain_id_full[0] = types.FixedString32.fromSlice("ABCDE");
+    chain_id_full[1] = types.FixedString32.fromSlice("ABCD");
+    input.chain_id_full = chain_id_full;
+
+    var selected_long = try copySelectedAtomInput(allocator, input, &.{"ABCDE"});
+    defer selected_long.deinit();
+    try std.testing.expectEqual(@as(usize, 1), selected_long.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected_long.x[0], 1e-12);
+    try std.testing.expectEqualStrings("ABCDE", selected_long.chain_id_full.?[0].slice());
+
+    var selected_prefix = try copySelectedAtomInput(allocator, input, &.{"ABCD"});
+    defer selected_prefix.deinit();
+    try std.testing.expectEqual(@as(usize, 1), selected_prefix.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), selected_prefix.x[0], 1e-12);
+    try std.testing.expectEqualStrings("ABCD", selected_prefix.chain_id_full.?[0].slice());
+}
+
 test "calculatePreparedInputResult computes total for selected input" {
     const allocator = std.testing.allocator;
     var input = try makeTestAtomInput(allocator, &.{ "A", "A" });
@@ -3939,6 +4175,8 @@ test "workflow file-first keeps existing output layout" {
     defer allocator.free(json_workflow_path);
     const input_path = try std.fs.path.join(allocator, &.{ input_dir, "tiny.pdb" });
     defer allocator.free(input_path);
+    const input_path_2 = try std.fs.path.join(allocator, &.{ input_dir, "tiny2.pdb" });
+    defer allocator.free(input_path_2);
 
     try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
     try std.Io.Dir.cwd().writeFile(std.testing.io, .{
@@ -3948,6 +4186,17 @@ test "workflow file-first keeps existing output layout" {
         \\ATOM      2  CA  ALA A   1       1.500   0.000   0.000  1.00 20.00           C
         \\ATOM      3  N   GLY B   1       5.000   0.000   0.000  1.00 20.00           N
         \\ATOM      4  CA  GLY B   1       6.500   0.000   0.000  1.00 20.00           C
+        \\END
+        \\
+        ,
+    });
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = input_path_2,
+        .data =
+        \\ATOM      1  N   ALA A   1       0.000   1.000   0.000  1.00 20.00           N
+        \\ATOM      2  CA  ALA A   1       1.500   1.000   0.000  1.00 20.00           C
+        \\ATOM      3  N   GLY B   1       5.000   1.000   0.000  1.00 20.00           N
+        \\ATOM      4  CA  GLY B   1       6.500   1.000   0.000  1.00 20.00           C
         \\END
         \\
         ,
@@ -3994,7 +4243,9 @@ test "workflow file-first keeps existing output layout" {
     const chain_b_jsonl_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, chain_b_jsonl, allocator, .limited(4096));
     defer allocator.free(chain_b_jsonl_content);
     try std.testing.expect(std.mem.indexOf(u8, chain_a_jsonl_content, "\"filename\":\"tiny.pdb\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, chain_a_jsonl_content, "\"filename\":\"tiny2.pdb\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, chain_b_jsonl_content, "\"filename\":\"tiny.pdb\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, chain_b_jsonl_content, "\"filename\":\"tiny2.pdb\"") != null);
 
     const json_workflow = try std.fmt.allocPrint(allocator,
         \\version = 1
@@ -4026,9 +4277,14 @@ test "workflow file-first keeps existing output layout" {
 
     const chain_a_json = try std.fs.path.join(allocator, &.{ json_output_dir, "chain_a", "tiny.json" });
     defer allocator.free(chain_a_json);
+    const chain_a_json_2 = try std.fs.path.join(allocator, &.{ json_output_dir, "chain_a", "tiny2.json" });
+    defer allocator.free(chain_a_json_2);
     const chain_a_json_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, chain_a_json, allocator, .limited(4096));
     defer allocator.free(chain_a_json_content);
+    const chain_a_json_content_2 = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, chain_a_json_2, allocator, .limited(4096));
+    defer allocator.free(chain_a_json_content_2);
     try std.testing.expect(std.mem.indexOf(u8, chain_a_json_content, "\"total_area\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, chain_a_json_content_2, "\"total_area\"") != null);
 }
 
 test "workflow mmCIF chain filters preserve long chain IDs" {
@@ -4134,7 +4390,7 @@ test "workflowFilesContainSdf detects SDF in pre-scanned files" {
     try std.testing.expect(workflowFilesContainSdf(files[0..]));
 }
 
-test "workflowRequiresJobFirstForLongChainFormats detects chain-filtered mmCIF and BinaryCIF" {
+test "workflowRequiresJobFirstForLongChainFormats allows chain-filtered mmCIF and BinaryCIF" {
     const mmcif_files = [_][]const u8{"long-chain.cif"};
     const bcif_files = [_][]const u8{"long-chain.bcif"};
     const pdb_json_files = [_][]const u8{ "chain.pdb", "atoms.json" };
@@ -4147,8 +4403,8 @@ test "workflowRequiresJobFirstForLongChainFormats detects chain-filtered mmCIF a
         .content = "",
         .jobs = long_chain_jobs[0..],
     };
-    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(mmcif_files[0..], long_chain_workflow));
-    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(bcif_files[0..], long_chain_workflow));
+    try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(mmcif_files[0..], long_chain_workflow));
+    try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(bcif_files[0..], long_chain_workflow));
     try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(pdb_json_files[0..], long_chain_workflow));
 
     var prefix_chain_jobs = [_]workflow_manifest.Job{
@@ -4159,8 +4415,8 @@ test "workflowRequiresJobFirstForLongChainFormats detects chain-filtered mmCIF a
         .content = "",
         .jobs = prefix_chain_jobs[0..],
     };
-    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(mmcif_files[0..], prefix_chain_workflow));
-    try std.testing.expect(workflowRequiresJobFirstForLongChainFormats(bcif_files[0..], prefix_chain_workflow));
+    try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(mmcif_files[0..], prefix_chain_workflow));
+    try std.testing.expect(!workflowRequiresJobFirstForLongChainFormats(bcif_files[0..], prefix_chain_workflow));
 
     var unfiltered_jobs = [_]workflow_manifest.Job{
         .{ .name = "all" },

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -497,9 +497,9 @@ fn chainMatchesFilter(chain: types.FixedString4, chains: []const []const u8) boo
     return false;
 }
 
-fn chainFullMatchesFilter(chain: types.FixedString32, chains: []const []const u8) bool {
+fn chainFullMatchesFilter(chain: []const u8, chains: []const []const u8) bool {
     for (chains) |target| {
-        if (chain.eqlSlice(target)) return true;
+        if (std.mem.eql(u8, chain, target)) return true;
     }
     return false;
 }
@@ -542,8 +542,12 @@ fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]cons
     errdefer if (element) |v| allocator.free(v);
     const chain_id = if (input.chain_id != null) try allocator.alloc(types.FixedString4, selected_count) else null;
     errdefer if (chain_id) |v| allocator.free(v);
-    const chain_id_full = if (input.chain_id_full != null) try allocator.alloc(types.FixedString32, selected_count) else null;
-    errdefer if (chain_id_full) |v| allocator.free(v);
+    const chain_id_full = if (input.chain_id_full != null) try allocator.alloc([]const u8, selected_count) else null;
+    var chain_id_full_copied: usize = 0;
+    errdefer if (chain_id_full) |v| {
+        for (v[0..chain_id_full_copied]) |chain| allocator.free(chain);
+        allocator.free(v);
+    };
     const residue_num = if (input.residue_num != null) try allocator.alloc(i32, selected_count) else null;
     errdefer if (residue_num) |v| allocator.free(v);
     const insertion_code = if (input.insertion_code != null) try allocator.alloc(types.FixedString4, selected_count) else null;
@@ -560,7 +564,10 @@ fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]cons
         if (atom_name) |v| v[out_i] = input.atom_name.?[i];
         if (element) |v| v[out_i] = input.element.?[i];
         if (chain_id) |v| v[out_i] = input.chain_id.?[i];
-        if (chain_id_full) |v| v[out_i] = input.chain_id_full.?[i];
+        if (chain_id_full) |v| {
+            v[out_i] = try allocator.dupe(u8, input.chain_id_full.?[i]);
+            chain_id_full_copied += 1;
+        }
         if (residue_num) |v| v[out_i] = input.residue_num.?[i];
         if (insertion_code) |v| v[out_i] = input.insertion_code.?[i];
         out_i += 1;
@@ -3811,22 +3818,44 @@ test "copySelectedAtomInput prefers extended chain IDs over truncated chain IDs"
     const allocator = std.testing.allocator;
     var input = try makeTestAtomInput(allocator, &.{ "ABCD", "ABCD" });
     defer input.deinit();
-    const chain_id_full = try allocator.alloc(types.FixedString32, 2);
-    chain_id_full[0] = types.FixedString32.fromSlice("ABCDE");
-    chain_id_full[1] = types.FixedString32.fromSlice("ABCD");
+    const chain_id_full = try allocator.alloc([]const u8, 2);
+    chain_id_full[0] = try allocator.dupe(u8, "ABCDE");
+    chain_id_full[1] = try allocator.dupe(u8, "ABCD");
     input.chain_id_full = chain_id_full;
 
     var selected_long = try copySelectedAtomInput(allocator, input, &.{"ABCDE"});
     defer selected_long.deinit();
     try std.testing.expectEqual(@as(usize, 1), selected_long.atomCount());
     try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected_long.x[0], 1e-12);
-    try std.testing.expectEqualStrings("ABCDE", selected_long.chain_id_full.?[0].slice());
+    try std.testing.expectEqualStrings("ABCDE", selected_long.chain_id_full.?[0]);
 
     var selected_prefix = try copySelectedAtomInput(allocator, input, &.{"ABCD"});
     defer selected_prefix.deinit();
     try std.testing.expectEqual(@as(usize, 1), selected_prefix.atomCount());
     try std.testing.expectApproxEqAbs(@as(f64, 1.0), selected_prefix.x[0], 1e-12);
-    try std.testing.expectEqualStrings("ABCD", selected_prefix.chain_id_full.?[0].slice());
+    try std.testing.expectEqualStrings("ABCD", selected_prefix.chain_id_full.?[0]);
+}
+
+test "copySelectedAtomInput keeps extended chain IDs lossless beyond fixed buffers" {
+    const allocator = std.testing.allocator;
+    var input = try makeTestAtomInput(allocator, &.{ "ABCD", "ABCD" });
+    defer input.deinit();
+    const chain_id_full = try allocator.alloc([]const u8, 2);
+    chain_id_full[0] = try allocator.dupe(u8, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg");
+    chain_id_full[1] = try allocator.dupe(u8, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef");
+    input.chain_id_full = chain_id_full;
+
+    var selected_long = try copySelectedAtomInput(allocator, input, &.{"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg"});
+    defer selected_long.deinit();
+    try std.testing.expectEqual(@as(usize, 1), selected_long.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 0.0), selected_long.x[0], 1e-12);
+    try std.testing.expectEqualStrings("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg", selected_long.chain_id_full.?[0]);
+
+    var selected_prefix = try copySelectedAtomInput(allocator, input, &.{"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"});
+    defer selected_prefix.deinit();
+    try std.testing.expectEqual(@as(usize, 1), selected_prefix.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), selected_prefix.x[0], 1e-12);
+    try std.testing.expectEqualStrings("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef", selected_prefix.chain_id_full.?[0]);
 }
 
 test "calculatePreparedInputResult computes total for selected input" {
@@ -4304,6 +4333,8 @@ test "workflow mmCIF chain filters preserve long chain IDs" {
     defer allocator.free(workflow_path);
     const input_path = try std.fs.path.join(allocator, &.{ input_dir, "long-chain.cif" });
     defer allocator.free(input_path);
+    const input_path_2 = try std.fs.path.join(allocator, &.{ input_dir, "long-chain-2.cif" });
+    defer allocator.free(input_path_2);
 
     try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
     try std.Io.Dir.cwd().writeFile(std.testing.io, .{
@@ -4321,8 +4352,29 @@ test "workflow mmCIF chain filters preserve long chain IDs" {
         \\_atom_site.Cartn_x
         \\_atom_site.Cartn_y
         \\_atom_site.Cartn_z
-        \\ATOM 1 N N ALA ABCDE 1 0.000 0.000 0.000
-        \\ATOM 2 C CA ALA ABCDE 1 1.500 0.000 0.000
+        \\ATOM 1 N N ALA ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg 1 0.000 0.000 0.000
+        \\ATOM 2 C CA ALA ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg 1 1.500 0.000 0.000
+        \\#
+        \\
+        ,
+    });
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = input_path_2,
+        .data =
+        \\data_LONG_CHAIN_2
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM 1 N N ALA ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef 1 0.000 1.000 0.000
+        \\ATOM 2 C CA ALA ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef 1 1.500 1.000 0.000
         \\#
         \\
         ,
@@ -4348,11 +4400,11 @@ test "workflow mmCIF chain filters preserve long chain IDs" {
         \\
         \\[[jobs]]
         \\name = "long_chain"
-        \\chains = ["ABCDE"]
+        \\chains = ["ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg"]
         \\
         \\[[jobs]]
-        \\name = "truncated_prefix"
-        \\chains = ["ABCD"]
+        \\name = "prefix_chain"
+        \\chains = ["ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"]
         \\
     , .{ input_dir, output_dir });
     defer allocator.free(workflow);
@@ -4362,7 +4414,7 @@ test "workflow mmCIF chain filters preserve long chain IDs" {
 
     const long_chain_jsonl = try std.fs.path.join(allocator, &.{ output_dir, "long_chain.jsonl" });
     defer allocator.free(long_chain_jsonl);
-    const prefix_jsonl = try std.fs.path.join(allocator, &.{ output_dir, "truncated_prefix.jsonl" });
+    const prefix_jsonl = try std.fs.path.join(allocator, &.{ output_dir, "prefix_chain.jsonl" });
     defer allocator.free(prefix_jsonl);
     const long_chain_content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, long_chain_jsonl, allocator, .limited(4096));
     defer allocator.free(long_chain_content);
@@ -4370,7 +4422,9 @@ test "workflow mmCIF chain filters preserve long chain IDs" {
     defer allocator.free(prefix_content);
 
     try std.testing.expect(std.mem.indexOf(u8, long_chain_content, "\"filename\":\"long-chain.cif\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, long_chain_content, "\"filename\":\"long-chain-2.cif\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, prefix_content, "\"filename\":\"long-chain.cif\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, prefix_content, "\"filename\":\"long-chain-2.cif\"") != null);
 }
 
 test "workflowJsonlOutputPath uses job file under output dir" {

--- a/src/bcif_parser.zig
+++ b/src/bcif_parser.zig
@@ -725,8 +725,9 @@ pub const BcifParser = struct {
         defer element_list.deinit(self.allocator);
         var chain_id_list = std.ArrayListUnmanaged(types.FixedString4).empty;
         defer chain_id_list.deinit(self.allocator);
-        var chain_id_full_list = std.ArrayListUnmanaged(types.FixedString32).empty;
+        var chain_id_full_list = std.ArrayListUnmanaged([]const u8).empty;
         defer chain_id_full_list.deinit(self.allocator);
+        errdefer freeStringItems(self.allocator, chain_id_full_list.items);
         var has_extended_chain = false;
         var residue_num_list = std.ArrayListUnmanaged(i32).empty;
         defer residue_num_list.deinit(self.allocator);
@@ -769,11 +770,11 @@ pub const BcifParser = struct {
             if (columns.getChainCol(self.use_auth_chain)) |chain_col| {
                 const chain = scalarString(decoded[chain_col], row) orelse "";
                 try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(chain));
-                try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(chain));
+                try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, chain));
                 has_extended_chain = has_extended_chain or chain.len > 4;
             } else {
                 try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(""));
+                try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, ""));
             }
 
             if (columns.getResSeqCol()) |seq_col| {
@@ -807,11 +808,15 @@ pub const BcifParser = struct {
         const chain_id = try chain_id_list.toOwnedSlice(self.allocator);
         errdefer self.allocator.free(chain_id);
         const chain_id_full_owned = try chain_id_full_list.toOwnedSlice(self.allocator);
-        const chain_id_full: ?[]const types.FixedString32 = if (has_extended_chain) chain_id_full_owned else blk: {
+        const chain_id_full: ?[]const []const u8 = if (has_extended_chain) chain_id_full_owned else blk: {
+            freeStringItems(self.allocator, chain_id_full_owned);
             self.allocator.free(chain_id_full_owned);
             break :blk null;
         };
-        errdefer if (chain_id_full) |chains| self.allocator.free(chains);
+        errdefer if (chain_id_full) |chains| {
+            freeStringItems(self.allocator, chains);
+            self.allocator.free(chains);
+        };
         const residue_num = try residue_num_list.toOwnedSlice(self.allocator);
         errdefer self.allocator.free(residue_num);
         const insertion_code = try insertion_code_list.toOwnedSlice(self.allocator);
@@ -896,6 +901,10 @@ pub const BcifParser = struct {
         return true;
     }
 };
+
+fn freeStringItems(allocator: Allocator, items: []const []const u8) void {
+    for (items) |item| allocator.free(item);
+}
 
 fn parseEncoding(allocator: Allocator, value: MsgValue) DecodeError!Encoding {
     const map = switch (value) {
@@ -1446,6 +1455,7 @@ const BuildBcifOptions = struct {
     omit_chain: bool = false,
     null_first_model: bool = false,
     include_long_chain: bool = false,
+    include_very_long_chain: bool = false,
 };
 
 fn buildMinimalBcif(options: BuildBcifOptions) ![]u8 {
@@ -1453,8 +1463,18 @@ fn buildMinimalBcif(options: BuildBcifOptions) ![]u8 {
     var rows = std.ArrayListUnmanaged(TestAtomRow).empty;
     defer rows.deinit(allocator);
 
-    const first_chain = if (options.include_long_chain) "ABCDE" else "A";
-    const second_chain = if (options.include_long_chain) "ABCD" else "A";
+    const first_chain = if (options.include_very_long_chain)
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg"
+    else if (options.include_long_chain)
+        "ABCDE"
+    else
+        "A";
+    const second_chain = if (options.include_very_long_chain)
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"
+    else if (options.include_long_chain)
+        "ABCD"
+    else
+        "A";
     try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = first_chain, .seq = 1, .x = 10.0, .y = 20.0, .z = 30.0, .model = 1 });
     try rows.append(allocator, .{ .group = "ATOM", .element = "N", .atom = "N", .residue = "ALA", .chain = second_chain, .seq = 1, .x = 11.0, .y = 21.0, .z = 32.0, .model = 1 });
     if (options.include_hydrogen) {
@@ -1878,8 +1898,8 @@ test "parse minimal BinaryCIF atom_site" {
     try std.testing.expectEqual(@as(i32, 1), input.residue_num.?[0]);
 }
 
-test "parse BinaryCIF keeps extended chain IDs when asym_id exceeds four characters" {
-    const source = try buildMinimalBcif(.{ .include_long_chain = true });
+test "parse BinaryCIF keeps extended chain IDs lossless beyond fixed buffers" {
+    const source = try buildMinimalBcif(.{ .include_very_long_chain = true });
     defer std.testing.allocator.free(source);
 
     var parser = BcifParser.init(std.testing.allocator);
@@ -1889,8 +1909,8 @@ test "parse BinaryCIF keeps extended chain IDs when asym_id exceeds four charact
     try std.testing.expectEqual(@as(usize, 2), input.atomCount());
     try std.testing.expect(input.chain_id_full != null);
     try std.testing.expectEqualStrings("ABCD", input.chain_id.?[0].slice());
-    try std.testing.expectEqualStrings("ABCDE", input.chain_id_full.?[0].slice());
-    try std.testing.expectEqualStrings("ABCD", input.chain_id_full.?[1].slice());
+    try std.testing.expectEqualStrings("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg", input.chain_id_full.?[0]);
+    try std.testing.expectEqualStrings("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef", input.chain_id_full.?[1]);
 }
 
 test "parse BinaryCIF with inline CCD data" {

--- a/src/bcif_parser.zig
+++ b/src/bcif_parser.zig
@@ -725,6 +725,9 @@ pub const BcifParser = struct {
         defer element_list.deinit(self.allocator);
         var chain_id_list = std.ArrayListUnmanaged(types.FixedString4).empty;
         defer chain_id_list.deinit(self.allocator);
+        var chain_id_full_list = std.ArrayListUnmanaged(types.FixedString32).empty;
+        defer chain_id_full_list.deinit(self.allocator);
+        var has_extended_chain = false;
         var residue_num_list = std.ArrayListUnmanaged(i32).empty;
         defer residue_num_list.deinit(self.allocator);
         var insertion_code_list = std.ArrayListUnmanaged(types.FixedString4).empty;
@@ -764,9 +767,13 @@ pub const BcifParser = struct {
             }
 
             if (columns.getChainCol(self.use_auth_chain)) |chain_col| {
-                try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(scalarString(decoded[chain_col], row) orelse ""));
+                const chain = scalarString(decoded[chain_col], row) orelse "";
+                try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(chain));
+                try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(chain));
+                has_extended_chain = has_extended_chain or chain.len > 4;
             } else {
                 try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
+                try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(""));
             }
 
             if (columns.getResSeqCol()) |seq_col| {
@@ -799,6 +806,12 @@ pub const BcifParser = struct {
         errdefer self.allocator.free(element);
         const chain_id = try chain_id_list.toOwnedSlice(self.allocator);
         errdefer self.allocator.free(chain_id);
+        const chain_id_full_owned = try chain_id_full_list.toOwnedSlice(self.allocator);
+        const chain_id_full: ?[]const types.FixedString32 = if (has_extended_chain) chain_id_full_owned else blk: {
+            self.allocator.free(chain_id_full_owned);
+            break :blk null;
+        };
+        errdefer if (chain_id_full) |chains| self.allocator.free(chains);
         const residue_num = try residue_num_list.toOwnedSlice(self.allocator);
         errdefer self.allocator.free(residue_num);
         const insertion_code = try insertion_code_list.toOwnedSlice(self.allocator);
@@ -813,6 +826,7 @@ pub const BcifParser = struct {
             .atom_name = atom_name,
             .element = element,
             .chain_id = chain_id,
+            .chain_id_full = chain_id_full,
             .residue_num = residue_num,
             .insertion_code = insertion_code,
             .allocator = self.allocator,
@@ -1431,6 +1445,7 @@ const BuildBcifOptions = struct {
     omit_model: bool = false,
     omit_chain: bool = false,
     null_first_model: bool = false,
+    include_long_chain: bool = false,
 };
 
 fn buildMinimalBcif(options: BuildBcifOptions) ![]u8 {
@@ -1438,8 +1453,10 @@ fn buildMinimalBcif(options: BuildBcifOptions) ![]u8 {
     var rows = std.ArrayListUnmanaged(TestAtomRow).empty;
     defer rows.deinit(allocator);
 
-    try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = "A", .seq = 1, .x = 10.0, .y = 20.0, .z = 30.0, .model = 1 });
-    try rows.append(allocator, .{ .group = "ATOM", .element = "N", .atom = "N", .residue = "ALA", .chain = "A", .seq = 1, .x = 11.0, .y = 21.0, .z = 32.0, .model = 1 });
+    const first_chain = if (options.include_long_chain) "ABCDE" else "A";
+    const second_chain = if (options.include_long_chain) "ABCD" else "A";
+    try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = first_chain, .seq = 1, .x = 10.0, .y = 20.0, .z = 30.0, .model = 1 });
+    try rows.append(allocator, .{ .group = "ATOM", .element = "N", .atom = "N", .residue = "ALA", .chain = second_chain, .seq = 1, .x = 11.0, .y = 21.0, .z = 32.0, .model = 1 });
     if (options.include_hydrogen) {
         try rows.append(allocator, .{ .group = "ATOM", .element = "H", .atom = "H", .residue = "ALA", .chain = "A", .seq = 1, .x = 12.0, .y = 22.0, .z = 33.0, .model = 1 });
     }
@@ -1859,6 +1876,21 @@ test "parse minimal BinaryCIF atom_site" {
     try std.testing.expectEqualStrings("CA", input.atom_name.?[0].slice());
     try std.testing.expectEqualStrings("A", input.chain_id.?[0].slice());
     try std.testing.expectEqual(@as(i32, 1), input.residue_num.?[0]);
+}
+
+test "parse BinaryCIF keeps extended chain IDs when asym_id exceeds four characters" {
+    const source = try buildMinimalBcif(.{ .include_long_chain = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expect(input.chain_id_full != null);
+    try std.testing.expectEqualStrings("ABCD", input.chain_id.?[0].slice());
+    try std.testing.expectEqualStrings("ABCDE", input.chain_id_full.?[0].slice());
+    try std.testing.expectEqualStrings("ABCD", input.chain_id_full.?[1].slice());
 }
 
 test "parse BinaryCIF with inline CCD data" {

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -316,6 +316,9 @@ pub const MmcifParser = struct {
         defer element_list.deinit(self.allocator);
         var chain_id_list = std.ArrayListUnmanaged(types.FixedString4).empty;
         defer chain_id_list.deinit(self.allocator);
+        var chain_id_full_list = std.ArrayListUnmanaged(types.FixedString32).empty;
+        defer chain_id_full_list.deinit(self.allocator);
+        var has_extended_chain = false;
         var residue_num_list = std.ArrayListUnmanaged(i32).empty;
         defer residue_num_list.deinit(self.allocator);
         var insertion_code_list = std.ArrayListUnmanaged(types.FixedString4).empty;
@@ -401,11 +404,15 @@ pub const MmcifParser = struct {
                                 const chain = row_values[chain_col];
                                 if (cif.isNull(chain)) {
                                     try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
+                                    try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(""));
                                 } else {
                                     try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(chain));
+                                    try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(chain));
+                                    has_extended_chain = has_extended_chain or chain.len > 4;
                                 }
                             } else {
                                 try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
+                                try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(""));
                             }
 
                             // Get residue sequence number
@@ -455,6 +462,12 @@ pub const MmcifParser = struct {
             return ParseError.NoAtomSiteLoop;
         }
 
+        const chain_id_full_owned = try chain_id_full_list.toOwnedSlice(self.allocator);
+        const chain_id_full: ?[]const types.FixedString32 = if (has_extended_chain) chain_id_full_owned else blk: {
+            self.allocator.free(chain_id_full_owned);
+            break :blk null;
+        };
+
         return AtomInput{
             .x = try x_list.toOwnedSlice(self.allocator),
             .y = try y_list.toOwnedSlice(self.allocator),
@@ -464,6 +477,7 @@ pub const MmcifParser = struct {
             .atom_name = try atom_name_list.toOwnedSlice(self.allocator),
             .element = try element_list.toOwnedSlice(self.allocator),
             .chain_id = try chain_id_list.toOwnedSlice(self.allocator),
+            .chain_id_full = chain_id_full,
             .residue_num = try residue_num_list.toOwnedSlice(self.allocator),
             .insertion_code = try insertion_code_list.toOwnedSlice(self.allocator),
             .allocator = self.allocator,
@@ -643,6 +657,34 @@ test "parse simple mmCIF" {
     try std.testing.expectEqual(@as(u8, 6), input.element.?[0]); // C
     try std.testing.expectEqual(@as(u8, 7), input.element.?[1]); // N
     try std.testing.expectEqual(@as(u8, 8), input.element.?[2]); // O
+}
+
+test "parse mmCIF keeps extended chain IDs when label_asym_id exceeds four characters" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CA ALA ABCDE 10.000 20.000 30.000
+        \\2 N N  ALA ABCD  11.000 21.000 31.000
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expect(input.chain_id_full != null);
+    try std.testing.expectEqualStrings("ABCD", input.chain_id.?[0].slice());
+    try std.testing.expectEqualStrings("ABCDE", input.chain_id_full.?[0].slice());
+    try std.testing.expectEqualStrings("ABCD", input.chain_id_full.?[1].slice());
 }
 
 test "parse with alternate locations" {

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -316,8 +316,9 @@ pub const MmcifParser = struct {
         defer element_list.deinit(self.allocator);
         var chain_id_list = std.ArrayListUnmanaged(types.FixedString4).empty;
         defer chain_id_list.deinit(self.allocator);
-        var chain_id_full_list = std.ArrayListUnmanaged(types.FixedString32).empty;
+        var chain_id_full_list = std.ArrayListUnmanaged([]const u8).empty;
         defer chain_id_full_list.deinit(self.allocator);
+        errdefer freeStringItems(self.allocator, chain_id_full_list.items);
         var has_extended_chain = false;
         var residue_num_list = std.ArrayListUnmanaged(i32).empty;
         defer residue_num_list.deinit(self.allocator);
@@ -404,15 +405,15 @@ pub const MmcifParser = struct {
                                 const chain = row_values[chain_col];
                                 if (cif.isNull(chain)) {
                                     try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                                    try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(""));
+                                    try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, ""));
                                 } else {
                                     try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(chain));
-                                    try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(chain));
+                                    try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, chain));
                                     has_extended_chain = has_extended_chain or chain.len > 4;
                                 }
                             } else {
                                 try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                                try chain_id_full_list.append(self.allocator, types.FixedString32.fromSlice(""));
+                                try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, ""));
                             }
 
                             // Get residue sequence number
@@ -462,24 +463,49 @@ pub const MmcifParser = struct {
             return ParseError.NoAtomSiteLoop;
         }
 
+        const x = try x_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(x);
+        const y = try y_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(y);
+        const z = try z_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(z);
+        const r = try r_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(r);
+        const residue = try residue_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(residue);
+        const atom_name = try atom_name_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(atom_name);
+        const element = try element_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(element);
+        const chain_id = try chain_id_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(chain_id);
         const chain_id_full_owned = try chain_id_full_list.toOwnedSlice(self.allocator);
-        const chain_id_full: ?[]const types.FixedString32 = if (has_extended_chain) chain_id_full_owned else blk: {
+        const chain_id_full: ?[]const []const u8 = if (has_extended_chain) chain_id_full_owned else blk: {
+            freeStringItems(self.allocator, chain_id_full_owned);
             self.allocator.free(chain_id_full_owned);
             break :blk null;
         };
+        errdefer if (chain_id_full) |chains| {
+            freeStringItems(self.allocator, chains);
+            self.allocator.free(chains);
+        };
+        const residue_num = try residue_num_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(residue_num);
+        const insertion_code = try insertion_code_list.toOwnedSlice(self.allocator);
+        errdefer self.allocator.free(insertion_code);
 
         return AtomInput{
-            .x = try x_list.toOwnedSlice(self.allocator),
-            .y = try y_list.toOwnedSlice(self.allocator),
-            .z = try z_list.toOwnedSlice(self.allocator),
-            .r = try r_list.toOwnedSlice(self.allocator),
-            .residue = try residue_list.toOwnedSlice(self.allocator),
-            .atom_name = try atom_name_list.toOwnedSlice(self.allocator),
-            .element = try element_list.toOwnedSlice(self.allocator),
-            .chain_id = try chain_id_list.toOwnedSlice(self.allocator),
+            .x = x,
+            .y = y,
+            .z = z,
+            .r = r,
+            .residue = residue,
+            .atom_name = atom_name,
+            .element = element,
+            .chain_id = chain_id,
             .chain_id_full = chain_id_full,
-            .residue_num = try residue_num_list.toOwnedSlice(self.allocator),
-            .insertion_code = try insertion_code_list.toOwnedSlice(self.allocator),
+            .residue_num = residue_num,
+            .insertion_code = insertion_code,
             .allocator = self.allocator,
         };
     }
@@ -565,6 +591,10 @@ pub const MmcifParser = struct {
         return true;
     }
 };
+
+fn freeStringItems(allocator: Allocator, items: []const []const u8) void {
+    for (items) |item| allocator.free(item);
+}
 
 /// Parse a float from a string, handling CIF null values
 fn parseFloat(s: []const u8) !f64 {
@@ -671,8 +701,8 @@ test "parse mmCIF keeps extended chain IDs when label_asym_id exceeds four chara
         \\_atom_site.Cartn_x
         \\_atom_site.Cartn_y
         \\_atom_site.Cartn_z
-        \\1 C CA ALA ABCDE 10.000 20.000 30.000
-        \\2 N N  ALA ABCD  11.000 21.000 31.000
+        \\1 C CA ALA ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg 10.000 20.000 30.000
+        \\2 N N  ALA ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef  11.000 21.000 31.000
         \\#
     ;
 
@@ -683,8 +713,8 @@ test "parse mmCIF keeps extended chain IDs when label_asym_id exceeds four chara
     try std.testing.expectEqual(@as(usize, 2), input.atomCount());
     try std.testing.expect(input.chain_id_full != null);
     try std.testing.expectEqualStrings("ABCD", input.chain_id.?[0].slice());
-    try std.testing.expectEqualStrings("ABCDE", input.chain_id_full.?[0].slice());
-    try std.testing.expectEqualStrings("ABCD", input.chain_id_full.?[1].slice());
+    try std.testing.expectEqualStrings("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg", input.chain_id_full.?[0]);
+    try std.testing.expectEqualStrings("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef", input.chain_id_full.?[1]);
 }
 
 test "parse with alternate locations" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -168,32 +168,6 @@ pub const FixedString5 = struct {
     }
 };
 
-/// Fixed-size string for extended chain identifiers (max 32 characters).
-/// Used only when a format can carry chain IDs that do not fit FixedString4.
-pub const FixedString32 = struct {
-    data: [32]u8 = [_]u8{0} ** 32,
-    len: u8 = 0,
-
-    /// Create from a slice (truncates if > 32 chars)
-    pub fn fromSlice(s: []const u8) FixedString32 {
-        var result = FixedString32{};
-        const copy_len: u8 = @intCast(@min(s.len, 32));
-        @memcpy(result.data[0..copy_len], s[0..copy_len]);
-        result.len = copy_len;
-        return result;
-    }
-
-    /// Get as slice
-    pub fn slice(self: *const FixedString32) []const u8 {
-        return self.data[0..self.len];
-    }
-
-    /// Check equality with a slice
-    pub fn eqlSlice(self: *const FixedString32, s: []const u8) bool {
-        return self.len == s.len and std.mem.eql(u8, self.slice(), s);
-    }
-};
-
 /// Input data structure for SASA calculation
 pub const AtomInput = struct {
     x: []const f64,
@@ -211,10 +185,10 @@ pub const AtomInput = struct {
     /// Chain IDs (e.g., "A", "B") - optional, for per-chain analysis
     chain_id: ?[]const FixedString4 = null,
     /// Extended chain IDs for formats that can exceed four characters (e.g. mmCIF).
-    /// When present, this mirrors `chain_id` length.
+    /// When present, this mirrors `chain_id` length and owns each string.
     /// Existing output paths keep using `chain_id` for compatibility; chain
     /// filtering should prefer this field when it is available.
-    chain_id_full: ?[]const FixedString32 = null,
+    chain_id_full: ?[]const []const u8 = null,
     /// Residue sequence numbers - optional, for per-residue analysis
     residue_num: ?[]const i32 = null,
     /// Insertion codes (e.g., "", "A", "B") - optional, for per-residue analysis
@@ -262,6 +236,9 @@ pub const AtomInput = struct {
             self.allocator.free(chains);
         }
         if (self.chain_id_full) |chains| {
+            for (chains) |chain| {
+                self.allocator.free(chain);
+            }
             self.allocator.free(chains);
         }
         if (self.residue_num) |nums| {

--- a/src/types.zig
+++ b/src/types.zig
@@ -168,6 +168,32 @@ pub const FixedString5 = struct {
     }
 };
 
+/// Fixed-size string for extended chain identifiers (max 32 characters).
+/// Used only when a format can carry chain IDs that do not fit FixedString4.
+pub const FixedString32 = struct {
+    data: [32]u8 = [_]u8{0} ** 32,
+    len: u8 = 0,
+
+    /// Create from a slice (truncates if > 32 chars)
+    pub fn fromSlice(s: []const u8) FixedString32 {
+        var result = FixedString32{};
+        const copy_len: u8 = @intCast(@min(s.len, 32));
+        @memcpy(result.data[0..copy_len], s[0..copy_len]);
+        result.len = copy_len;
+        return result;
+    }
+
+    /// Get as slice
+    pub fn slice(self: *const FixedString32) []const u8 {
+        return self.data[0..self.len];
+    }
+
+    /// Check equality with a slice
+    pub fn eqlSlice(self: *const FixedString32, s: []const u8) bool {
+        return self.len == s.len and std.mem.eql(u8, self.slice(), s);
+    }
+};
+
 /// Input data structure for SASA calculation
 pub const AtomInput = struct {
     x: []const f64,
@@ -184,6 +210,11 @@ pub const AtomInput = struct {
     element: ?[]const u8 = null,
     /// Chain IDs (e.g., "A", "B") - optional, for per-chain analysis
     chain_id: ?[]const FixedString4 = null,
+    /// Extended chain IDs for formats that can exceed four characters (e.g. mmCIF).
+    /// When present, this mirrors `chain_id` length.
+    /// Existing output paths keep using `chain_id` for compatibility; chain
+    /// filtering should prefer this field when it is available.
+    chain_id_full: ?[]const FixedString32 = null,
     /// Residue sequence numbers - optional, for per-residue analysis
     residue_num: ?[]const i32 = null,
     /// Insertion codes (e.g., "", "A", "B") - optional, for per-residue analysis
@@ -228,6 +259,9 @@ pub const AtomInput = struct {
             self.allocator.free(elem);
         }
         if (self.chain_id) |chains| {
+            self.allocator.free(chains);
+        }
+        if (self.chain_id_full) |chains| {
             self.allocator.free(chains);
         }
         if (self.residue_num) |nums| {


### PR DESCRIPTION
## Summary
- Enables file-first workflow execution for chain-filtered mmCIF and BinaryCIF inputs by carrying extended chain IDs through `AtomInput` selection metadata.
- Adds file-level parallelism to workflow file-first execution so multi-job workflows avoid repeated parsing without losing batch throughput.
- Expands parser and workflow tests for long chain IDs, prefix-safety, JSONL/per-file layout, and BCIF/mmCIF extended chain metadata.

## Validation
- `zig fmt --check src/`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa --help`
- `./zig-out/bin/zsasa --version`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json`
- Compared n0128 AFDB dimer workflow JSONL output against `main` after sorting per-job output.
- Smoke benchmarked AFDB dimer symlink samples:
  - n0128 parse-stress: new ~0.21-0.23s real vs main ~0.40-0.44s real
  - n0512 parse-stress: new ~1.01s real vs main ~1.60s real
  - n2048 parse-stress: new ~4.40s real vs main ~6.18s real
