### PR TITLE
feat: add experimental bitmask bias correction

### DIFF
--- a/python/tests/test_sasa.py
+++ b/python/tests/test_sasa.py
@@ -590,6 +590,31 @@ class TestBitmask:
         expected = 4 * np.pi * (1.5 + 1.4) ** 2
         assert abs(result.total_area - expected) < 2.0
 
+    def test_bitmask_correction_increases_partial_overlap(self):
+        """Correction should increase partially occluded bitmask SASA."""
+        coords = np.array([[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]])
+        radii = np.array([1.5, 1.5])
+
+        raw = calculate_sasa(coords, radii, n_points=128, use_bitmask=True)
+        corrected = calculate_sasa(
+            coords,
+            radii,
+            n_points=128,
+            use_bitmask=True,
+            bitmask_correction=True,
+            bitmask_correction_coeff=0.2,
+        )
+
+        assert corrected.total_area > raw.total_area
+
+    def test_bitmask_correction_requires_bitmask(self):
+        """Correction without bitmask mode should raise ValueError."""
+        coords = np.array([[0.0, 0.0, 0.0]])
+        radii = np.array([1.5])
+
+        with pytest.raises(ValueError, match="bitmask_correction=True requires use_bitmask=True"):
+            calculate_sasa(coords, radii, bitmask_correction=True)
+
     def test_bitmask_all_supported_n_points(self):
         """Bitmask should work for all supported n_points values."""
         coords = np.array([[0.0, 0.0, 0.0]])
@@ -618,6 +643,14 @@ class TestBitmask:
             assert len(w) == 1
             assert "Falling back" in str(w[0].message)
         assert result.total_area > 0
+
+    def test_bitmask_correction_unsupported_n_points_raises(self):
+        """Correction should not silently fall back when bitmask n_points is unsupported."""
+        coords = np.array([[0.0, 0.0, 0.0]])
+        radii = np.array([1.5])
+
+        with pytest.raises(ValueError, match="bitmask_correction=True requires n_points"):
+            calculate_sasa(coords, radii, n_points=2000, use_bitmask=True, bitmask_correction=True)
 
     def test_bitmask_default_n_points_works(self):
         """use_bitmask=True with default n_points (100) should work."""
@@ -648,6 +681,28 @@ class TestBitmask:
         assert bitmask.atom_areas.shape == (n_frames, 2)
         np.testing.assert_allclose(bitmask.atom_areas, standard.atom_areas, rtol=0.02)
 
+    def test_bitmask_batch_correction_increases_partial_overlap(self):
+        """Batch correction should increase partially occluded bitmask SASA."""
+        from zsasa import calculate_sasa_batch
+
+        coords = np.array(
+            [[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]],
+            dtype=np.float32,
+        )
+        radii = np.array([1.5, 1.5], dtype=np.float32)
+
+        raw = calculate_sasa_batch(coords, radii, n_points=128, use_bitmask=True)
+        corrected = calculate_sasa_batch(
+            coords,
+            radii,
+            n_points=128,
+            use_bitmask=True,
+            bitmask_correction=True,
+            bitmask_correction_coeff=0.2,
+        )
+
+        assert corrected.total_areas[0] > raw.total_areas[0]
+
     def test_bitmask_batch_invalid_algorithm(self):
         """Batch bitmask with algorithm='lr' should raise ValueError."""
         from zsasa import calculate_sasa_batch
@@ -671,6 +726,22 @@ class TestBitmask:
             assert len(w) == 1
             assert "Falling back" in str(w[0].message)
         assert result.atom_areas.sum() > 0
+
+    def test_bitmask_batch_correction_unsupported_n_points_raises(self):
+        """Batch correction should not silently fall back when bitmask n_points is unsupported."""
+        from zsasa import calculate_sasa_batch
+
+        coords = np.array([[[0.0, 0.0, 0.0]]], dtype=np.float32)
+        radii = np.array([1.5], dtype=np.float32)
+
+        with pytest.raises(ValueError, match="bitmask_correction=True requires n_points"):
+            calculate_sasa_batch(
+                coords,
+                radii,
+                n_points=2000,
+                use_bitmask=True,
+                bitmask_correction=True,
+            )
 
     def test_bitmask_batch_f32_precision(self):
         """Bitmask batch with f32 precision should work."""

--- a/python/zsasa/_ffi.py
+++ b/python/zsasa/_ffi.py
@@ -23,16 +23,23 @@ _BITMASK_MIN_N_POINTS = 1
 _BITMASK_MAX_N_POINTS = 1024
 
 
-def _validate_bitmask_params(algorithm: str, n_points: int) -> bool:
+def _validate_bitmask_params(algorithm: str, n_points: int, *, strict: bool = False) -> bool:
     """Validate parameters for bitmask mode.
 
     Returns True if bitmask should be used, False if falling back to standard SR.
-    Raises ValueError if algorithm is incompatible (not SR).
+    Raises ValueError if algorithm is incompatible (not SR), or if strict=True
+    and n_points is outside the bitmask range.
     """
     if algorithm != "sr":
         msg = "use_bitmask=True only supports algorithm='sr' (Shrake-Rupley)"
         raise ValueError(msg)
     if not (_BITMASK_MIN_N_POINTS <= n_points <= _BITMASK_MAX_N_POINTS):
+        if strict:
+            msg = (
+                f"bitmask_correction=True requires n_points in "
+                f"{_BITMASK_MIN_N_POINTS}..{_BITMASK_MAX_N_POINTS}, got {n_points}"
+            )
+            raise ValueError(msg)
         warnings.warn(
             f"use_bitmask=True requires n_points in "
             f"{_BITMASK_MIN_N_POINTS}..{_BITMASK_MAX_N_POINTS}, got {n_points}. "
@@ -109,6 +116,12 @@ _CDEF = """
         double* atom_areas, double* total_area
     );
 
+    int zsasa_calc_sr_bitmask_corrected(
+        const double* x, const double* y, const double* z, const double* radii,
+        size_t n_atoms, uint32_t n_points, double probe_radius, size_t n_threads,
+        double correction_coeff, double* atom_areas, double* total_area
+    );
+
     // Bitmask batch SASA calculation (f64 internal precision)
     int zsasa_calc_sr_batch_bitmask(
         const float* coordinates, size_t n_frames, size_t n_atoms,
@@ -116,11 +129,23 @@ _CDEF = """
         size_t n_threads, float* atom_areas
     );
 
+    int zsasa_calc_sr_batch_bitmask_corrected(
+        const float* coordinates, size_t n_frames, size_t n_atoms,
+        const float* radii, uint32_t n_points, float probe_radius,
+        size_t n_threads, double correction_coeff, float* atom_areas
+    );
+
     // Bitmask batch SASA calculation (f32 internal precision)
     int zsasa_calc_sr_batch_bitmask_f32(
         const float* coordinates, size_t n_frames, size_t n_atoms,
         const float* radii, uint32_t n_points, float probe_radius,
         size_t n_threads, float* atom_areas
+    );
+
+    int zsasa_calc_sr_batch_bitmask_f32_corrected(
+        const float* coordinates, size_t n_frames, size_t n_atoms,
+        const float* radii, uint32_t n_points, float probe_radius,
+        size_t n_threads, double correction_coeff, float* atom_areas
     );
 
     // Classifier functions

--- a/python/zsasa/dcd.py
+++ b/python/zsasa/dcd.py
@@ -240,6 +240,8 @@ def compute_sasa_trajectory(
     stop: int | None = None,
     step: int = 1,
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> TrajectorySasaResult:
     """Compute SASA for a DCD trajectory using native Zig reader.
 
@@ -272,6 +274,12 @@ def compute_sasa_trajectory(
     use_bitmask : bool, optional
         Use bitmask LUT optimization for SR algorithm.
         Supports n_points 1..1024. Default: False.
+    bitmask_correction : bool, optional
+        Apply experimental bitmask exposed-fraction correction.
+        Requires use_bitmask=True. Default: False.
+    bitmask_correction_coeff : float, optional
+        Override the experimental correction coefficient.
+        None uses the library default.
 
     Returns
     -------
@@ -340,6 +348,8 @@ def compute_sasa_trajectory(
         probe_radius=probe_radius,
         n_threads=n_threads,
         use_bitmask=use_bitmask,
+        bitmask_correction=bitmask_correction,
+        bitmask_correction_coeff=bitmask_correction_coeff,
     )
 
     return TrajectorySasaResult(

--- a/python/zsasa/mdanalysis.py
+++ b/python/zsasa/mdanalysis.py
@@ -190,6 +190,8 @@ class SASAAnalysis:
         n_slices: int = 20,
         n_threads: int = 0,
         use_bitmask: bool = False,
+        bitmask_correction: bool = False,
+        bitmask_correction_coeff: float | None = None,
     ) -> SASAAnalysis:
         """Run the SASA analysis.
 
@@ -215,6 +217,12 @@ class SASAAnalysis:
         use_bitmask : bool, optional
             Use bitmask LUT optimization for SR algorithm.
             Supports n_points 1..1024. Default: False.
+        bitmask_correction : bool, optional
+            Apply experimental bitmask exposed-fraction correction.
+            Requires use_bitmask=True. Default: False.
+        bitmask_correction_coeff : float, optional
+            Override the experimental correction coefficient.
+            None uses the library default.
 
         Returns
         -------
@@ -257,6 +265,8 @@ class SASAAnalysis:
                 probe_radius=probe_radius,
                 n_threads=n_threads,
                 use_bitmask=use_bitmask,
+                bitmask_correction=bitmask_correction,
+                bitmask_correction_coeff=bitmask_correction_coeff,
             )
         elif algorithm == "lr":
             result = calculate_sasa_batch(
@@ -267,6 +277,8 @@ class SASAAnalysis:
                 probe_radius=probe_radius,
                 n_threads=n_threads,
                 use_bitmask=use_bitmask,
+                bitmask_correction=bitmask_correction,
+                bitmask_correction_coeff=bitmask_correction_coeff,
             )
         else:
             msg = f"Unknown algorithm: {algorithm}. Use 'sr' or 'lr'."
