### PR TITLE
feat: add trajectory bitmask LUT modes

### DIFF
--- a/src/bitmask_lut.zig
+++ b/src/bitmask_lut.zig
@@ -50,6 +50,16 @@ pub fn BitmaskLutGen(comptime T: type) type {
         /// Build the lookup table for the given n_points.
         /// Returns error.UnsupportedNPoints if n_points is not in 1..1024.
         pub fn init(allocator: Allocator, n_points_val: u32) !Self {
+            return initVariant(allocator, n_points_val, 0);
+        }
+
+        /// Build a deterministic rotated test-point variant of the lookup table.
+        ///
+        /// Variant 0 is identical to init(). Non-zero variants rotate sphere test
+        /// points before mask construction while keeping direction-bin layout
+        /// unchanged, which decorrelates quantization without changing runtime
+        /// binning semantics.
+        pub fn initVariant(allocator: Allocator, n_points_val: u32, variant: usize) !Self {
             if (!isSupportedNPoints(n_points_val)) return error.UnsupportedNPoints;
 
             const words: usize = (n_points_val + 63) / 64;
@@ -67,6 +77,9 @@ pub fn BitmaskLutGen(comptime T: type) type {
             const TestPointsGen = test_points.generateTestPointsGen(T);
             const tp = try TestPointsGen.generate(allocator, n_points_val);
             defer allocator.free(tp);
+            if (variant != 0) {
+                rotateTestPoints(tp, variant);
+            }
 
             // Allocate masks: n_dirs * angle_bins * words
             const total_masks = n_dirs * angle_bins * words;
@@ -102,6 +115,25 @@ pub fn BitmaskLutGen(comptime T: type) type {
                 .last_word_mask = last_word_mask,
                 .allocator = allocator,
             };
+        }
+
+        fn rotateTestPoints(points: []Vec, variant: usize) void {
+            const v: T = @floatFromInt(variant);
+            const angle_z = v * 2.39996322972865332;
+            const angle_y = v * 0.7548776662466927;
+            const cz = @cos(angle_z);
+            const sz = @sin(angle_z);
+            const cy = @cos(angle_y);
+            const sy = @sin(angle_y);
+
+            for (points) |*p| {
+                const xz = p.x * cz - p.y * sz;
+                const yz = p.x * sz + p.y * cz;
+                const zz = p.z;
+                p.x = xz * cy + zz * sy;
+                p.y = yz;
+                p.z = -xz * sy + zz * cy;
+            }
         }
 
         pub fn deinit(self: *Self) void {
@@ -229,6 +261,26 @@ test "BitmaskLut init and deinit - 128 points" {
     try std.testing.expectEqual(@as(usize, 2), lut.words);
     try std.testing.expectEqual(@as(u32, 128), lut.n_points);
     try std.testing.expectEqual(std.math.maxInt(u64), lut.last_word_mask);
+}
+
+test "BitmaskLut variant zero matches default" {
+    const allocator = std.testing.allocator;
+    var default_lut = try BitmaskLut.init(allocator, 128);
+    defer default_lut.deinit();
+    var variant_lut = try BitmaskLut.initVariant(allocator, 128, 0);
+    defer variant_lut.deinit();
+
+    try std.testing.expectEqualSlices(u64, default_lut.masks, variant_lut.masks);
+}
+
+test "BitmaskLut rotated variant changes masks" {
+    const allocator = std.testing.allocator;
+    var default_lut = try BitmaskLut.init(allocator, 128);
+    defer default_lut.deinit();
+    var variant_lut = try BitmaskLut.initVariant(allocator, 128, 1);
+    defer variant_lut.deinit();
+
+    try std.testing.expect(!std.mem.eql(u64, default_lut.masks, variant_lut.masks));
 }
 
 test "BitmaskLut init and deinit - 256 points" {

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -123,6 +123,14 @@ const TrajectoryReader = struct {
 
 const SdfPathList = sdf_parser.SdfPathList;
 
+const bitmask_lut_cycle_count: usize = 4;
+
+const BitmaskLutMode = enum {
+    single,
+    per_frame,
+    cycle,
+};
+
 /// Trajectory mode arguments
 pub const TrajArgs = struct {
     traj_path: ?[]const u8 = null,
@@ -143,6 +151,7 @@ pub const TrajArgs = struct {
     include_hydrogens: bool = true, // Include hydrogen atoms (default: include for MD trajectories)
     batch_size: u32 = 0, // Frames per batch for parallel processing (0 = auto)
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
+    bitmask_lut_mode: BitmaskLutMode = .single,
     bitmask_correction: bool = false, // Experimental exposed-fraction correction for bitmask SR
     bitmask_correction_coeff: f64 = shrake_rupley_bitmask.default_bitmask_correction_coeff,
     quiet: bool = false,
@@ -164,6 +173,21 @@ fn parseBitmaskCorrectionCoeff(value: []const u8) f64 {
         std.process.exit(1);
     }
     return coeff;
+}
+
+fn parseBitmaskLutMode(value: []const u8) BitmaskLutMode {
+    if (std.mem.eql(u8, value, "single")) return .single;
+    if (std.mem.eql(u8, value, "per-frame")) return .per_frame;
+    if (std.mem.eql(u8, value, "cycle")) return .cycle;
+    std.debug.print("Error: Invalid bitmask LUT mode: {s}\n", .{value});
+    std.process.exit(1);
+}
+
+fn validateBitmaskLutMode(args: TrajArgs) !void {
+    if (args.bitmask_lut_mode != .single and !args.use_bitmask) {
+        std.debug.print("Error: --bitmask-lut-mode requires --use-bitmask\n", .{});
+        return error.InvalidArgument;
+    }
 }
 
 /// Parse trajectory mode arguments
@@ -277,6 +301,15 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
                 result.include_hydrogens = false;
             } else if (std.mem.eql(u8, arg, "--use-bitmask")) {
                 result.use_bitmask = true;
+            } else if (std.mem.startsWith(u8, arg, "--bitmask-lut-mode=")) {
+                result.bitmask_lut_mode = parseBitmaskLutMode(arg["--bitmask-lut-mode=".len..]);
+            } else if (std.mem.eql(u8, arg, "--bitmask-lut-mode")) {
+                i += 1;
+                if (i >= args.len) {
+                    std.debug.print("Error: Missing value for --bitmask-lut-mode\n", .{});
+                    std.process.exit(1);
+                }
+                result.bitmask_lut_mode = parseBitmaskLutMode(args[i]);
             } else if (std.mem.eql(u8, arg, "--bitmask-correction")) {
                 result.bitmask_correction = true;
             } else if (std.mem.startsWith(u8, arg, "--bitmask-correction-coeff=")) {
@@ -395,6 +428,10 @@ pub fn printHelp(program_name: []const u8) void {
         \\                       Include hydrogen atoms (default, for backward compat)
         \\    --use-bitmask      Use bitmask LUT optimization for SR algorithm
         \\                       (n-points must be 1..1024)
+        \\    --bitmask-lut-mode=MODE
+        \\                       Trajectory bitmask LUT reuse mode:
+        \\                       single (default), per-frame, cycle
+        \\                       Non-default modes require --use-bitmask
         \\    --bitmask-correction
         \\                       Experimental correction for bitmask quantization bias
         \\                       Requires --use-bitmask
@@ -467,28 +504,73 @@ const FrameResult = struct {
 const TrajLuts = struct {
     lut_f64: ?bitmask_lut.BitmaskLut = null,
     lut_f32: ?bitmask_lut.BitmaskLutGen(f32) = null,
+    cycle_f64: [bitmask_lut_cycle_count]bitmask_lut.BitmaskLut = undefined,
+    cycle_f32: [bitmask_lut_cycle_count]bitmask_lut.BitmaskLutGen(f32) = undefined,
+    cycle_len: usize = 0,
+    cycle_precision: Precision = .f64,
 
     fn init(allocator: Allocator, args: TrajArgs) !TrajLuts {
         if (!args.use_bitmask) return .{};
         if (args.algorithm != .sr) return error.BitmaskRequiresSR;
-        return switch (args.precision) {
-            .f64 => .{ .lut_f64 = try bitmask_lut.BitmaskLut.init(allocator, args.n_points) },
-            .f32 => .{ .lut_f32 = try bitmask_lut.BitmaskLutGen(f32).init(allocator, args.n_points) },
-        };
+        if (!bitmask_lut.isSupportedNPoints(args.n_points)) return error.UnsupportedNPoints;
+        switch (args.bitmask_lut_mode) {
+            .per_frame => return .{},
+            .single => return switch (args.precision) {
+                .f64 => .{ .lut_f64 = try bitmask_lut.BitmaskLut.init(allocator, args.n_points) },
+                .f32 => .{ .lut_f32 = try bitmask_lut.BitmaskLutGen(f32).init(allocator, args.n_points) },
+            },
+            .cycle => {
+                var luts = TrajLuts{
+                    .cycle_precision = args.precision,
+                };
+                errdefer luts.deinit();
+                switch (args.precision) {
+                    .f64 => for (0..bitmask_lut_cycle_count) |i| {
+                        luts.cycle_f64[i] = try bitmask_lut.BitmaskLut.initVariant(allocator, args.n_points, i);
+                        luts.cycle_len = i + 1;
+                    },
+                    .f32 => for (0..bitmask_lut_cycle_count) |i| {
+                        luts.cycle_f32[i] = try bitmask_lut.BitmaskLutGen(f32).initVariant(allocator, args.n_points, i);
+                        luts.cycle_len = i + 1;
+                    },
+                }
+                return luts;
+            },
+        }
     }
 
     fn deinit(self: *TrajLuts) void {
         if (self.lut_f64) |*lut| lut.deinit();
         if (self.lut_f32) |*lut| lut.deinit();
+        if (self.cycle_len > 0) {
+            switch (self.cycle_precision) {
+                .f64 => for (self.cycle_f64[0..self.cycle_len]) |*lut| lut.deinit(),
+                .f32 => for (self.cycle_f32[0..self.cycle_len]) |*lut| lut.deinit(),
+            }
+        }
         self.* = .{};
     }
 
-    fn f64Ptr(self: *const TrajLuts) ?*const bitmask_lut.BitmaskLut {
-        return if (self.lut_f64 != null) &self.lut_f64.? else null;
+    fn f64Ptr(self: *const TrajLuts, frame_idx: usize) ?*const bitmask_lut.BitmaskLut {
+        if (self.lut_f64 != null) return &self.lut_f64.?;
+        if (self.cycle_len > 0 and self.cycle_precision == .f64) {
+            return &self.cycle_f64[frame_idx % self.cycle_len];
+        }
+        return null;
     }
 
-    fn f32Ptr(self: *const TrajLuts) ?*const bitmask_lut.BitmaskLutGen(f32) {
-        return if (self.lut_f32 != null) &self.lut_f32.? else null;
+    fn f32Ptr(self: *const TrajLuts, frame_idx: usize) ?*const bitmask_lut.BitmaskLutGen(f32) {
+        if (self.lut_f32 != null) return &self.lut_f32.?;
+        if (self.cycle_len > 0 and self.cycle_precision == .f32) {
+            return &self.cycle_f32[frame_idx % self.cycle_len];
+        }
+        return null;
+    }
+
+    fn reusableLutCount(self: *const TrajLuts) usize {
+        if (self.cycle_len > 0) return self.cycle_len;
+        if (self.lut_f64 != null or self.lut_f32 != null) return 1;
+        return 0;
     }
 };
 
@@ -510,6 +592,8 @@ const BatchWorkerArgs = struct {
     n_points: u32,
     n_slices: u32,
     coord_scale: f64, // ztraj readers already yield Å; kept for reader abstraction
+    use_bitmask: bool = false,
+    bitmask_luts: ?*const TrajLuts = null,
     bitmask_lut_f64: ?*const bitmask_lut.BitmaskLut = null,
     bitmask_lut_f32: ?*const bitmask_lut.BitmaskLutGen(f32) = null,
     bitmask_correction: bool = false,
@@ -576,18 +660,31 @@ fn batchWorkerFn(args: BatchWorkerArgs) void {
         // Calculate SASA (single-threaded per frame)
         var total_sasa: f64 = 0;
         const frame_id = args.frame_data[batch_idx].frame_idx;
+        const frame_slot: usize = @intCast(frame_id);
 
         if (args.precision == .f32) {
             const config = Configf32{
                 .probe_radius = @floatCast(args.probe_radius),
                 .n_points = args.n_points,
             };
-            if (args.bitmask_lut_f32) |lut| {
+            const lut_opt = if (args.bitmask_luts) |luts| luts.f32Ptr(frame_slot) else args.bitmask_lut_f32;
+            if (lut_opt) |lut| {
                 const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
                     .enabled = args.bitmask_correction,
                     .coeff = @floatCast(args.bitmask_correction_coeff),
                 };
                 var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithLutAndCorrection(thread_alloc, input, config, lut, correction) catch |err| {
+                    setWorkerError(args, "frame {d}: bitmask-f32 failed: {s}", .{ frame_id, @errorName(err) });
+                    return;
+                };
+                total_sasa = @floatCast(result.total_area);
+                result.deinit();
+            } else if (args.use_bitmask) {
+                const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
+                    .enabled = args.bitmask_correction,
+                    .coeff = @floatCast(args.bitmask_correction_coeff),
+                };
+                var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithCorrection(thread_alloc, input, config, correction) catch |err| {
                     setWorkerError(args, "frame {d}: bitmask-f32 failed: {s}", .{ frame_id, @errorName(err) });
                     return;
                 };
@@ -607,12 +704,24 @@ fn batchWorkerFn(args: BatchWorkerArgs) void {
                     .probe_radius = args.probe_radius,
                     .n_points = args.n_points,
                 };
-                if (args.bitmask_lut_f64) |lut| {
+                const lut_opt = if (args.bitmask_luts) |luts| luts.f64Ptr(frame_slot) else args.bitmask_lut_f64;
+                if (lut_opt) |lut| {
                     const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
                         .enabled = args.bitmask_correction,
                         .coeff = args.bitmask_correction_coeff,
                     };
                     var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithLutAndCorrection(thread_alloc, input, config, lut, correction) catch |err| {
+                        setWorkerError(args, "frame {d}: bitmask-f64 failed: {s}", .{ frame_id, @errorName(err) });
+                        return;
+                    };
+                    total_sasa = result.total_area;
+                    result.deinit();
+                } else if (args.use_bitmask) {
+                    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
+                        .enabled = args.bitmask_correction,
+                        .coeff = args.bitmask_correction_coeff,
+                    };
+                    var result = shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithCorrection(thread_alloc, input, config, correction) catch |err| {
                         setWorkerError(args, "frame {d}: bitmask-f64 failed: {s}", .{ frame_id, @errorName(err) });
                         return;
                     };
@@ -719,6 +828,11 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
         std.debug.print("Error: Missing topology file\n", .{});
         return error.MissingArgument;
     };
+    if (args.bitmask_correction and !args.use_bitmask) {
+        std.debug.print("Error: --bitmask-correction requires --use-bitmask\n", .{});
+        return error.InvalidArgument;
+    }
+    try validateBitmaskLutMode(args);
 
     // Detect trajectory format
     const traj_format = detectTrajectoryFormat(traj_path) orelse {
@@ -844,11 +958,6 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
         return error.AtomCountMismatch;
     }
 
-    if (args.bitmask_correction and !args.use_bitmask) {
-        std.debug.print("Error: --bitmask-correction requires --use-bitmask\n", .{});
-        return error.InvalidArgument;
-    }
-
     // Open output file with buffered writer
     const output_file = try std.Io.Dir.cwd().createFile(io, args.output_path, .{});
     defer output_file.close(io);
@@ -865,7 +974,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
     else
         args.n_threads;
 
-    // Build bitmask LUT once (if enabled) — reused across all frames
+    // Prepare trajectory bitmask LUTs according to the selected reuse mode.
     var luts = TrajLuts.init(allocator, args) catch |err| {
         switch (err) {
             error.BitmaskRequiresSR => {
@@ -891,6 +1000,14 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
             if (args.precision == .f32) "f32" else "f64",
             if (args.use_bitmask) ", Bitmask: enabled" else "",
         });
+        if (args.use_bitmask) {
+            const mode_name: []const u8 = switch (args.bitmask_lut_mode) {
+                .single => "single",
+                .per_frame => "per-frame",
+                .cycle => "cycle",
+            };
+            std.debug.print("Bitmask LUT mode: {s}\n", .{mode_name});
+        }
         std.debug.print("Processing frames", .{});
         if (args.stride > 1) std.debug.print(" (stride={d})", .{args.stride});
         if (args.start_frame > 0) std.debug.print(" from {d}", .{args.start_frame});
@@ -1017,12 +1134,20 @@ fn runSequential(
                     .probe_radius = @floatCast(args.probe_radius),
                     .n_points = args.n_points,
                 };
-                if (luts.f32Ptr()) |lut| {
+                if (luts.f32Ptr(@intCast(frame_idx.*))) |lut| {
                     const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
                         .enabled = args.bitmask_correction,
                         .coeff = @floatCast(args.bitmask_correction_coeff),
                     };
                     var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithLutAndCorrection(allocator, frame_input, config, lut, correction);
+                    defer result.deinit();
+                    break :blk @floatCast(result.total_area);
+                } else if (args.use_bitmask) {
+                    const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f32){
+                        .enabled = args.bitmask_correction,
+                        .coeff = @floatCast(args.bitmask_correction_coeff),
+                    };
+                    var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f32).calculateSasaWithCorrection(allocator, frame_input, config, correction);
                     defer result.deinit();
                     break :blk @floatCast(result.total_area);
                 } else {
@@ -1038,12 +1163,20 @@ fn runSequential(
                             .probe_radius = args.probe_radius,
                             .n_points = args.n_points,
                         };
-                        if (luts.f64Ptr()) |lut| {
+                        if (luts.f64Ptr(@intCast(frame_idx.*))) |lut| {
                             const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
                                 .enabled = args.bitmask_correction,
                                 .coeff = args.bitmask_correction_coeff,
                             };
                             var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithLutAndCorrection(allocator, frame_input, config, lut, correction);
+                            defer result.deinit();
+                            break :blk result.total_area;
+                        } else if (args.use_bitmask) {
+                            const correction = shrake_rupley_bitmask.BitmaskCorrectionGen(f64){
+                                .enabled = args.bitmask_correction,
+                                .coeff = args.bitmask_correction_coeff,
+                            };
+                            var result = try shrake_rupley_bitmask.ShrakeRupleyBitmaskGen(f64).calculateSasaWithCorrection(allocator, frame_input, config, correction);
                             defer result.deinit();
                             break :blk result.total_area;
                         } else {
@@ -1149,8 +1282,8 @@ fn runBatchParallel(
                 .n_points = args.n_points,
                 .n_slices = args.n_slices,
                 .coord_scale = reader.coordScale(),
-                .bitmask_lut_f64 = luts.f64Ptr(),
-                .bitmask_lut_f32 = luts.f32Ptr(),
+                .use_bitmask = args.use_bitmask,
+                .bitmask_luts = luts,
                 .bitmask_correction = args.bitmask_correction,
                 .bitmask_correction_coeff = args.bitmask_correction_coeff,
             }}) catch {
@@ -1300,6 +1433,49 @@ test "TrajArgs --bitmask-correction-coeff" {
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.bitmask_correction);
     try std.testing.expectEqual(@as(f64, 0.2), parsed.bitmask_correction_coeff);
+}
+
+test "TrajArgs --bitmask-lut-mode parses supported modes" {
+    const single_args = [_][]const u8{ "zsasa", "traj", "--use-bitmask", "--bitmask-lut-mode=single", "traj.xtc", "topology.pdb" };
+    const per_frame_args = [_][]const u8{ "zsasa", "traj", "--use-bitmask", "--bitmask-lut-mode", "per-frame", "traj.xtc", "topology.pdb" };
+    const cycle_args = [_][]const u8{ "zsasa", "traj", "--use-bitmask", "--bitmask-lut-mode=cycle", "traj.xtc", "topology.pdb" };
+
+    try std.testing.expectEqual(BitmaskLutMode.single, parseArgs(&single_args, 2).bitmask_lut_mode);
+    try std.testing.expectEqual(BitmaskLutMode.per_frame, parseArgs(&per_frame_args, 2).bitmask_lut_mode);
+    try std.testing.expectEqual(BitmaskLutMode.cycle, parseArgs(&cycle_args, 2).bitmask_lut_mode);
+}
+
+test "TrajArgs non-default bitmask LUT mode requires bitmask" {
+    try std.testing.expectError(
+        error.InvalidArgument,
+        validateBitmaskLutMode(.{ .bitmask_lut_mode = .per_frame }),
+    );
+    try validateBitmaskLutMode(.{ .use_bitmask = true, .bitmask_lut_mode = .per_frame });
+}
+
+test "TrajLuts honors bitmask LUT reuse modes" {
+    const allocator = std.testing.allocator;
+
+    var single = try TrajLuts.init(allocator, .{ .use_bitmask = true, .bitmask_lut_mode = .single, .precision = .f64 });
+    defer single.deinit();
+    try std.testing.expect(single.f64Ptr(0) != null);
+    try std.testing.expectEqual(@as(usize, 1), single.reusableLutCount());
+
+    var per_frame = try TrajLuts.init(allocator, .{ .use_bitmask = true, .bitmask_lut_mode = .per_frame, .precision = .f64 });
+    defer per_frame.deinit();
+    try std.testing.expect(per_frame.f64Ptr(0) == null);
+    try std.testing.expectEqual(@as(usize, 0), per_frame.reusableLutCount());
+    try std.testing.expectError(
+        error.UnsupportedNPoints,
+        TrajLuts.init(allocator, .{ .use_bitmask = true, .bitmask_lut_mode = .per_frame, .precision = .f64, .n_points = 2000 }),
+    );
+
+    var cycle = try TrajLuts.init(allocator, .{ .use_bitmask = true, .bitmask_lut_mode = .cycle, .precision = .f64 });
+    defer cycle.deinit();
+    try std.testing.expect(cycle.f64Ptr(0) != null);
+    try std.testing.expect(!std.mem.eql(u64, cycle.f64Ptr(0).?.masks, cycle.f64Ptr(1).?.masks));
+    try std.testing.expect(cycle.f64Ptr(bitmask_lut_cycle_count) == cycle.f64Ptr(0));
+    try std.testing.expectEqual(bitmask_lut_cycle_count, cycle.reusableLutCount());
 }
 
 test "TrajArgs quiet suppresses progress even when show_progress defaults true" {

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -115,6 +115,7 @@ For batch custom classifier configs, use a workflow `[classifier]` section. See 
 | `--n-points=N` | Test points per atom (SR only, 1-10000) | `100` |
 | `--n-slices=N` | Slices per atom diameter (LR only, 1-1000) | `20` |
 | `--use-bitmask` | Use [bitmask LUT optimization](../guide/algorithms.mdx#bitmask-lut-optimization) (SR only, n_points 1-1024) | off |
+| `--bitmask-lut-mode=MODE` | Trajectory-only bitmask LUT reuse mode: `single`, `per-frame`, or `cycle`; non-default modes require `--use-bitmask` | `single` |
 | `--bitmask-correction` | Experimental exposed-fraction correction for bitmask quantization bias; requires `--use-bitmask` | off |
 | `--bitmask-correction-coeff=V` | Override the experimental correction coefficient | `0.020` |
 | `--adaptive-sr` | Batch-only experimental two-stage bitmask SR; requires `--use-bitmask` and `--algorithm=sr` | off |

--- a/website/docs/guide/algorithms.mdx
+++ b/website/docs/guide/algorithms.mdx
@@ -153,11 +153,33 @@ f_corrected = f + coeff × f × (1 - f)
 
 This leaves fully buried (`f = 0`) and fully exposed (`f = 1`) atoms unchanged, while lifting partially exposed atoms where LUT direction/angle quantization most often over-occludes surface points. The default coefficient is conservative (`0.020`) and can be overridden with `--bitmask-correction-coeff=V`. Treat this as an experimental bias-mitigation mode, not as a replacement for exact SR when maximum numerical agreement is required.
 
+
+### Trajectory LUT Reuse Modes
+
+Trajectory bitmask mode reuses one prebuilt LUT by default for maximum throughput:
+
+```bash
+zsasa traj --use-bitmask --bitmask-lut-mode=single trajectory.xtc topology.pdb
+```
+
+For experiments that need to separate LUT reuse from bitmask quantization, trajectory mode also supports:
+
+- `single` — default; build one LUT and reuse it for all frames.
+- `per-frame` — rebuild the bitmask LUT for each processed frame. This is slower and mainly useful as a validation/control mode.
+- `cycle` — prebuild a small deterministic set of rotated test-point LUT variants and cycle frames through them. This keeps LUT reuse while decorrelating the fixed test-point quantization pattern across adjacent frames.
+
+```bash
+zsasa traj --use-bitmask --bitmask-lut-mode=cycle trajectory.xtc topology.pdb
+```
+
+`cycle` changes bitmask approximation details and should be treated as an experimental accuracy mode. Use exact SR when maximum numerical agreement is required.
+
 ### Constraints
 
 - **SR algorithm only** — not available for Lee-Richards
 - **Supported n_points**: 1–1024
 - **Correction mode**: requires bitmask SR and is disabled by default
+- **Trajectory LUT modes**: `single` is the default; `per-frame` and `cycle` require `--use-bitmask`
 - Lahuta uses n_points=128 fixed; zsasa supports any value in range
 
 ### When to Use
@@ -181,6 +203,9 @@ zsasa traj --use-bitmask --n-points=128 trajectory.xtc topology.pdb
 
 # Trajectory with experimental bitmask bias correction
 zsasa traj --use-bitmask --bitmask-correction trajectory.xtc topology.pdb
+
+# Trajectory with rotated LUT cycling
+zsasa traj --use-bitmask --bitmask-lut-mode=cycle trajectory.xtc topology.pdb
 
 # Batch with bitmask
 zsasa batch --use-bitmask --n-points=128 input_dir/ output_dir/


### PR DESCRIPTION
## Summary
- Add trajectory-only `--bitmask-lut-mode=single|per-frame|cycle`.
- Preserve the existing fast single-LUT reuse default while adding per-frame rebuild and rotated-LUT cycling modes.
- Add deterministic rotated test-point LUT variants and tests, without changing runtime direction-bin semantics.
- Document the trajectory LUT reuse modes and trade-offs.

## Validation
- `git diff --check`
- `zig fmt --check src/`
- `zig build test --summary all` (952/954 tests passed, 2 skipped)
- `zig build -Doptimize=ReleaseFast`
- `cd website && npm run build`
- Trajectory smoke on 5wvo_C frames 0..20 for `single`, `per-frame`, and `cycle`

## Benchmark Notes
5wvo_C, 1001 frames, f64, n_points=100, threads=10:
- `single`: rbias -1.7494%, MAPE 1.7494%, real 0.84s
- `per-frame`: same results as `single`, real 3.06s
- `cycle`: rbias -1.6906%, MAPE 1.6906%, real 0.91s
- `single + correction`: rbias -0.1212%, MAPE 0.2556%, real 0.86s
- `cycle + correction`: rbias -0.0615%, MAPE 0.3015%, real 0.91s