@@ -324,6 +336,8 @@ def compute_sasa(
     n_threads: int = 0,
     mode: Literal["atom", "residue", "total"] = "atom",
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> NDArray[np.float32]:
     """Compute SASA for MDAnalysis Universe or AtomGroup.
 
@@ -356,6 +370,12 @@ def compute_sasa(
     use_bitmask : bool, optional
         Use bitmask LUT optimization for SR algorithm.
         Supports n_points 1..1024. Default: False.
+    bitmask_correction : bool, optional
+        Apply experimental bitmask exposed-fraction correction.
+        Requires use_bitmask=True. Default: False.
+    bitmask_correction_coeff : float, optional
+        Override the experimental correction coefficient.
+        None uses the library default.
 
     Returns
     -------
@@ -377,6 +397,8 @@ def compute_sasa(
         n_slices=n_slices,
         n_threads=n_threads,
         use_bitmask=use_bitmask,
+        bitmask_correction=bitmask_correction,
+        bitmask_correction_coeff=bitmask_correction_coeff,
     )
 
     if mode == "total":

--- a/python/zsasa/mdtraj.py
+++ b/python/zsasa/mdtraj.py
@@ -112,6 +112,8 @@ def compute_sasa(
     n_threads: int = 0,
     mode: Literal["atom", "residue", "total"] = "atom",
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> NDArray[np.float32]:
     """Compute SASA for MDTraj trajectory using zsasa.
 
@@ -134,6 +136,10 @@ def compute_sasa(
               Default: "atom".
         use_bitmask: Use bitmask LUT optimization for SR algorithm.
             Supports n_points 1..1024. Default: False.
+        bitmask_correction: Apply experimental bitmask exposed-fraction
+            correction. Requires use_bitmask=True. Default: False.
+        bitmask_correction_coeff: Optional non-negative correction coefficient.
+            None uses the library default.
 
     Returns:
         SASA values in nm² (matching MDTraj's output units).
@@ -180,6 +186,8 @@ def compute_sasa(
             probe_radius=probe_radius,
             n_threads=n_threads,
             use_bitmask=use_bitmask,
+            bitmask_correction=bitmask_correction,
+            bitmask_correction_coeff=bitmask_correction_coeff,
         )
     elif algorithm == "lr":
         result = calculate_sasa_batch(
@@ -190,6 +198,8 @@ def compute_sasa(
             probe_radius=probe_radius,
             n_threads=n_threads,
             use_bitmask=use_bitmask,
+            bitmask_correction=bitmask_correction,
+            bitmask_correction_coeff=bitmask_correction_coeff,
         )
     else:
         msg = f"Unknown algorithm: {algorithm}. Use 'sr' or 'lr'."

--- a/python/zsasa/sasa.py
+++ b/python/zsasa/sasa.py
@@ -44,6 +44,8 @@ def calculate_sasa(
     probe_radius: float = 1.4,
     n_threads: int = 0,
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> SasaResult:
     """Calculate Solvent Accessible Surface Area (SASA).
 
@@ -57,6 +59,10 @@ def calculate_sasa(
         n_threads: Number of threads to use. 0 = auto-detect. Default: 0.
         use_bitmask: Use bitmask LUT optimization for SR algorithm.
             Supports n_points 1..1024. Default: False.
+        bitmask_correction: Apply experimental bitmask exposed-fraction
+            correction. Requires use_bitmask=True. Default: False.
+        bitmask_correction_coeff: Optional non-negative correction coefficient.
+            Defaults to the library's experimental coefficient when omitted.
 
     Returns:
         SasaResult containing total_area and per-atom atom_areas.
@@ -89,10 +95,18 @@ def calculate_sasa(
     if n_threads < 0:
         msg = f"n_threads must be non-negative, got {n_threads}"
         raise ValueError(msg)
+    if bitmask_correction and not use_bitmask:
+        msg = "bitmask_correction=True requires use_bitmask=True"
+        raise ValueError(msg)
+    if bitmask_correction_coeff is not None and (
+        bitmask_correction_coeff < 0 or not np.isfinite(bitmask_correction_coeff)
+    ):
+        msg = f"bitmask_correction_coeff must be non-negative, got {bitmask_correction_coeff}"
+        raise ValueError(msg)
 
     # Validate bitmask constraints
     if use_bitmask:
-        use_bitmask = _validate_bitmask_params(algorithm, n_points)
+        use_bitmask = _validate_bitmask_params(algorithm, n_points, strict=bitmask_correction)
 
     # Validate and convert inputs
     coords = np.ascontiguousarray(coords, dtype=np.float64)
@@ -129,18 +143,34 @@ def calculate_sasa(
 
     # Call the appropriate function
     if use_bitmask:
-        result = lib.zsasa_calc_sr_bitmask(
-            x_ptr,
-            y_ptr,
-            z_ptr,
-            radii_ptr,
-            n_atoms,
-            n_points,
-            probe_radius,
-            n_threads,
-            areas_ptr,
-            total_area,
-        )
+        if bitmask_correction:
+            coeff = 0.020 if bitmask_correction_coeff is None else bitmask_correction_coeff
+            result = lib.zsasa_calc_sr_bitmask_corrected(
+                x_ptr,
+                y_ptr,
+                z_ptr,
+                radii_ptr,
+                n_atoms,
+                n_points,
+                probe_radius,
+                n_threads,
+                coeff,
+                areas_ptr,
+                total_area,
+            )
+        else:
+            result = lib.zsasa_calc_sr_bitmask(
+                x_ptr,
+                y_ptr,
+                z_ptr,
+                radii_ptr,
+                n_atoms,
+                n_points,
+                probe_radius,
+                n_threads,
+                areas_ptr,
+                total_area,
+            )
     elif algorithm == "sr":
         result = lib.zsasa_calc_sr(
             x_ptr,
@@ -238,6 +268,8 @@ def calculate_sasa_batch(
     n_threads: int = 0,
     precision: Literal["f64", "f32"] = "f64",
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> BatchSasaResult:
     """Calculate SASA for multiple frames (batch processing).
 
@@ -256,6 +288,10 @@ def calculate_sasa_batch(
             or "f32" (matches RustSASA/mdsasa-bolt for comparison). Default: "f64".
         use_bitmask: Use bitmask LUT optimization for SR algorithm.
             Supports n_points 1..1024. Default: False.
+        bitmask_correction: Apply experimental bitmask exposed-fraction
+            correction. Requires use_bitmask=True. Default: False.
+        bitmask_correction_coeff: Optional non-negative correction coefficient.
+            Defaults to the library's experimental coefficient when omitted.
 
     Returns:
         BatchSasaResult containing per-atom SASA for all frames.
@@ -289,10 +325,18 @@ def calculate_sasa_batch(
     if n_threads < 0:
         msg = f"n_threads must be non-negative, got {n_threads}"
         raise ValueError(msg)
+    if bitmask_correction and not use_bitmask:
+        msg = "bitmask_correction=True requires use_bitmask=True"
+        raise ValueError(msg)
+    if bitmask_correction_coeff is not None and (
+        bitmask_correction_coeff < 0 or not np.isfinite(bitmask_correction_coeff)
+    ):
+        msg = f"bitmask_correction_coeff must be non-negative, got {bitmask_correction_coeff}"
+        raise ValueError(msg)
 
     # Validate bitmask constraints
     if use_bitmask:
-        use_bitmask = _validate_bitmask_params(algorithm, n_points)
+        use_bitmask = _validate_bitmask_params(algorithm, n_points, strict=bitmask_correction)
 
     # Validate and convert inputs
     coordinates = np.ascontiguousarray(coordinates, dtype=np.float32)
@@ -323,28 +367,55 @@ def calculate_sasa_batch(
 
     # Call the appropriate batch function based on algorithm, precision, and bitmask
     if use_bitmask:
+        coeff = 0.020 if bitmask_correction_coeff is None else bitmask_correction_coeff
         if precision == "f32":
-            result = lib.zsasa_calc_sr_batch_bitmask_f32(
-                coords_ptr,
-                n_frames,
-                n_atoms,
-                radii_ptr,
-                n_points,
-                probe_radius,
-                n_threads,
-                areas_ptr,
-            )
+            if bitmask_correction:
+                result = lib.zsasa_calc_sr_batch_bitmask_f32_corrected(
+                    coords_ptr,
+                    n_frames,
+                    n_atoms,
+                    radii_ptr,
+                    n_points,
+                    probe_radius,
+                    n_threads,
+                    coeff,
+                    areas_ptr,
+                )
+            else:
+                result = lib.zsasa_calc_sr_batch_bitmask_f32(
+                    coords_ptr,
+                    n_frames,
+                    n_atoms,
+                    radii_ptr,
+                    n_points,
+                    probe_radius,
+                    n_threads,
+                    areas_ptr,
+                )
         else:
-            result = lib.zsasa_calc_sr_batch_bitmask(
-                coords_ptr,
-                n_frames,
-                n_atoms,
-                radii_ptr,
-                n_points,
-                probe_radius,
-                n_threads,
-                areas_ptr,
-            )
+            if bitmask_correction:
+                result = lib.zsasa_calc_sr_batch_bitmask_corrected(
+                    coords_ptr,
+                    n_frames,
+                    n_atoms,
+                    radii_ptr,
+                    n_points,
+                    probe_radius,
+                    n_threads,
+                    coeff,
+                    areas_ptr,
+                )
+            else:
+                result = lib.zsasa_calc_sr_batch_bitmask(
+                    coords_ptr,
+                    n_frames,
+                    n_atoms,
+                    radii_ptr,
+                    n_points,
+                    probe_radius,
+                    n_threads,
+                    areas_ptr,
+                )
     elif precision == "f64":
         # Default: f32 I/O with f64 internal precision
         if algorithm == "sr":

--- a/python/zsasa/xtc.py
+++ b/python/zsasa/xtc.py
@@ -270,6 +270,8 @@ def compute_sasa_trajectory(
     stop: int | None = None,
     step: int = 1,
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> TrajectorySasaResult:
     """Compute SASA for an XTC trajectory using native Zig reader.
 
@@ -302,6 +304,12 @@ def compute_sasa_trajectory(
     use_bitmask : bool, optional
         Use bitmask LUT optimization for SR algorithm.
         Supports n_points 1..1024. Default: False.
+    bitmask_correction : bool, optional
+        Apply experimental bitmask exposed-fraction correction.
+        Requires use_bitmask=True. Default: False.
+    bitmask_correction_coeff : float, optional
+        Override the experimental correction coefficient.
+        None uses the library default.
 
     Returns
     -------
@@ -373,6 +381,8 @@ def compute_sasa_trajectory(
         probe_radius=probe_radius,
         n_threads=n_threads,
         use_bitmask=use_bitmask,
+        bitmask_correction=bitmask_correction,
+        bitmask_correction_coeff=bitmask_correction_coeff,
     )
 
     return TrajectorySasaResult(

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -70,6 +70,8 @@ pub const BatchConfig = struct {
     include_hydrogens: bool = false, // Include hydrogen atoms (default: exclude)
     include_hetatm: bool = false, // Include HETATM records (default: exclude)
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
+    bitmask_correction: bool = false, // Experimental exposed-fraction correction for bitmask SR
+    bitmask_correction_coeff: f64 = shrake_rupley_bitmask.default_bitmask_correction_coeff,
     adaptive_sr: bool = false, // Experimental two-stage bitmask SR for batch mode
     coarse_points: u32 = 64,
     fine_points: u32 = 256,
@@ -268,20 +270,26 @@ fn calculateSasaDispatch(
     }
 
     if (bitmask_lut_ptr) |lut| {
+        const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(T){
+            .enabled = config.bitmask_correction,
+            .coeff = @floatCast(config.bitmask_correction_coeff),
+        };
         return if (n_threads > 1)
-            shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(T).calculateSasaParallelWithLut(
+            shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(T).calculateSasaParallelWithLutAndCorrection(
                 allocator,
                 input,
                 sr_config,
                 n_threads,
                 lut,
+                correction,
             )
         else
-            shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(T).calculateSasaWithLut(
+            shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(T).calculateSasaWithLutAndCorrection(
                 allocator,
                 input,
                 sr_config,
                 lut,
+                correction,
             );
     }
 
@@ -2143,6 +2151,8 @@ pub const BatchArgs = struct {
     include_hydrogens: bool = false,
     include_hetatm: bool = false,
     use_bitmask: bool = false,
+    bitmask_correction: bool = false,
+    bitmask_correction_coeff: f64 = shrake_rupley_bitmask.default_bitmask_correction_coeff,
     adaptive_sr: bool = false,
     coarse_points: u32 = 64,
     fine_points: u32 = 256,
@@ -2165,6 +2175,8 @@ pub const BatchArgs = struct {
     include_hydrogens_explicit: bool = false,
     include_hetatm_explicit: bool = false,
     use_bitmask_explicit: bool = false,
+    bitmask_correction_explicit: bool = false,
+    bitmask_correction_coeff_explicit: bool = false,
     adaptive_sr_explicit: bool = false,
     coarse_points_explicit: bool = false,
     fine_points_explicit: bool = false,
@@ -2246,6 +2258,18 @@ fn parseBitmaskPoints(option_name: []const u8, value: []const u8) u32 {
         std.process.exit(1);
     }
     return n;
+}
+
+fn parseBitmaskCorrectionCoeff(value: []const u8) f64 {
+    const coeff = std.fmt.parseFloat(f64, value) catch {
+        std.debug.print("Error: Invalid bitmask correction coefficient: {s}\n", .{value});
+        std.process.exit(1);
+    };
+    if (!std.math.isFinite(coeff) or coeff < 0.0) {
+        std.debug.print("Error: Bitmask correction coefficient must be finite and non-negative: {d}\n", .{coeff});
+        std.process.exit(1);
+    }
+    return coeff;
 }
 
 fn parseAdaptiveThreshold(option_name: []const u8, value: []const u8) f64 {
@@ -2522,6 +2546,28 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
             result.use_bitmask = true;
             result.use_bitmask_explicit = true;
         }
+        // --bitmask-correction
+        else if (std.mem.eql(u8, arg, "--bitmask-correction")) {
+            result.bitmask_correction = true;
+            result.bitmask_correction_explicit = true;
+        }
+        // --bitmask-correction-coeff=VALUE or --bitmask-correction-coeff VALUE
+        else if (std.mem.startsWith(u8, arg, "--bitmask-correction-coeff=")) {
+            result.bitmask_correction_coeff = parseBitmaskCorrectionCoeff(arg["--bitmask-correction-coeff=".len..]);
+            result.bitmask_correction = true;
+            result.bitmask_correction_explicit = true;
+            result.bitmask_correction_coeff_explicit = true;
+        } else if (std.mem.eql(u8, arg, "--bitmask-correction-coeff")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --bitmask-correction-coeff\n", .{});
+                std.process.exit(1);
+            }
+            result.bitmask_correction_coeff = parseBitmaskCorrectionCoeff(args[i]);
+            result.bitmask_correction = true;
+            result.bitmask_correction_explicit = true;
+            result.bitmask_correction_coeff_explicit = true;
+        }
         // --adaptive-sr and adaptive bitmask controls
         else if (std.mem.eql(u8, arg, "--adaptive-sr")) {
             result.adaptive_sr = true;
@@ -2717,6 +2763,11 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --include-hetatm    Include HETATM records (default: exclude)
         \\    --use-bitmask       Use bitmask LUT optimization for SR algorithm
         \\                        (n-points must be 1..1024)
+        \\    --bitmask-correction
+        \\                        Experimental correction for bitmask quantization bias
+        \\                        Requires --use-bitmask
+        \\    --bitmask-correction-coeff=V
+        \\                        Override correction coefficient (default: 0.020)
         \\    --adaptive-sr       Experimental adaptive two-stage bitmask SR
         \\    --coarse-points=N   Coarse adaptive points (default: 64)
         \\    --fine-points=N     Fine adaptive points (default: --n-points or 256)
@@ -2828,8 +2879,21 @@ fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
     if (args.include_hydrogens_explicit) config.include_hydrogens = args.include_hydrogens;
     if (args.include_hetatm_explicit) config.include_hetatm = args.include_hetatm;
     if (args.use_bitmask_explicit) config.use_bitmask = args.use_bitmask;
+    if (args.bitmask_correction_explicit) config.bitmask_correction = args.bitmask_correction;
+    if (args.bitmask_correction_coeff_explicit) config.bitmask_correction_coeff = args.bitmask_correction_coeff;
     if (args.use_auth_chain) config.use_auth_chain = true;
     if (args.residue_map) config.residue_map = true;
+}
+
+fn validateBitmaskCorrectionConfig(config: BatchConfig) !void {
+    if (config.bitmask_correction and !config.use_bitmask) {
+        std.debug.print("Error: --bitmask-correction requires --use-bitmask\n", .{});
+        return error.InvalidArgument;
+    }
+    if (config.bitmask_correction and config.adaptive_sr) {
+        std.debug.print("Error: --bitmask-correction is not supported with --adaptive-sr\n", .{});
+        return error.InvalidArgument;
+    }
 }
 
 fn applyWorkflowClassifierToBatchConfig(config: *BatchConfig, args: BatchArgs, classifier_config: workflow_manifest.ClassifierConfig) !void {
@@ -2932,6 +2996,7 @@ fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     var resource_config = BatchConfig{};
     try applyWorkflowToBatchConfig(&resource_config, args, workflow.calculation, workflow.output, workflow.classifier);
     applyCliOverrides(&resource_config, args);
+    try validateBitmaskCorrectionConfig(resource_config);
     if (workflowRequiresJobFirstForAuthChain(args, workflow, resource_config)) {
         return runWorkflowJobFirst(allocator, io, args);
     }
@@ -3142,6 +3207,7 @@ fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void 
     var resource_config = BatchConfig{};
     try applyWorkflowToBatchConfig(&resource_config, args, workflow.calculation, workflow.output, workflow.classifier);
     applyCliOverrides(&resource_config, args);
+    try validateBitmaskCorrectionConfig(resource_config);
     const effective_classifier_type = resource_config.classifier_type;
 
     const ccd_path = resolveWorkflowCcdPath(args, workflow.classifier, effective_classifier_type);
@@ -3186,6 +3252,7 @@ fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void 
         config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
         if (custom_classifier) |*c| config.custom_classifier = c;
         applyWorkflowJobOverrides(&config, args, job);
+        try validateBitmaskCorrectionConfig(config);
         validateBatchOutputFormat(config.output_format) catch {
             std.debug.print("Error: freesasa and rsa output formats are only supported by the calc command\n", .{});
             return error.InvalidArgument;
@@ -3266,6 +3333,7 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
     var resource_config = BatchConfig{};
     try applyWorkflowToBatchConfig(&resource_config, args, workflow.calculation, workflow.output, workflow.classifier);
     applyCliOverrides(&resource_config, args);
+    try validateBitmaskCorrectionConfig(resource_config);
     resource_config.include_hetatm = resource_config.include_hetatm or (resource_config.classifier_type == .ccd);
     const effective_classifier_type = resource_config.classifier_type;
 
@@ -3317,6 +3385,7 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
         config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
         if (custom_classifier) |*c| config.custom_classifier = c;
         applyWorkflowJobOverrides(&config, args, job);
+        try validateBitmaskCorrectionConfig(config);
         validateBatchOutputFormat(config.output_format) catch {
             std.debug.print("Error: freesasa and rsa output formats are only supported by the calc command\n", .{});
             return error.InvalidArgument;
@@ -3624,6 +3693,14 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
             return error.InvalidArgument;
         }
     }
+    if (args.bitmask_correction and !args.use_bitmask) {
+        std.debug.print("Error: --bitmask-correction requires --use-bitmask\n", .{});
+        return error.InvalidArgument;
+    }
+    if (args.bitmask_correction and args.adaptive_sr) {
+        std.debug.print("Error: --bitmask-correction is not supported with --adaptive-sr\n", .{});
+        return error.InvalidArgument;
+    }
 
     // For jsonl, don't pass output_dir to runBatch (no per-file I/O during computation)
     const output_dir: ?[]const u8 = if (args.output_format == .jsonl) null else args.output_path;
@@ -3656,6 +3733,8 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         .include_hydrogens = args.include_hydrogens,
         .include_hetatm = args.include_hetatm or (args.classifier_type == .ccd),
         .use_bitmask = args.use_bitmask,
+        .bitmask_correction = args.bitmask_correction,
+        .bitmask_correction_coeff = args.bitmask_correction_coeff,
         .adaptive_sr = args.adaptive_sr,
         .coarse_points = args.coarse_points,
         .fine_points = args.fine_points,
@@ -4816,6 +4895,31 @@ test "BatchArgs --use-bitmask" {
     const args = [_][]const u8{ "zsasa", "batch", "--use-bitmask", "input_dir/" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.use_bitmask);
+}
+
+test "BatchArgs --bitmask-correction-coeff" {
+    const args = [_][]const u8{ "zsasa", "batch", "--use-bitmask", "--bitmask-correction-coeff=0.2", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.bitmask_correction);
+    try std.testing.expectEqual(@as(f64, 0.2), parsed.bitmask_correction_coeff);
+}
+
+test "BatchConfig bitmask correction requires bitmask" {
+    try std.testing.expectError(
+        error.InvalidArgument,
+        validateBitmaskCorrectionConfig(.{ .bitmask_correction = true }),
+    );
+}
+
+test "BatchConfig bitmask correction rejects adaptive SR" {
+    try std.testing.expectError(
+        error.InvalidArgument,
+        validateBitmaskCorrectionConfig(.{
+            .use_bitmask = true,
+            .bitmask_correction = true,
+            .adaptive_sr = true,
+        }),
+    );
 }
 
 test "BatchArgs --output=DIR (equals form)" {

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -231,6 +231,67 @@ export fn zsasa_calc_sr_bitmask(
     return ZSASA_OK;
 }
 
+/// Calculate SASA using Shrake-Rupley bitmask algorithm with experimental correction.
+export fn zsasa_calc_sr_bitmask_corrected(
+    x: [*]const f64,
+    y: [*]const f64,
+    z: [*]const f64,
+    radii: [*]const f64,
+    n_atoms: usize,
+    n_points: u32,
+    probe_radius: f64,
+    n_threads: usize,
+    correction_coeff: f64,
+    atom_areas: [*]f64,
+    total_area: *f64,
+) callconv(.c) c_int {
+    if (n_atoms == 0 or n_points == 0 or probe_radius <= 0.0 or correction_coeff < 0.0 or !std.math.isFinite(correction_coeff)) {
+        return ZSASA_ERROR_INVALID_INPUT;
+    }
+
+    if (!bitmask_lut.isSupportedNPoints(n_points)) {
+        return ZSASA_ERROR_UNSUPPORTED_N_POINTS;
+    }
+
+    const r_copy = c_allocator.dupe(f64, radii[0..n_atoms]) catch {
+        return ZSASA_ERROR_OUT_OF_MEMORY;
+    };
+    defer c_allocator.free(r_copy);
+
+    const input = AtomInput{
+        .x = x[0..n_atoms],
+        .y = y[0..n_atoms],
+        .z = z[0..n_atoms],
+        .r = r_copy,
+        .allocator = c_allocator,
+    };
+
+    const config = Config{
+        .n_points = n_points,
+        .probe_radius = probe_radius,
+    };
+    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
+        .enabled = true,
+        .coeff = correction_coeff,
+    };
+
+    const SRBitmask = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64);
+    const result = if (n_threads == 1)
+        SRBitmask.calculateSasaWithCorrection(c_allocator, input, config, correction) catch {
+            return ZSASA_ERROR_CALCULATION;
+        }
+    else
+        SRBitmask.calculateSasaParallelWithCorrection(c_allocator, input, config, n_threads, correction) catch {
+            return ZSASA_ERROR_CALCULATION;
+        };
+    defer c_allocator.free(result.atom_areas);
+
+    @memcpy(atom_areas[0..n_atoms], result.atom_areas);
+    total_area.* = result.total_area;
+
+    return ZSASA_OK;
+}
+
 // =============================================================================
 // Batch Processing Infrastructure
 // =============================================================================
@@ -743,6 +804,7 @@ const BatchWorkerArgsBitmask = struct {
     thread_id: usize,
     n_threads: usize,
     lut: *const bitmask_lut.BitmaskLut,
+    correction: shrake_rupley_bitmask.BitmaskCorrectionGen(f64) = .{},
 };
 
 /// Worker function for bitmask batch processing (f64 internal precision)
@@ -793,7 +855,7 @@ fn batchWorkerFnBitmask(args: BatchWorkerArgsBitmask) void {
             .probe_radius = args.probe_radius,
         };
 
-        const result = SRBitmask.calculateSasaWithLut(c_allocator, input, config, args.lut) catch {
+        const result = SRBitmask.calculateSasaWithLutAndCorrection(c_allocator, input, config, args.lut, args.correction) catch {
             args.error_flag.store(true, .release);
             return;
         };
@@ -814,9 +876,11 @@ fn calculateBatchBitmask(
     n_points: u32,
     probe_radius: f32,
     n_threads: usize,
+    correction_enabled: bool,
+    correction_coeff: f64,
     atom_areas: [*]f32,
 ) c_int {
-    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or probe_radius <= 0.0) {
+    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or probe_radius <= 0.0 or correction_coeff < 0.0 or !std.math.isFinite(correction_coeff)) {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -846,6 +910,10 @@ fn calculateBatchBitmask(
     }
 
     var error_flag = std.atomic.Value(bool).init(false);
+    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
+        .enabled = correction_enabled,
+        .coeff = correction_coeff,
+    };
 
     const thread_count = @min(actual_threads, n_frames);
     const threads = c_allocator.alloc(std.Thread, thread_count) catch {
@@ -866,6 +934,7 @@ fn calculateBatchBitmask(
             .thread_id = i,
             .n_threads = thread_count,
             .lut = &lut,
+            .correction = correction,
         }}) catch {
             error_flag.store(true, .release);
             for (threads[0..i]) |thread| {
@@ -899,6 +968,7 @@ const BatchWorkerArgsBitmaskF32 = struct {
     thread_id: usize,
     n_threads: usize,
     lut: *const bitmask_lut.BitmaskLutf32,
+    correction: shrake_rupley_bitmask.BitmaskCorrectionGen(f32) = .{},
 };
 
 /// Worker function for bitmask batch processing (f32 internal precision)
@@ -959,7 +1029,7 @@ fn batchWorkerFnBitmaskF32(args: BatchWorkerArgsBitmaskF32) void {
             .probe_radius = args.probe_radius,
         };
 
-        const result = SRBitmask.calculateSasaWithLut(c_allocator, input, config, args.lut) catch {
+        const result = SRBitmask.calculateSasaWithLutAndCorrection(c_allocator, input, config, args.lut, args.correction) catch {
             args.error_flag.store(true, .release);
             return;
         };
@@ -980,9 +1050,11 @@ fn calculateBatchBitmaskF32(
     n_points: u32,
     probe_radius: f32,
     n_threads: usize,
+    correction_enabled: bool,
+    correction_coeff: f64,
     atom_areas: [*]f32,
 ) c_int {
-    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or probe_radius <= 0.0) {
+    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or probe_radius <= 0.0 or correction_coeff < 0.0 or !std.math.isFinite(correction_coeff)) {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -1012,6 +1084,10 @@ fn calculateBatchBitmaskF32(
     }
 
     var error_flag = std.atomic.Value(bool).init(false);
+    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
+        .enabled = correction_enabled,
+        .coeff = @floatCast(correction_coeff),
+    };
 
     const thread_count = @min(actual_threads, n_frames);
     const threads = c_allocator.alloc(std.Thread, thread_count) catch {
@@ -1032,6 +1108,7 @@ fn calculateBatchBitmaskF32(
             .thread_id = i,
             .n_threads = thread_count,
             .lut = &lut,
+            .correction = correction,
         }}) catch {
             error_flag.store(true, .release);
             for (threads[0..i]) |thread| {
@@ -1087,6 +1164,34 @@ export fn zsasa_calc_sr_batch_bitmask(
         n_points,
         probe_radius,
         n_threads,
+        false,
+        shrake_rupley_bitmask.default_bitmask_correction_coeff,
+        atom_areas,
+    );
+}
+
+/// Calculate SASA for multiple frames using corrected bitmask Shrake-Rupley algorithm.
+export fn zsasa_calc_sr_batch_bitmask_corrected(
+    coordinates: [*]const f32,
+    n_frames: usize,
+    n_atoms: usize,
+    radii: [*]const f32,
+    n_points: u32,
+    probe_radius: f32,
+    n_threads: usize,
+    correction_coeff: f64,
+    atom_areas: [*]f32,
+) callconv(.c) c_int {
+    return calculateBatchBitmask(
+        coordinates,
+        n_frames,
+        n_atoms,
+        radii,
+        n_points,
+        probe_radius,
+        n_threads,
+        true,
+        correction_coeff,
         atom_areas,
     );
 }
@@ -1112,6 +1217,34 @@ export fn zsasa_calc_sr_batch_bitmask_f32(
         n_points,
         probe_radius,
         n_threads,
+        false,
+        shrake_rupley_bitmask.default_bitmask_correction_coeff,
+        atom_areas,
+    );
+}
+
+/// Calculate SASA for multiple frames using corrected bitmask Shrake-Rupley algorithm (f32 precision).
+export fn zsasa_calc_sr_batch_bitmask_f32_corrected(
+    coordinates: [*]const f32,
+    n_frames: usize,
+    n_atoms: usize,
+    radii: [*]const f32,
+    n_points: u32,
+    probe_radius: f32,
+    n_threads: usize,
+    correction_coeff: f64,
+    atom_areas: [*]f32,
+) callconv(.c) c_int {
+    return calculateBatchBitmaskF32(
+        coordinates,
+        n_frames,
+        n_atoms,
+        radii,
+        n_points,
+        probe_radius,
+        n_threads,
+        true,
+        correction_coeff,
         atom_areas,
     );
 }

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -67,6 +67,8 @@ pub const CalcArgs = struct {
     rsa: bool = false, // Show RSA (Relative Solvent Accessibility)
     polar: bool = false, // Show polar/nonpolar SASA summary
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
+    bitmask_correction: bool = false, // Experimental exposed-fraction correction for bitmask SR
+    bitmask_correction_coeff: f64 = shrake_rupley_bitmask.default_bitmask_correction_coeff,
     ccd_path: ?[]const u8 = null, // External CCD dictionary file (.zsdc or .cif[.gz|.zst])
     sdf_paths: SdfPathList = .{}, // --sdf=PATH (up to 16)
     mol_selector: ?[]const u8 = null, // --mol=NAME or --mol=N (1-based index)
@@ -92,6 +94,8 @@ pub const CalcArgs = struct {
     rsa_explicit: bool = false,
     polar_explicit: bool = false,
     use_bitmask_explicit: bool = false,
+    bitmask_correction_explicit: bool = false,
+    bitmask_correction_coeff_explicit: bool = false,
     ccd_explicit: bool = false,
     sdf_explicit: bool = false,
     mol_explicit: bool = false,
@@ -147,6 +151,19 @@ fn parseNPoints(value: []const u8) u32 {
         std.debug.print("Error: n-points must be between 1 and 10000: {d}\n", .{n});
         std.process.exit(1);
     };
+}
+
+/// Parse and validate experimental bitmask correction coefficient.
+fn parseBitmaskCorrectionCoeff(value: []const u8) f64 {
+    const coeff = std.fmt.parseFloat(f64, value) catch {
+        std.debug.print("Error: Invalid bitmask correction coefficient: {s}\n", .{value});
+        std.process.exit(1);
+    };
+    if (!std.math.isFinite(coeff) or coeff < 0.0) {
+        std.debug.print("Error: Bitmask correction coefficient must be finite and non-negative: {d}\n", .{coeff});
+        std.process.exit(1);
+    }
+    return coeff;
 }
 
 /// Parse and validate output format value
@@ -532,6 +549,28 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) CalcArgs {
             result.use_bitmask = true;
             result.use_bitmask_explicit = true;
         }
+        // --bitmask-correction
+        else if (std.mem.eql(u8, arg, "--bitmask-correction")) {
+            result.bitmask_correction = true;
+            result.bitmask_correction_explicit = true;
+        }
+        // --bitmask-correction-coeff=VALUE or --bitmask-correction-coeff VALUE
+        else if (std.mem.startsWith(u8, arg, "--bitmask-correction-coeff=")) {
+            result.bitmask_correction_coeff = parseBitmaskCorrectionCoeff(arg["--bitmask-correction-coeff=".len..]);
+            result.bitmask_correction = true;
+            result.bitmask_correction_explicit = true;
+            result.bitmask_correction_coeff_explicit = true;
+        } else if (std.mem.eql(u8, arg, "--bitmask-correction-coeff")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --bitmask-correction-coeff\n", .{});
+                std.process.exit(1);
+            }
+            result.bitmask_correction_coeff = parseBitmaskCorrectionCoeff(args[i]);
+            result.bitmask_correction = true;
+            result.bitmask_correction_explicit = true;
+            result.bitmask_correction_coeff_explicit = true;
+        }
         // --help or -h
         else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             result.show_help = true;
@@ -779,6 +818,11 @@ pub fn printHelp(program_name: []const u8) void {
         \\    -o, --output=FILE  Output file (alternative to positional argument)
         \\    --use-bitmask      Use bitmask LUT optimization for SR algorithm
         \\                       Faster but approximate; n-points must be 1..1024
+        \\    --bitmask-correction
+        \\                       Experimental correction for bitmask quantization bias
+        \\                       Requires --use-bitmask
+        \\    --bitmask-correction-coeff=V
+        \\                       Override correction coefficient (default: 0.020)
         \\    --validate         Validate input only, do not calculate SASA
         \\    --timing           Show timing breakdown (for benchmarking)
         \\    -q, --quiet        Suppress progress output
@@ -1335,6 +1379,10 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
             std.process.exit(1);
         }
     }
+    if (effective_args.bitmask_correction and !effective_args.use_bitmask) {
+        std.debug.print("Error: --bitmask-correction requires --use-bitmask\n", .{});
+        std.process.exit(1);
+    }
 
     // Apply classifier (--config takes precedence over --classifier)
     // Default: ccd for PDB/mmCIF input (ProtOr-compatible with CCD extension)
@@ -1457,13 +1505,17 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
                     .probe_radius = effective_args.probe_radius,
                 };
                 break :blk if (effective_args.use_bitmask) bitmask_blk: {
+                    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
+                        .enabled = effective_args.bitmask_correction,
+                        .coeff = effective_args.bitmask_correction_coeff,
+                    };
                     break :bitmask_blk if (effective_args.n_threads == 1)
-                        shrake_rupley_bitmask.calculateSasa(allocator, input, config) catch |err| {
+                        shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithCorrection(allocator, input, config, correction) catch |err| {
                             std.debug.print("Error calculating SASA: {s}\n", .{@errorName(err)});
                             std.process.exit(1);
                         }
                     else
-                        shrake_rupley_bitmask.calculateSasaParallel(allocator, input, config, effective_args.n_threads) catch |err| {
+                        shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaParallelWithCorrection(allocator, input, config, effective_args.n_threads, correction) catch |err| {
                             std.debug.print("Error calculating SASA: {s}\n", .{@errorName(err)});
                             std.process.exit(1);
                         };
@@ -1506,13 +1558,17 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
                         .probe_radius = @floatCast(effective_args.probe_radius),
                     };
                     break :inner if (effective_args.use_bitmask) bitmask_inner: {
+                        const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
+                            .enabled = effective_args.bitmask_correction,
+                            .coeff = @floatCast(effective_args.bitmask_correction_coeff),
+                        };
                         break :bitmask_inner if (effective_args.n_threads == 1)
-                            shrake_rupley_bitmask.calculateSasaf32(allocator, input, config) catch |err| {
+                            shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithCorrection(allocator, input, config, correction) catch |err| {
                                 std.debug.print("Error calculating SASA: {s}\n", .{@errorName(err)});
                                 std.process.exit(1);
                             }
                         else
-                            shrake_rupley_bitmask.calculateSasaParallelf32(allocator, input, config, effective_args.n_threads) catch |err| {
+                            shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaParallelWithCorrection(allocator, input, config, effective_args.n_threads, correction) catch |err| {
                                 std.debug.print("Error calculating SASA: {s}\n", .{@errorName(err)});
                                 std.process.exit(1);
                             };
@@ -1823,6 +1879,20 @@ test "CalcArgs --use-bitmask" {
     const args = [_][]const u8{ "zsasa", "calc", "--use-bitmask", "input.json" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.use_bitmask);
+}
+
+test "CalcArgs --bitmask-correction" {
+    const args = [_][]const u8{ "zsasa", "calc", "--use-bitmask", "--bitmask-correction", "input.json" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.use_bitmask);
+    try std.testing.expectEqual(true, parsed.bitmask_correction);
+}
+
+test "CalcArgs --bitmask-correction-coeff implies correction" {
+    const args = [_][]const u8{ "zsasa", "calc", "--use-bitmask", "--bitmask-correction-coeff=0.2", "input.json" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.bitmask_correction);
+    try std.testing.expectEqual(@as(f64, 0.2), parsed.bitmask_correction_coeff);
 }
 
 test "CalcArgs --timing" {

--- a/src/shrake_rupley_bitmask.zig
+++ b/src/shrake_rupley_bitmask.zig
@@ -18,6 +18,26 @@ const BitmaskLut = bitmask_lut.BitmaskLut;
 const BitmaskLutGen = bitmask_lut.BitmaskLutGen;
 const Allocator = std.mem.Allocator;
 
+/// Conservative default coefficient for experimental bitmask bias correction.
+pub const default_bitmask_correction_coeff: f64 = 0.020;
+
+/// Generic correction configuration for bitmask exposed-fraction adjustment.
+pub fn BitmaskCorrectionGen(comptime T: type) type {
+    return struct {
+        enabled: bool = false,
+        coeff: T = @as(T, @floatCast(default_bitmask_correction_coeff)),
+    };
+}
+
+/// Apply the experimental exposed-fraction correction term.
+///
+/// The term is zero for fully buried (0) and fully exposed (1) atoms and peaks
+/// for boundary atoms where LUT quantization is expected to over-occlude.
+pub fn applyBitmaskCorrection(comptime T: type, fraction: T, coeff: T) T {
+    const corrected = fraction + coeff * fraction * (1.0 - fraction);
+    return @min(@as(T, 1.0), @max(@as(T, 0.0), corrected));
+}
+
 /// Calculate SASA for a single atom using bitmask-based occlusion.
 ///
 /// Instead of checking every test point against every neighbor, this approach:
@@ -447,6 +467,7 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
     const Cfg = ConfigGen(T);
     const NList = NeighborListGen(T);
     const Lut = BitmaskLutGen(T);
+    const Correction = BitmaskCorrectionGen(T);
 
     return struct {
         const Self = @This();
@@ -479,6 +500,26 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             atom_radius_probe: T,
             neighbors: []const u32,
             lut: *const Lut,
+        ) T {
+            return Self.atomSasaBitmaskWithCorrection(
+                atom_idx,
+                positions,
+                radii_with_probe_sq,
+                atom_radius_probe,
+                neighbors,
+                lut,
+                .{},
+            );
+        }
+
+        fn atomSasaBitmaskWithCorrection(
+            atom_idx: usize,
+            positions: []const Vec,
+            radii_with_probe_sq: []const T,
+            atom_radius_probe: T,
+            neighbors: []const u32,
+            lut: *const Lut,
+            correction: Correction,
         ) T {
             const words = lut.words;
 
@@ -597,7 +638,11 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             }
 
             const surface_area = 4.0 * std.math.pi * r_i * r_i;
-            const exposed_fraction = @as(T, @floatFromInt(exposed)) / @as(T, @floatFromInt(lut.n_points));
+            const raw_exposed_fraction = @as(T, @floatFromInt(exposed)) / @as(T, @floatFromInt(lut.n_points));
+            const exposed_fraction = if (correction.enabled)
+                applyBitmaskCorrection(T, raw_exposed_fraction, correction.coeff)
+            else
+                raw_exposed_fraction;
             return surface_area * exposed_fraction;
         }
 
@@ -630,6 +675,7 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             probe_radius: T,
             atom_areas: []T,
             lut: *const Lut,
+            correction: Correction = .{},
         };
 
         fn parallelSasaWorker(ctx: Self.ParallelContext, chunk_start: usize, chunk_end: usize) T {
@@ -638,13 +684,14 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             for (chunk_start..chunk_end) |i| {
                 const atom_radius_probe = ctx.radii[i] + ctx.probe_radius;
                 const neighbors = ctx.neighbor_list_data.getNeighbors(i);
-                const area = Self.atomSasaBitmask(
+                const area = Self.atomSasaBitmaskWithCorrection(
                     i,
                     ctx.positions,
                     ctx.radii_with_probe_sq,
                     atom_radius_probe,
                     neighbors,
                     ctx.lut,
+                    ctx.correction,
                 );
                 ctx.atom_areas[i] = area;
                 chunk_total += area;
@@ -720,6 +767,22 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             return calculateSasaCore(allocator, input, config, &lut);
         }
 
+        /// Calculate SASA with optional experimental bitmask bias correction.
+        pub fn calculateSasaWithCorrection(
+            allocator: Allocator,
+            input: AtomInput,
+            config: Cfg,
+            correction: Correction,
+        ) !Result {
+            const n_atoms = input.atomCount();
+            if (n_atoms == 0) return error.NoAtoms;
+            if (!bitmask_lut.isSupportedNPoints(config.n_points)) return error.UnsupportedNPoints;
+
+            var lut = try Lut.init(allocator, config.n_points);
+            defer lut.deinit();
+            return calculateSasaCoreWithCorrection(allocator, input, config, &lut, correction);
+        }
+
         /// Calculate SASA with a pre-built LUT (single-threaded, generic precision).
         /// Use this in batch mode to avoid rebuilding the LUT per file.
         /// Caller must ensure lut was built with config.n_points.
@@ -733,6 +796,20 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             if (n_atoms == 0) return error.NoAtoms;
             std.debug.assert(config.n_points == lut.n_points);
             return calculateSasaCore(allocator, input, config, lut);
+        }
+
+        /// Calculate SASA with a pre-built LUT and optional experimental correction.
+        pub fn calculateSasaWithLutAndCorrection(
+            allocator: Allocator,
+            input: AtomInput,
+            config: Cfg,
+            lut: *const Lut,
+            correction: Correction,
+        ) !Result {
+            const n_atoms = input.atomCount();
+            if (n_atoms == 0) return error.NoAtoms;
+            std.debug.assert(config.n_points == lut.n_points);
+            return calculateSasaCoreWithCorrection(allocator, input, config, lut, correction);
         }
 
         pub fn calculateSasaAdaptiveWithLuts(
@@ -756,6 +833,16 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             input: AtomInput,
             config: Cfg,
             lut: *const Lut,
+        ) !Result {
+            return calculateSasaCoreWithCorrection(allocator, input, config, lut, .{});
+        }
+
+        fn calculateSasaCoreWithCorrection(
+            allocator: Allocator,
+            input: AtomInput,
+            config: Cfg,
+            lut: *const Lut,
+            correction: Correction,
         ) !Result {
             const n_atoms = input.atomCount();
 
@@ -794,13 +881,14 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             for (0..n_atoms) |i| {
                 const atom_radius_probe = radii[i] + config.probe_radius;
                 const neighbors = neighbor_list_data.getNeighbors(i);
-                const area = Self.atomSasaBitmask(
+                const area = Self.atomSasaBitmaskWithCorrection(
                     i,
                     positions,
                     radii_with_probe_sq,
                     atom_radius_probe,
                     neighbors,
                     lut,
+                    correction,
                 );
                 atom_areas[i] = area;
                 total_area += area;
@@ -902,6 +990,23 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             return calculateSasaParallelCore(allocator, input, config, n_threads, &lut);
         }
 
+        /// Calculate SASA in parallel with optional experimental bitmask bias correction.
+        pub fn calculateSasaParallelWithCorrection(
+            allocator: Allocator,
+            input: AtomInput,
+            config: Cfg,
+            n_threads: usize,
+            correction: Correction,
+        ) !Result {
+            const n_atoms = input.atomCount();
+            if (n_atoms == 0) return error.NoAtoms;
+            if (!bitmask_lut.isSupportedNPoints(config.n_points)) return error.UnsupportedNPoints;
+
+            var lut = try Lut.init(allocator, config.n_points);
+            defer lut.deinit();
+            return calculateSasaParallelCoreWithCorrection(allocator, input, config, n_threads, &lut, correction);
+        }
+
         /// Calculate SASA with a pre-built LUT (parallel, generic precision).
         /// Caller must ensure lut was built with config.n_points.
         pub fn calculateSasaParallelWithLut(
@@ -915,6 +1020,21 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             if (n_atoms == 0) return error.NoAtoms;
             std.debug.assert(config.n_points == lut.n_points);
             return calculateSasaParallelCore(allocator, input, config, n_threads, lut);
+        }
+
+        /// Calculate SASA in parallel with a pre-built LUT and optional correction.
+        pub fn calculateSasaParallelWithLutAndCorrection(
+            allocator: Allocator,
+            input: AtomInput,
+            config: Cfg,
+            n_threads: usize,
+            lut: *const Lut,
+            correction: Correction,
+        ) !Result {
+            const n_atoms = input.atomCount();
+            if (n_atoms == 0) return error.NoAtoms;
+            std.debug.assert(config.n_points == lut.n_points);
+            return calculateSasaParallelCoreWithCorrection(allocator, input, config, n_threads, lut, correction);
         }
 
         pub fn calculateSasaAdaptiveParallelWithLuts(
@@ -940,6 +1060,17 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
             config: Cfg,
             n_threads: usize,
             lut: *const Lut,
+        ) !Result {
+            return calculateSasaParallelCoreWithCorrection(allocator, input, config, n_threads, lut, .{});
+        }
+
+        fn calculateSasaParallelCoreWithCorrection(
+            allocator: Allocator,
+            input: AtomInput,
+            config: Cfg,
+            n_threads: usize,
+            lut: *const Lut,
+            correction: Correction,
         ) !Result {
             const n_atoms = input.atomCount();
             const actual_threads = if (n_threads == 0)
@@ -986,6 +1117,7 @@ pub fn ShrakeRupleyBitmaskGen(comptime T: type) type {
                 .probe_radius = config.probe_radius,
                 .atom_areas = atom_areas,
                 .lut = lut,
+                .correction = correction,
             };
 
             const chunk_size = @max(64, n_atoms / (actual_threads * 4));
@@ -1104,6 +1236,82 @@ pub fn calculateSasaParallelf32(allocator: Allocator, input: AtomInput, config: 
 // =============================================================================
 // Tests
 // =============================================================================
+
+test "bitmask correction leaves boundary fractions unchanged" {
+    try std.testing.expectEqual(@as(f64, 0.0), applyBitmaskCorrection(f64, 0.0, 0.5));
+    try std.testing.expectEqual(@as(f64, 1.0), applyBitmaskCorrection(f64, 1.0, 0.5));
+}
+
+test "bitmask correction increases partially exposed fraction" {
+    const corrected = applyBitmaskCorrection(f64, 0.5, 0.2);
+    try std.testing.expectApproxEqAbs(@as(f64, 0.55), corrected, 1e-12);
+}
+
+test "bitmask correction increases partially occluded atom area" {
+    const allocator = std.testing.allocator;
+
+    const x = try allocator.dupe(f64, &.{ 0.0, 2.5 });
+    const y = try allocator.dupe(f64, &.{ 0.0, 0.0 });
+    const z = try allocator.dupe(f64, &.{ 0.0, 0.0 });
+    const r = try allocator.dupe(f64, &.{ 1.5, 1.5 });
+
+    var input = AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .allocator = allocator,
+    };
+    defer input.deinit();
+
+    const config = Config{ .n_points = 128, .probe_radius = 1.4 };
+    var raw = try ShrakeRupleyBitmaskGen(f64).calculateSasaWithCorrection(allocator, input, config, .{});
+    defer raw.deinit();
+    var corrected = try ShrakeRupleyBitmaskGen(f64).calculateSasaWithCorrection(
+        allocator,
+        input,
+        config,
+        .{ .enabled = true, .coeff = 0.2 },
+    );
+    defer corrected.deinit();
+
+    try std.testing.expect(corrected.total_area > raw.total_area);
+}
+
+test "bitmask correction works with prebuilt LUT" {
+    const allocator = std.testing.allocator;
+
+    const x = try allocator.dupe(f64, &.{ 0.0, 2.5 });
+    const y = try allocator.dupe(f64, &.{ 0.0, 0.0 });
+    const z = try allocator.dupe(f64, &.{ 0.0, 0.0 });
+    const r = try allocator.dupe(f64, &.{ 1.5, 1.5 });
+
+    var input = AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .allocator = allocator,
+    };
+    defer input.deinit();
+
+    const config = Config{ .n_points = 128, .probe_radius = 1.4 };
+    var lut = try bitmask_lut.BitmaskLut.init(allocator, config.n_points);
+    defer lut.deinit();
+
+    var raw = try ShrakeRupleyBitmaskGen(f64).calculateSasaWithLutAndCorrection(allocator, input, config, &lut, .{});
+    defer raw.deinit();
+    var corrected = try ShrakeRupleyBitmaskGen(f64).calculateSasaWithLutAndCorrection(
+        allocator,
+        input,
+        config,
+        &lut,
+        .{ .enabled = true, .coeff = 0.2 },
+    );
+    defer corrected.deinit();
+
+    try std.testing.expect(corrected.total_area > raw.total_area);
+}
 
 test "bitmask calculateSasa - single isolated atom" {
     const allocator = std.testing.allocator;

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -143,6 +143,8 @@ pub const TrajArgs = struct {
     include_hydrogens: bool = true, // Include hydrogen atoms (default: include for MD trajectories)
     batch_size: u32 = 0, // Frames per batch for parallel processing (0 = auto)
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
+    bitmask_correction: bool = false, // Experimental exposed-fraction correction for bitmask SR
+    bitmask_correction_coeff: f64 = shrake_rupley_bitmask.default_bitmask_correction_coeff,
     quiet: bool = false,
     show_progress: bool = true,
     show_help: bool = false,
@@ -150,6 +152,18 @@ pub const TrajArgs = struct {
 
 fn shouldShowProgress(args: TrajArgs) bool {
     return args.show_progress and !args.quiet;
+}
+
+fn parseBitmaskCorrectionCoeff(value: []const u8) f64 {
+    const coeff = std.fmt.parseFloat(f64, value) catch {
+        std.debug.print("Error: Invalid bitmask correction coefficient: {s}\n", .{value});
+        std.process.exit(1);
+    };
+    if (!std.math.isFinite(coeff) or coeff < 0.0) {
+        std.debug.print("Error: Bitmask correction coefficient must be finite and non-negative: {d}\n", .{coeff});
+        std.process.exit(1);
+    }
+    return coeff;
 }
 
 /// Parse trajectory mode arguments
@@ -263,6 +277,19 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
                 result.include_hydrogens = false;
             } else if (std.mem.eql(u8, arg, "--use-bitmask")) {
                 result.use_bitmask = true;
+            } else if (std.mem.eql(u8, arg, "--bitmask-correction")) {
+                result.bitmask_correction = true;
+            } else if (std.mem.startsWith(u8, arg, "--bitmask-correction-coeff=")) {
+                result.bitmask_correction_coeff = parseBitmaskCorrectionCoeff(arg["--bitmask-correction-coeff=".len..]);
+                result.bitmask_correction = true;
+            } else if (std.mem.eql(u8, arg, "--bitmask-correction-coeff")) {
+                i += 1;
+                if (i >= args.len) {
+                    std.debug.print("Error: Missing value for --bitmask-correction-coeff\n", .{});
+                    std.process.exit(1);
+                }
+                result.bitmask_correction_coeff = parseBitmaskCorrectionCoeff(args[i]);
+                result.bitmask_correction = true;
             } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
                 result.quiet = true;
                 result.show_progress = false;
@@ -368,6 +395,11 @@ pub fn printHelp(program_name: []const u8) void {
         \\                       Include hydrogen atoms (default, for backward compat)
         \\    --use-bitmask      Use bitmask LUT optimization for SR algorithm
         \\                       (n-points must be 1..1024)
+        \\    --bitmask-correction
+        \\                       Experimental correction for bitmask quantization bias
+        \\                       Requires --use-bitmask
+        \\    --bitmask-correction-coeff=V
+        \\                       Override correction coefficient (default: 0.020)
         \\    --stride=N         Process every Nth frame (default: 1)
         \\    --start=N          Start from frame N (default: 0)
         \\    --end=N            End at frame N (default: all)
@@ -480,6 +512,8 @@ const BatchWorkerArgs = struct {
     coord_scale: f64, // ztraj readers already yield Å; kept for reader abstraction
     bitmask_lut_f64: ?*const bitmask_lut.BitmaskLut = null,
     bitmask_lut_f32: ?*const bitmask_lut.BitmaskLutGen(f32) = null,
+    bitmask_correction: bool = false,
+    bitmask_correction_coeff: f64 = shrake_rupley_bitmask.default_bitmask_correction_coeff,
 };
 
 /// Set error flag and store a descriptive message (first writer wins).
@@ -549,7 +583,11 @@ fn batchWorkerFn(args: BatchWorkerArgs) void {
                 .n_points = args.n_points,
             };
             if (args.bitmask_lut_f32) |lut| {
-                var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithLut(thread_alloc, input, config, lut) catch |err| {
+                const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
+                    .enabled = args.bitmask_correction,
+                    .coeff = @floatCast(args.bitmask_correction_coeff),
+                };
+                var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithLutAndCorrection(thread_alloc, input, config, lut, correction) catch |err| {
                     setWorkerError(args, "frame {d}: bitmask-f32 failed: {s}", .{ frame_id, @errorName(err) });
                     return;
                 };
@@ -570,7 +608,11 @@ fn batchWorkerFn(args: BatchWorkerArgs) void {
                     .n_points = args.n_points,
                 };
                 if (args.bitmask_lut_f64) |lut| {
-                    var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithLut(thread_alloc, input, config, lut) catch |err| {
+                    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
+                        .enabled = args.bitmask_correction,
+                        .coeff = args.bitmask_correction_coeff,
+                    };
+                    var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithLutAndCorrection(thread_alloc, input, config, lut, correction) catch |err| {
                         setWorkerError(args, "frame {d}: bitmask-f64 failed: {s}", .{ frame_id, @errorName(err) });
                         return;
                     };
@@ -802,6 +844,11 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
         return error.AtomCountMismatch;
     }
 
+    if (args.bitmask_correction and !args.use_bitmask) {
+        std.debug.print("Error: --bitmask-correction requires --use-bitmask\n", .{});
+        return error.InvalidArgument;
+    }
+
     // Open output file with buffered writer
     const output_file = try std.Io.Dir.cwd().createFile(io, args.output_path, .{});
     defer output_file.close(io);
@@ -971,7 +1018,11 @@ fn runSequential(
                     .n_points = args.n_points,
                 };
                 if (luts.f32Ptr()) |lut| {
-                    var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithLut(allocator, frame_input, config, lut);
+                    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
+                        .enabled = args.bitmask_correction,
+                        .coeff = @floatCast(args.bitmask_correction_coeff),
+                    };
+                    var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithLutAndCorrection(allocator, frame_input, config, lut, correction);
                     defer result.deinit();
                     break :blk @floatCast(result.total_area);
                 } else {
@@ -988,7 +1039,11 @@ fn runSequential(
                             .n_points = args.n_points,
                         };
                         if (luts.f64Ptr()) |lut| {
-                            var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithLut(allocator, frame_input, config, lut);
+                            const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
+                                .enabled = args.bitmask_correction,
+                                .coeff = args.bitmask_correction_coeff,
+                            };
+                            var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithLutAndCorrection(allocator, frame_input, config, lut, correction);
                             defer result.deinit();
                             break :blk result.total_area;
                         } else {
@@ -1096,6 +1151,8 @@ fn runBatchParallel(
                 .coord_scale = reader.coordScale(),
                 .bitmask_lut_f64 = luts.f64Ptr(),
                 .bitmask_lut_f32 = luts.f32Ptr(),
+                .bitmask_correction = args.bitmask_correction,
+                .bitmask_correction_coeff = args.bitmask_correction_coeff,
             }}) catch {
                 error_flag.store(true, .release);
                 for (threads[0..i]) |thread| {
@@ -1236,6 +1293,13 @@ test "TrajArgs quiet disables progress" {
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.quiet);
     try std.testing.expectEqual(false, parsed.show_progress);
+}
+
+test "TrajArgs --bitmask-correction-coeff" {
+    const args = [_][]const u8{ "zsasa", "traj", "--use-bitmask", "--bitmask-correction-coeff=0.2", "traj.xtc", "topology.pdb" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(true, parsed.bitmask_correction);
+    try std.testing.expectEqual(@as(f64, 0.2), parsed.bitmask_correction_coeff);
 }
 
 test "TrajArgs quiet suppresses progress even when show_progress defaults true" {

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -115,6 +115,8 @@ For batch custom classifier configs, use a workflow `[classifier]` section. See 
 | `--n-points=N` | Test points per atom (SR only, 1-10000) | `100` |
 | `--n-slices=N` | Slices per atom diameter (LR only, 1-1000) | `20` |
 | `--use-bitmask` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points 1-1024) | off |
+| `--bitmask-correction` | Experimental exposed-fraction correction for bitmask quantization bias; requires `--use-bitmask` | off |
+| `--bitmask-correction-coeff=V` | Override the experimental correction coefficient | `0.020` |
 | `--adaptive-sr` | Batch-only experimental two-stage bitmask SR; requires `--use-bitmask` and `--algorithm=sr` | off |
 | `--coarse-points=N` | Coarse adaptive SR test points (bitmask range 1-1024) | `64` |
 | `--fine-points=N` | Fine adaptive SR test points; defaults to explicit `--n-points`, otherwise 256 | `256` |

--- a/website/docs/guide/algorithms.mdx
+++ b/website/docs/guide/algorithms.mdx
@@ -137,10 +137,27 @@ The offset is **constant** regardless of n_points (unlike standard SR where erro
 
 For detailed accuracy analysis, see [SASA Validation](../benchmarks/validation.md).
 
+### Experimental Bias Correction
+
+Bitmask mode also provides an opt-in experimental correction for workflows where the mean total-SASA offset matters:
+
+```bash
+zsasa traj --use-bitmask --bitmask-correction trajectory.xtc topology.pdb
+```
+
+The correction adjusts each atom's bitmask exposed fraction with a boundary-weighted term:
+
+```text
+f_corrected = f + coeff × f × (1 - f)
+```
+
+This leaves fully buried (`f = 0`) and fully exposed (`f = 1`) atoms unchanged, while lifting partially exposed atoms where LUT direction/angle quantization most often over-occludes surface points. The default coefficient is conservative (`0.020`) and can be overridden with `--bitmask-correction-coeff=V`. Treat this as an experimental bias-mitigation mode, not as a replacement for exact SR when maximum numerical agreement is required.
+
 ### Constraints
 
 - **SR algorithm only** — not available for Lee-Richards
 - **Supported n_points**: 1–1024
+- **Correction mode**: requires bitmask SR and is disabled by default
 - Lahuta uses n_points=128 fixed; zsasa supports any value in range
 
 ### When to Use
@@ -162,6 +179,9 @@ zsasa calc --use-bitmask --n-points=128 structure.cif output.json
 # Trajectory with bitmask
 zsasa traj --use-bitmask --n-points=128 trajectory.xtc topology.pdb
 
+# Trajectory with experimental bitmask bias correction
+zsasa traj --use-bitmask --bitmask-correction trajectory.xtc topology.pdb
+
 # Batch with bitmask
 zsasa batch --use-bitmask --n-points=128 input_dir/ output_dir/
 ```
@@ -174,6 +194,15 @@ from zsasa import calculate_sasa
 
 # Single frame
 result = calculate_sasa(coords, radii, n_points=128, use_bitmask=True)
+
+# Experimental correction
+result = calculate_sasa(
+    coords,
+    radii,
+    n_points=128,
+    use_bitmask=True,
+    bitmask_correction=True,
+)
 
 # Batch (trajectory)
 from zsasa import calculate_sasa_batch

--- a/website/docs/integrations/mdanalysis.md
+++ b/website/docs/integrations/mdanalysis.md
@@ -67,6 +67,8 @@ def run(
     n_slices: int = 20,
     n_threads: int = 0,
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> SASAAnalysis
 ```
 
@@ -83,6 +85,8 @@ def run(
 | `n_slices` | `int` | `20` | Slices per atom (LR) |
 | `n_threads` | `int` | `0` | Threads (0 = auto) |
 | `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
+| `bitmask_correction` | `bool` | `False` | Experimental exposed-fraction correction for bitmask quantization bias; requires `use_bitmask=True` |
+| `bitmask_correction_coeff` | `float \| None` | `None` | Override the experimental correction coefficient (`None` uses library default) |
 
 **Returns:** `self` for method chaining.
 
@@ -138,6 +142,8 @@ def compute_sasa(
     n_threads: int = 0,
     mode: Literal["atom", "residue", "total"] = "atom",
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> NDArray[np.float32]
 ```
 

--- a/website/docs/integrations/mdtraj.md
+++ b/website/docs/integrations/mdtraj.md
@@ -35,6 +35,8 @@ def compute_sasa(
     n_threads: int = 0,
     mode: Literal["atom", "residue", "total"] = "atom",
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> NDArray[np.float32]
 ```
 
@@ -50,6 +52,8 @@ def compute_sasa(
 | `n_threads` | `int` | `0` | Threads (0 = auto) |
 | `mode` | `"atom"`, `"residue"`, `"total"` | `"atom"` | Output mode |
 | `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
+| `bitmask_correction` | `bool` | `False` | Experimental exposed-fraction correction for bitmask quantization bias; requires `use_bitmask=True` |
+| `bitmask_correction_coeff` | `float \| None` | `None` | Override the experimental correction coefficient (`None` uses library default) |
 
 **Returns:** SASA values in nm² (matching MDTraj's output units).
 

--- a/website/docs/python-api/core.md
+++ b/website/docs/python-api/core.md
@@ -15,6 +15,8 @@ def calculate_sasa(
     probe_radius: float = 1.4,
     n_threads: int = 0,
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> SasaResult
 ```
 
@@ -32,6 +34,8 @@ Calculate Solvent Accessible Surface Area.
 | `probe_radius` | `float` | `1.4` | Water probe radius in Å |
 | `n_threads` | `int` | `0` | Number of threads (0 = auto) |
 | `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
+| `bitmask_correction` | `bool` | `False` | Experimental exposed-fraction correction for bitmask quantization bias; requires `use_bitmask=True` |
+| `bitmask_correction_coeff` | `float \| None` | `None` | Override the experimental correction coefficient (`None` uses library default) |
 
 **Returns:** `SasaResult`
 
@@ -66,6 +70,8 @@ def calculate_sasa_batch(
     n_threads: int = 0,
     precision: Literal["f64", "f32"] = "f64",
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> BatchSasaResult
 ```
 
@@ -84,6 +90,8 @@ Calculate SASA for multiple frames in batch.
 | `n_threads` | `int` | `0` | Number of threads (0 = auto) |
 | `precision` | `"f64"` or `"f32"` | `"f64"` | Floating-point precision |
 | `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
+| `bitmask_correction` | `bool` | `False` | Experimental exposed-fraction correction for bitmask quantization bias; requires `use_bitmask=True` |
+| `bitmask_correction_coeff` | `float \| None` | `None` | Override the experimental correction coefficient (`None` uses library default) |
 
 **Returns:** `BatchSasaResult`
 

--- a/website/docs/python-api/xtc.md
+++ b/website/docs/python-api/xtc.md
@@ -134,6 +134,8 @@ def compute_sasa_trajectory(
     stop: int | None = None,
     step: int = 1,
     use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
 ) -> TrajectorySasaResult
 ```
 
@@ -152,6 +154,8 @@ def compute_sasa_trajectory(
 | `stop` | `int \| None` | `None` | Stop before this frame (None = all) |
 | `step` | `int` | `1` | Process every Nth frame |
 | `use_bitmask` | `bool` | `False` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points must be 1..1024) |
+| `bitmask_correction` | `bool` | `False` | Experimental exposed-fraction correction for bitmask quantization bias; requires `use_bitmask=True` |
+| `bitmask_correction_coeff` | `float \| None` | `None` | Override the experimental correction coefficient (`None` uses library default) |
 
 **Returns:** `TrajectorySasaResult`
 


### PR DESCRIPTION
## Summary
- Add an opt-in experimental bitmask exposed-fraction correction term for CLI, C ABI, and Python APIs.
- Wire correction through calc, traj, batch, and Python trajectory wrappers while keeping default bitmask behavior unchanged.
- Document the correction mode and add focused Zig/Python tests.

## Validation
- `zig fmt --check src/`
- `zig build test --summary all` (945/947 tests passed, 2 skipped)
- `zig build -Doptimize=ReleaseFast`
- `cd python && uv run --extra dev ruff check .`
- `cd python && uv run --extra dev pytest tests/ -q` (154 passed, 16 skipped)
- `cd website && npm run build`

## Benchmark Notes
- `examples/1ubq.pdb`, `n_points=128`: raw bitmask relative error -1.256%; corrected +0.247%.
- 5wvo_C trajectory, 1001 frames: raw bitmask rbias -1.7494% / MAPE 1.7494%; corrected rbias -0.1212% / MAPE 0.2556% with bitmask-like runtime.

## Review Follow-up
- Added strict Python validation so `bitmask_correction=True` cannot silently fall back when n_points is outside the bitmask range.
- Added batch config validation for workflow/effective configs so correction cannot be silently ignored without bitmask mode or with adaptive SR.
- Moved trajectory invalid-combination validation before output file creation.
