### PR TITLE
feat: add BSA workflow analysis

### DIFF
--- a/docs/superpowers/plans/2026-06-28-bsa-analysis-workflow.md
+++ b/docs/superpowers/plans/2026-06-28-bsa-analysis-workflow.md
@@ -1,0 +1,391 @@
+# BSA Analysis Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a BSA/ΔSASA analysis mode to batch workflow files with analysis-specific JSONL output.
+
+**Architecture:** Extend workflow parsing with an optional `[analysis]` table, add a JSONL serializer for BSA analysis rows, and add a file-first batch workflow analysis runner that computes partner A, partner B, and AB complex SASA using existing selection and SASA calculation helpers. Keep normal workflow jobs unchanged when `[analysis]` is absent.
+
+**Tech Stack:** Zig 0.16, existing TOML parser, existing batch workflow file-first parsing/classification path, existing JSON stringify helpers, Docusaurus Markdown docs.
+
+---
+
+### Task 1: Parse `[analysis]` in workflow manifests
+
+**Files:**
+- Modify: `/Users/nagaet/ghq/github.com/N283T/zsasa/src/workflow_manifest.zig`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add tests in `src/workflow_manifest.zig` near existing workflow parser tests:
+
+```zig
+test "parse BSA analysis workflow" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "structures"
+        \\
+        \\[output]
+        \\dir = "results"
+        \\format = "jsonl"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\name = "interface_ab"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\level = "residue"
+    ;
+    var workflow = try parse(std.testing.allocator, input);
+    defer workflow.deinit();
+
+    try std.testing.expectEqualStrings("bsa", workflow.analysis.?.type.?);
+    try std.testing.expectEqualStrings("interface_ab", workflow.analysis.?.name.?);
+    try std.testing.expectEqual(@as(usize, 1), workflow.analysis.?.partner_a.?.len);
+    try std.testing.expectEqualStrings("A", workflow.analysis.?.partner_a.?[0]);
+    try std.testing.expectEqual(@as(usize, 1), workflow.analysis.?.partner_b.?.len);
+    try std.testing.expectEqualStrings("B", workflow.analysis.?.partner_b.?[0]);
+    try std.testing.expectEqualStrings("residue", workflow.analysis.?.level.?);
+}
+
+test "reject BSA analysis without both partners" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\partner_a = ["A"]
+    ;
+    try std.testing.expectError(error.InvalidAnalysisConfig, parse(std.testing.allocator, input));
+}
+
+test "reject BSA analysis invalid level" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\level = "chain"
+    ;
+    try std.testing.expectError(error.InvalidAnalysisConfig, parse(std.testing.allocator, input));
+}
+```
+
+- [ ] **Step 2: Run parser tests to verify RED**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | tee /tmp/zsasa-bsa-parser-red.log
+```
+
+Expected: FAIL because `Workflow` has no `analysis` field and `InvalidAnalysisConfig` is undefined.
+
+- [ ] **Step 3: Implement manifest parsing**
+
+Add `InvalidAnalysisConfig` to `WorkflowError`; add:
+
+```zig
+pub const Analysis = struct {
+    type: ?[]const u8 = null,
+    name: ?[]const u8 = null,
+    partner_a: ?[]const []const u8 = null,
+    partner_b: ?[]const []const u8 = null,
+    level: ?[]const u8 = null,
+};
+```
+
+Add `analysis: ?Analysis = null` to `Workflow`, free `partner_a` and `partner_b` in `Workflow.deinit`, allow table name `analysis` in `validateKnownDocumentShape`, parse it in `parseOwned`, and implement:
+
+```zig
+fn parseAnalysis(allocator: Allocator, table: toml_parser.Table) Error!Analysis {
+    try rejectUnknownFields(table.entries, &.{ "type", "name", "partner_a", "partner_b", "level" });
+    const analysis = Analysis{
+        .type = try optionalString(table.entries, "type"),
+        .name = try optionalString(table.entries, "name"),
+        .partner_a = try optionalStringArray(allocator, table.entries, "partner_a"),
+        .partner_b = try optionalStringArray(allocator, table.entries, "partner_b"),
+        .level = try optionalString(table.entries, "level"),
+    };
+    try validateAnalysis(analysis);
+    return analysis;
+}
+```
+
+`validateAnalysis` accepts only `type = "bsa"`, requires non-empty partner arrays, checks `name` with `isSafeJobName` when present, and accepts only absent/`"total"`/`"residue"` level.
+
+- [ ] **Step 4: Run parser tests to verify GREEN**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | tee /tmp/zsasa-bsa-parser-green.log
+```
+
+Expected: PASS.
+
+### Task 2: Add BSA analysis JSONL serialization
+
+**Files:**
+- Modify: `/Users/nagaet/ghq/github.com/N283T/zsasa/src/json_writer.zig`
+
+- [ ] **Step 1: Write failing serializer test**
+
+Add a test near existing JSONL tests:
+
+```zig
+test "BSA analysis JSONL includes total and residue delta fields" {
+    const allocator = std.testing.allocator;
+    const partner_a = [_][]const u8{"A"};
+    const partner_b = [_][]const u8{"B"};
+    const residue_chain = [_][]const u8{ "A", "B" };
+    const residue_name = [_][]const u8{ "GLY", "ALA" };
+    const residue_number = [_]i32{ 1, 2 };
+    const residue_insertion_code = [_][]const u8{ "", "" };
+    const residue_delta_sasa = [_]f64{ 3.0, 5.0 };
+
+    const line = try bsaAnalysisToJsonlLine(allocator, .{
+        .filename = "tiny.pdb",
+        .name = "interface_ab",
+        .partner_a = partner_a[0..],
+        .partner_b = partner_b[0..],
+        .sasa_partner_a = 10.0,
+        .sasa_partner_b = 20.0,
+        .sasa_complex = 14.0,
+        .delta_sasa_total = 16.0,
+        .bsa = 8.0,
+        .delta_sasa_level = "residue",
+        .residue_chain = residue_chain[0..],
+        .residue_name = residue_name[0..],
+        .residue_number = residue_number[0..],
+        .residue_insertion_code = residue_insertion_code[0..],
+        .residue_delta_sasa = residue_delta_sasa[0..],
+    });
+    defer allocator.free(line);
+
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"analysis\":\"bsa\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"delta_sasa_total\":16") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"bsa\":8") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_delta_sasa\":[3,5]") != null);
+}
+```
+
+- [ ] **Step 2: Run serializer test to verify RED**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | tee /tmp/zsasa-bsa-json-red.log
+```
+
+Expected: FAIL because `bsaAnalysisToJsonlLine` is undefined.
+
+- [ ] **Step 3: Implement serializer**
+
+Add public input struct and function in `src/json_writer.zig`:
+
+```zig
+pub const BsaAnalysisJsonl = struct {
+    filename: []const u8,
+    name: []const u8,
+    partner_a: []const []const u8,
+    partner_b: []const []const u8,
+    sasa_partner_a: f64,
+    sasa_partner_b: f64,
+    sasa_complex: f64,
+    delta_sasa_total: f64,
+    bsa: f64,
+    delta_sasa_level: []const u8,
+    residue_chain: []const []const u8 = &.{},
+    residue_name: []const []const u8 = &.{},
+    residue_number: []const i32 = &.{},
+    residue_insertion_code: []const []const u8 = &.{},
+    residue_delta_sasa: []const f64 = &.{},
+};
+```
+
+Implement `bsaAnalysisToJsonlLine` with separate total-only and residue entry structs so residue arrays are omitted when `delta_sasa_level` is `"total"`.
+
+- [ ] **Step 4: Run serializer test to verify GREEN**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | tee /tmp/zsasa-bsa-json-green.log
+```
+
+Expected: PASS.
+
+### Task 3: Implement BSA analysis workflow runner
+
+**Files:**
+- Modify: `/Users/nagaet/ghq/github.com/N283T/zsasa/src/batch.zig`
+
+- [ ] **Step 1: Write failing workflow integration test**
+
+Add a test near existing workflow integration tests in `src/batch.zig` that creates a temporary input directory with a two-chain PDB, writes a workflow with `[analysis]`, runs `runWorkflow`, and checks `<output>/interface_ab.jsonl` contains BSA fields:
+
+```zig
+test "workflow BSA analysis writes analysis JSONL" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const output_dir = try std.fs.path.join(allocator, &.{ root, "output" });
+    defer allocator.free(output_dir);
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+
+    const pdb_path = try std.fs.path.join(allocator, &.{ input_dir, "tiny_ab.pdb" });
+    defer allocator.free(pdb_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = pdb_path, .data =
+        "ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "ATOM      2  CA  GLY A   1       1.500   0.000   0.000  1.00 20.00           C  \n" ++
+        "ATOM      3  N   ALA B   2       3.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "ATOM      4  CA  ALA B   2       4.500   0.000   0.000  1.00 20.00           C  \n" ++
+        "END\n",
+    });
+
+    const workflow_path = try std.fs.path.join(allocator, &.{ root, "bsa.toml" });
+    defer allocator.free(workflow_path);
+    const workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "jsonl"
+        \\
+        \\[calculation]
+        \\n_points = 16
+        \\quiet = true
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\name = "interface_ab"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\level = "residue"
+    , .{ input_dir, output_dir });
+    defer allocator.free(workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = workflow_path });
+
+    const jsonl_path = try std.fs.path.join(allocator, &.{ output_dir, "interface_ab.jsonl" });
+    defer allocator.free(jsonl_path);
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, jsonl_path, allocator, .limited(8192));
+    defer allocator.free(content);
+
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"analysis\":\"bsa\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"delta_sasa_total\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"bsa\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"residue_delta_sasa\"") != null);
+}
+```
+
+- [ ] **Step 2: Run integration test to verify RED**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | tee /tmp/zsasa-bsa-workflow-red.log
+```
+
+Expected: FAIL because workflow analysis runner is not implemented.
+
+- [ ] **Step 3: Implement analysis runner**
+
+In `src/batch.zig`, add helper structs/functions for BSA analysis:
+
+- `analysisOutputName(analysis)` returns `analysis.name orelse "bsa"`.
+- `analysisOutputPath(allocator, output_dir, name)` returns `<output_dir>/<name>.jsonl`.
+- `appendStringArrays(allocator, a, b)` creates complex chain selection.
+- `calculateSelectedSasaForAnalysis` wraps `copySelectedAtomInput` plus `calculatePreparedInputResult` and returns selected input and result while preserving atom areas for ΔSASA.
+- `buildResidueDeltaArrays` maps selected partner atom deltas to residue arrays using the selected inputs' residue metadata.
+- `runWorkflowBsaAnalysis` mirrors the sequential file-first path: load resources, scan files, parse/classify once, calculate A/B/AB SASA, write one BSA JSONL row per successful file, and print `Workflow complete` counts.
+
+At the start of `runWorkflow`, after parsing the workflow, dispatch to `runWorkflowBsaAnalysis` when `workflow.analysis != null`.
+
+- [ ] **Step 4: Run integration test to verify GREEN**
+
+Run:
+
+```bash
+zig build test --summary all 2>&1 | tee /tmp/zsasa-bsa-workflow-green.log
+```
+
+Expected: PASS.
+
+### Task 4: Document BSA analysis workflows
+
+**Files:**
+- Modify: `/Users/nagaet/ghq/github.com/N283T/zsasa/website/docs/guide/workflows.md`
+
+- [ ] **Step 1: Add workflow docs**
+
+Add a "BSA / ΔSASA Analysis" section after the batch workflow example. Include the TOML example from the design, the formulas `delta_sasa_total = sasa_partner_a + sasa_partner_b - sasa_complex` and `bsa = delta_sasa_total / 2`, and mention that analysis JSONL does not use normal SASA `total_area`/`atom_areas` fields.
+
+- [ ] **Step 2: Run docs-relevant grep check**
+
+Run:
+
+```bash
+rg -n "BSA|ΔSASA|delta_sasa_total|partner_a" website/docs/guide/workflows.md
+```
+
+Expected: Shows the new section and fields.
+
+### Task 5: Format and verify
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Format Zig files**
+
+Run:
+
+```bash
+zig fmt src/workflow_manifest.zig src/json_writer.zig src/batch.zig
+```
+
+- [ ] **Step 2: Run focused checks**
+
+Run:
+
+```bash
+zig fmt --check src/
+zig build test
+zig build -Doptimize=ReleaseFast
+./zig-out/bin/zsasa --help
+./zig-out/bin/zsasa --version
+mkdir -p /tmp/zsasa-check
+./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Review diff**
+
+Run:
+
+```bash
+git diff -- src/workflow_manifest.zig src/json_writer.zig src/batch.zig website/docs/guide/workflows.md docs/superpowers/specs/2026-06-28-bsa-analysis-workflow-design.md docs/superpowers/plans/2026-06-28-bsa-analysis-workflow.md
+```
+
+Expected: Changes match the design and contain no debug prints, placeholders, or unrelated edits.

--- a/docs/superpowers/specs/2026-06-28-bsa-analysis-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-28-bsa-analysis-workflow-design.md
@@ -1,0 +1,169 @@
+# BSA Analysis Workflow Design
+
+## Summary
+
+Add a workflow-level BSA analysis mode for two-chain-group interfaces. The mode computes partner A SASA, partner B SASA, complex SASA, total ΔSASA, and BSA in one reproducible workflow analysis output. BSA and ΔSASA are intentionally separate concepts: ΔSASA is the unhalved loss of accessible area, while BSA is half of total ΔSASA for a two-partner interface.
+
+## Goals
+
+- Add an `[analysis]` section to workflow TOML for BSA-focused batch workflows.
+- Keep the existing `[[jobs]]` workflow behavior and output schemas unchanged.
+- Use a parser shape supported by the existing minimal TOML parser.
+- Produce one JSONL row per input structure for analysis batch output.
+- Make the first implementation correctness-first by reusing existing SASA calculation paths for partner A, partner B, and the AB complex.
+- Leave room for a later direct interface calculator that skips full A/B/AB output materialization.
+
+## Non-goals
+
+- Do not add a general expression engine for derived workflow outputs.
+- Do not implement multi-interface or N-partner automatic enumeration in the first change.
+- Do not optimize BSA/ΔSASA by direct cross-interface point-difference calculation yet.
+- Do not change normal `zsasa batch --workflow` job output behavior.
+- Do not support BSA analysis for `calc --workflow` in this first change.
+
+## Workflow schema
+
+Use a single optional `[analysis]` table in sectioned workflow files:
+
+```toml
+[analysis]
+type = "bsa"
+name = "interface_ab"
+partner_a = ["A"]
+partner_b = ["B"]
+level = "residue"
+```
+
+Fields:
+
+- `type`: required for analysis mode. First supported value: `"bsa"`.
+- `name`: optional safe output name. Defaults to `"bsa"`.
+- `partner_a`: required string array of chain IDs for the first isolated partner.
+- `partner_b`: required string array of chain IDs for the second isolated partner.
+- `level`: optional output detail level. First implementation supports `"total"` and `"residue"`; default is `"total"`.
+
+The schema uses `partner_a` and `partner_b` instead of nested arrays such as `partners = [["A"], ["B"]]` because the current TOML parser supports arrays of strings but not nested arrays.
+
+Validation:
+
+- `[analysis]` is only accepted in non-legacy sectioned workflows.
+- `type = "bsa"` requires non-empty `partner_a` and `partner_b`.
+- `name` must pass the same path-safety rules as job names.
+- `level` must be `"total"` or `"residue"`.
+- Batch BSA analysis requires `[input].dir` or positional input directory.
+- JSONL analysis output requires `[output].dir` or positional output path/dir. The output file is `<output_dir>/<analysis.name>.jsonl`.
+- If `[analysis]` is present, existing `[[jobs]]` entries are not required for the analysis output.
+
+## Calculation semantics
+
+For each input structure:
+
+1. Parse and classify the full input once where practical.
+2. Select atoms for partner A using `partner_a` chains.
+3. Select atoms for partner B using `partner_b` chains.
+4. Select atoms for the complex using `partner_a + partner_b` chains.
+5. Compute SASA for all three selections with the workflow calculation settings.
+6. Compute totals:
+   - `delta_sasa_total = sasa_partner_a + sasa_partner_b - sasa_complex`
+   - `bsa = delta_sasa_total / 2`
+7. For `level = "residue"`, compute per-atom ΔSASA by mapping complex atom areas back to partner-selected atom order:
+   - partner A atoms: `delta = sasa_partner_a_atom - sasa_complex_atom`
+   - partner B atoms: `delta = sasa_partner_b_atom - sasa_complex_atom`
+   Then aggregate consecutive atoms by residue using the existing residue-map conventions.
+
+The first implementation may run only in the file-first workflow path and may fallback or reject unsupported combinations with explicit errors. Normal `[[jobs]]` behavior remains available for users who need existing per-job outputs.
+
+## JSONL output schema
+
+BSA analysis JSONL is a separate analysis schema, not an extension of normal SASA JSONL. It intentionally avoids `total_area` and `atom_areas` because those names are ambiguous for BSA.
+
+One row per successfully processed input structure:
+
+```json
+{
+  "filename": "1abc.cif",
+  "analysis": "bsa",
+  "name": "interface_ab",
+  "partner_a": ["A"],
+  "partner_b": ["B"],
+  "sasa_partner_a": 1234.5,
+  "sasa_partner_b": 1000.0,
+  "sasa_complex": 1800.0,
+  "delta_sasa_total": 434.5,
+  "bsa": 217.25,
+  "delta_sasa_level": "residue",
+  "residue_chain": ["A", "B"],
+  "residue_name": ["ARG", "TYR"],
+  "residue_number": [12, 42],
+  "residue_insertion_code": ["", ""],
+  "residue_delta_sasa": [20.1, 14.5]
+}
+```
+
+For `level = "total"`, residue arrays are omitted.
+
+Rows for failed files are not written, matching current batch JSONL behavior. Failures contribute to the human-readable workflow summary.
+
+## Architecture
+
+### Workflow manifest
+
+Extend `src/workflow_manifest.zig` with:
+
+- `Analysis` struct stored on `Workflow`.
+- Parsing for `[analysis]` via `parseAnalysis`.
+- Validation helpers for BSA analysis fields and safe analysis names.
+- Tests for valid BSA analysis, missing partners, invalid level, and legacy rejection.
+
+### Analysis result writer
+
+Extend `src/json_writer.zig` with a BSA JSONL serializer that accepts plain slices and optional residue ΔSASA map data. This keeps analysis output formatting out of workflow execution logic.
+
+### Workflow execution
+
+Extend `src/batch.zig` with an analysis path that runs before normal `[[jobs]]` output when `[analysis]` is present. The first implementation should:
+
+- Reuse workflow config/classifier resource loading patterns.
+- Scan input files using existing batch discovery.
+- Parse/classify each file once.
+- Use `copySelectedAtomInput` for partner and complex selections.
+- Use `calculatePreparedInputResult` for SASA results.
+- Serialize BSA rows to `<output_dir>/<analysis.name>.jsonl`.
+- Keep regular job execution unchanged when no `[analysis]` is present.
+
+If both `[analysis]` and `[[jobs]]` are present, the first implementation may run analysis output only and document that jobs are ignored in analysis mode, or run analysis before jobs if implementation remains simple. The initial implementation should prefer a small and clear analysis-only path.
+
+## Testing
+
+Add focused Zig tests:
+
+- Workflow parser accepts `[analysis] type = "bsa"` and stores name, partners, and level.
+- Workflow parser rejects BSA analysis without both partners.
+- JSONL serializer outputs `bsa`, `delta_sasa_total`, and residue ΔSASA fields with expected names.
+- Workflow integration test creates a tiny two-chain fixture, runs `batch --workflow`, and verifies `<output_dir>/<analysis.name>.jsonl` contains `"analysis":"bsa"`, `"bsa"`, `"delta_sasa_total"`, and residue ΔSASA fields for `level = "residue"`.
+
+Run focused checks:
+
+```bash
+zig fmt --check src/
+zig build test
+zig build -Doptimize=ReleaseFast
+./zig-out/bin/zsasa --help
+./zig-out/bin/zsasa --version
+mkdir -p /tmp/zsasa-check
+./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json
+```
+
+Docs check is not required unless website docs are changed. If website workflow docs are updated, run `cd website && npm run build` after dependencies are available.
+
+## Documentation
+
+Update `website/docs/guide/workflows.md` with a BSA analysis workflow example and the distinction between BSA and ΔSASA:
+
+- ΔSASA is unhalved.
+- BSA is `delta_sasa_total / 2` for the two-partner analysis.
+- BSA analysis JSONL uses analysis-specific fields instead of normal SASA `total_area` and `atom_areas`.
+
+## Future optimization
+
+A later direct calculator can compute ΔSASA only for cross-interface candidate atoms and avoid materializing full partner and complex SASA outputs. This design deliberately keeps the public schema independent from the initial internal implementation so that optimization can be introduced without changing workflow files or JSONL consumers.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -176,6 +176,12 @@ fn workflowJsonlOutputPath(allocator: Allocator, output_dir: []const u8, job_nam
     return std.fs.path.join(allocator, &.{ output_dir, filename });
 }
 
+fn workflowAnalysisJsonlOutputPath(allocator: Allocator, output_dir: []const u8, analysis_name: []const u8) ![]const u8 {
+    const filename = try std.fmt.allocPrint(allocator, "{s}.jsonl", .{analysis_name});
+    defer allocator.free(filename);
+    return std.fs.path.join(allocator, &.{ output_dir, filename });
+}
+
 fn workflowPerFileOutputDir(allocator: Allocator, output_dir: []const u8, job_name: []const u8) ![]const u8 {
     return std.fs.path.join(allocator, &.{ output_dir, job_name });
 }
@@ -1327,6 +1333,67 @@ fn appendJsonlResultToFile(io: std.Io, file: std.Io.File, allocator: Allocator, 
     try writer.interface.writeAll(line);
     try writer.interface.writeByte('\n');
     try writer.interface.flush();
+}
+
+fn appendBsaAnalysisJsonlToFile(io: std.Io, file: std.Io.File, allocator: Allocator, row: json_writer.BsaAnalysisJsonl) !void {
+    const line = try json_writer.bsaAnalysisToJsonlLine(allocator, row);
+    defer allocator.free(line);
+
+    const file_len = try file.length(io);
+    var write_buf: [64 * 1024]u8 = undefined;
+    var writer = std.Io.File.Writer.init(file, io, &write_buf);
+    try writer.seekTo(file_len);
+    try writer.interface.writeAll(line);
+    try writer.interface.writeByte('\n');
+    try writer.interface.flush();
+}
+
+fn analysisName(analysis: workflow_manifest.Analysis) []const u8 {
+    return analysis.name orelse "bsa";
+}
+
+fn analysisLevel(analysis: workflow_manifest.Analysis) []const u8 {
+    return analysis.level orelse "total";
+}
+
+fn appendChainGroups(allocator: Allocator, a: []const []const u8, b: []const []const u8) ![]const []const u8 {
+    const out = try allocator.alloc([]const u8, a.len + b.len);
+    @memcpy(out[0..a.len], a);
+    @memcpy(out[a.len..], b);
+    return out;
+}
+
+const BsaResidueDeltaArrays = struct {
+    residue_chain: []const []const u8 = &.{},
+    residue_name: []const []const u8 = &.{},
+    residue_number: []const i32 = &.{},
+    residue_insertion_code: []const []const u8 = &.{},
+    residue_delta_sasa: []const f64 = &.{},
+};
+
+fn buildBsaResidueDeltaArrays(allocator: Allocator, input: AtomInput, atom_delta_sasa: []const f64) !BsaResidueDeltaArrays {
+    var map = try json_writer.buildResidueMap(allocator, input, atom_delta_sasa);
+    defer map.deinit();
+
+    const residue_chain = try allocator.alloc([]const u8, map.len());
+    const residue_name = try allocator.alloc([]const u8, map.len());
+    const residue_insertion_code = try allocator.alloc([]const u8, map.len());
+    const residue_number = try allocator.dupe(i32, map.residue_number);
+    const residue_delta_sasa = try allocator.dupe(f64, map.residue_sasa);
+
+    for (0..map.len()) |i| {
+        residue_chain[i] = try allocator.dupe(u8, map.residue_chain[i].slice());
+        residue_name[i] = try allocator.dupe(u8, map.residue_name[i].slice());
+        residue_insertion_code[i] = try allocator.dupe(u8, map.residue_insertion_code[i].slice());
+    }
+
+    return .{
+        .residue_chain = residue_chain,
+        .residue_name = residue_name,
+        .residue_number = residue_number,
+        .residue_insertion_code = residue_insertion_code,
+        .residue_delta_sasa = residue_delta_sasa,
+    };
 }
 
 /// Run batch processing sequentially (single-threaded path, used when n_threads <= 1)
@@ -2988,6 +3055,8 @@ fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     };
     defer workflow.deinit();
 
+    if (workflow.analysis != null) return runWorkflowBsaAnalysis(allocator, io, args, workflow);
+
     if (workflow.jobs.len == 0) return runWorkflowFileFirst(allocator, io, args, null);
     const input_dir = args.input_path orelse workflow.input.dir orelse return runWorkflowFileFirst(allocator, io, args, null);
     const output_dir = args.output_path orelse workflow.output.dir;
@@ -3039,6 +3108,247 @@ fn workflowRequiresJobFirstForAuthChain(args: BatchArgs, workflow: workflow_mani
         if (job_use_auth_chain != shared_config.use_auth_chain) return true;
     }
     return false;
+}
+
+fn runWorkflowBsaAnalysis(
+    allocator: Allocator,
+    io: std.Io,
+    args: BatchArgs,
+    workflow: workflow_manifest.Workflow,
+) !void {
+    const analysis = workflow.analysis orelse return error.InvalidArgument;
+    const partner_a = analysis.partner_a orelse return error.InvalidArgument;
+    const partner_b = analysis.partner_b orelse return error.InvalidArgument;
+    const level = analysisLevel(analysis);
+    const name = analysisName(analysis);
+
+    if (workflow.output.format) |format| {
+        if (!std.mem.eql(u8, format, "jsonl")) {
+            std.debug.print("Error: BSA analysis workflow output format must be \"jsonl\"\n", .{});
+            return error.InvalidArgument;
+        }
+    }
+
+    const input_dir = args.input_path orelse workflow.input.dir orelse {
+        std.debug.print("Error: Missing input directory (provide positional input_dir or [input].dir in workflow)\n", .{});
+        return error.MissingArgument;
+    };
+    const output_dir = args.output_path orelse workflow.output.dir orelse {
+        std.debug.print("Error: BSA analysis workflow requires an output directory\n", .{});
+        return error.InvalidArgument;
+    };
+
+    try std.Io.Dir.cwd().createDirPath(io, output_dir);
+    const jsonl_output_path = try workflowAnalysisJsonlOutputPath(allocator, output_dir, name);
+    defer allocator.free(jsonl_output_path);
+    try truncateJsonlOutput(io, jsonl_output_path);
+    const jsonl_file = try std.Io.Dir.cwd().openFile(io, jsonl_output_path, .{ .mode = .write_only });
+    defer jsonl_file.close(io);
+
+    const load_quiet = if (args.quiet_explicit) args.quiet else (workflow.calculation.quiet orelse args.quiet);
+
+    var config = BatchConfig{};
+    try applyWorkflowToBatchConfig(&config, args, workflow.calculation, workflow.output, workflow.classifier);
+    applyCliOverrides(&config, args);
+    try validateBitmaskCorrectionConfig(config);
+    config.include_hetatm = config.include_hetatm or (config.classifier_type == .ccd);
+    config.store_atom_areas = true;
+    config.residue_map = false;
+    config.output_format = .jsonl;
+    config.chain_filter = null;
+    const effective_classifier_type = config.classifier_type;
+
+    const ccd_path = resolveWorkflowCcdPath(args, workflow.classifier, effective_classifier_type);
+    var ext_ccd: ?ccd_parser.ComponentDict = null;
+    if (ccd_path) |path| {
+        ext_ccd = try loadExternalCcd(allocator, io, path, load_quiet);
+    }
+    defer if (ext_ccd) |*d| d.deinit();
+
+    const workflow_sdf_paths: []const []const u8 = workflow.classifier.sdf orelse &.{};
+    const sdf_paths = resolveWorkflowSdfPaths(args, workflow_sdf_paths, effective_classifier_type);
+    var sdf_ccd: ?ccd_parser.ComponentDict = null;
+    if (sdf_paths.len > 0) {
+        sdf_ccd = loadSdfComponents(allocator, io, sdf_paths, load_quiet) catch |err| {
+            std.debug.print("Error loading SDF components: {s}\n", .{@errorName(err)});
+            return err;
+        };
+    }
+    defer if (sdf_ccd) |*d| d.deinit();
+
+    var custom_classifier: ?classifier.Classifier = null;
+    const custom_classifier_path: ?[]const u8 = if (!args.classifier_explicit and workflow.classifier.type != null and std.mem.eql(u8, workflow.classifier.type.?, "custom"))
+        workflow.classifier.config
+    else
+        null;
+    if (custom_classifier_path) |path| {
+        custom_classifier = try loadCustomClassifier(allocator, io, path);
+    }
+    defer if (custom_classifier) |*c| c.deinit();
+
+    config.external_ccd = if (ext_ccd != null) &ext_ccd.? else null;
+    config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
+    if (custom_classifier) |*c| config.custom_classifier = c;
+
+    if ((config.classifier_type == .ccd or config.classifier_type == .protor) and config.include_hydrogens and !config.quiet) {
+        std.debug.print("Warning: --include-hydrogens with CCD classifier may give inaccurate results\n", .{});
+        std.debug.print("         CCD uses united-atom radii that already account for implicit hydrogens\n", .{});
+    }
+
+    const files = try scanDirectory(allocator, io, input_dir);
+    defer freeScannedFiles(allocator, files);
+
+    var luts = try BatchLuts.init(allocator, config);
+    defer luts.deinit();
+
+    const complex_chains = try appendChainGroups(allocator, partner_a, partner_b);
+    defer allocator.free(complex_chains);
+
+    var successful: usize = 0;
+    var failed: usize = 0;
+    var total_sasa_time_ns: u64 = 0;
+
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    for (files) |filename| {
+        const input_path = try std.fs.path.join(arena.allocator(), &.{ input_dir, filename });
+
+        var source_config = config;
+        source_config.chain_filter = null;
+        var source_input = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
+            failed += 1;
+            std.debug.print("Error running BSA analysis '{s}' on '{s}': read/parse failed: {s}\n", .{ name, filename, @errorName(err) });
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        workflowClassifySourceInput(&source_input, input_path, source_config) catch |err| {
+            failed += 1;
+            std.debug.print("Error running BSA analysis '{s}' on '{s}': classifier failed: {s}\n", .{ name, filename, @errorName(err) });
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        const partner_a_input = copySelectedAtomInput(arena.allocator(), source_input, partner_a) catch |err| {
+            failed += 1;
+            std.debug.print("Error running BSA analysis '{s}' on '{s}': partner A selection failed: {s}\n", .{ name, filename, @errorName(err) });
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+        const partner_b_input = copySelectedAtomInput(arena.allocator(), source_input, partner_b) catch |err| {
+            failed += 1;
+            std.debug.print("Error running BSA analysis '{s}' on '{s}': partner B selection failed: {s}\n", .{ name, filename, @errorName(err) });
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+        const complex_input = copySelectedAtomInput(arena.allocator(), source_input, complex_chains) catch |err| {
+            failed += 1;
+            std.debug.print("Error running BSA analysis '{s}' on '{s}': complex selection failed: {s}\n", .{ name, filename, @errorName(err) });
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        const n_threads = effectiveWorkflowSasaThreads(config);
+        const partner_a_result = switch (config.precision) {
+            .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, arena.allocator(), partner_a_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+            .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, arena.allocator(), partner_a_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+        };
+        const partner_b_result = switch (config.precision) {
+            .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, arena.allocator(), partner_b_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+            .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, arena.allocator(), partner_b_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+        };
+        const complex_result = switch (config.precision) {
+            .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, arena.allocator(), complex_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+            .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, arena.allocator(), complex_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+        };
+
+        if (partner_a_result.status != .ok or partner_b_result.status != .ok or complex_result.status != .ok) {
+            failed += 1;
+            std.debug.print("Error running BSA analysis '{s}' on '{s}': SASA calculation failed\n", .{ name, filename });
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        }
+
+        const partner_a_areas = partner_a_result.atom_areas orelse {
+            failed += 1;
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+        const partner_b_areas = partner_b_result.atom_areas orelse {
+            failed += 1;
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+        const complex_areas = complex_result.atom_areas orelse {
+            failed += 1;
+            source_input.deinit();
+            _ = arena.reset(.retain_capacity);
+            continue;
+        };
+
+        const delta_total = partner_a_result.total_sasa + partner_b_result.total_sasa - complex_result.total_sasa;
+        const bsa = delta_total / 2.0;
+
+        var residue_arrays = BsaResidueDeltaArrays{};
+        if (std.mem.eql(u8, level, "residue")) {
+            const atom_delta_sasa = try arena.allocator().alloc(f64, complex_input.atomCount());
+            var a_index: usize = 0;
+            var b_index: usize = 0;
+            for (0..complex_input.atomCount()) |i| {
+                if (atomSelectedByChains(complex_input, i, partner_a)) {
+                    atom_delta_sasa[i] = partner_a_areas[a_index] - complex_areas[i];
+                    a_index += 1;
+                } else {
+                    atom_delta_sasa[i] = partner_b_areas[b_index] - complex_areas[i];
+                    b_index += 1;
+                }
+            }
+            residue_arrays = buildBsaResidueDeltaArrays(arena.allocator(), complex_input, atom_delta_sasa) catch |err| {
+                failed += 1;
+                std.debug.print("Error running BSA analysis '{s}' on '{s}': residue delta map failed: {s}\n", .{ name, filename, @errorName(err) });
+                source_input.deinit();
+                _ = arena.reset(.retain_capacity);
+                continue;
+            };
+        }
+
+        try appendBsaAnalysisJsonlToFile(io, jsonl_file, arena.allocator(), .{
+            .filename = filename,
+            .name = name,
+            .partner_a = partner_a,
+            .partner_b = partner_b,
+            .sasa_partner_a = partner_a_result.total_sasa,
+            .sasa_partner_b = partner_b_result.total_sasa,
+            .sasa_complex = complex_result.total_sasa,
+            .delta_sasa_total = delta_total,
+            .bsa = bsa,
+            .delta_sasa_level = level,
+            .residue_chain = residue_arrays.residue_chain,
+            .residue_name = residue_arrays.residue_name,
+            .residue_number = residue_arrays.residue_number,
+            .residue_insertion_code = residue_arrays.residue_insertion_code,
+            .residue_delta_sasa = residue_arrays.residue_delta_sasa,
+        });
+
+        successful += 1;
+        total_sasa_time_ns += partner_a_result.sasa_time_ns + partner_b_result.sasa_time_ns + complex_result.sasa_time_ns;
+        source_input.deinit();
+        _ = arena.reset(.retain_capacity);
+    }
+
+    if (config.show_timing) {
+        const total_sasa_ms = @as(f64, @floatFromInt(total_sasa_time_ns)) / 1_000_000.0;
+        std.debug.print("BSA analysis SASA time: {d:.2} ms\n", .{total_sasa_ms});
+    }
+    std.debug.print("Workflow complete: {d} successful, {d} failed\n", .{ successful, failed });
 }
 
 fn effectiveWorkflowSasaThreads(config: BatchConfig) usize {
@@ -4393,6 +4703,72 @@ test "workflow file-first keeps existing output layout" {
     defer allocator.free(chain_a_json_content_2);
     try std.testing.expect(std.mem.indexOf(u8, chain_a_json_content, "\"total_area\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, chain_a_json_content_2, "\"total_area\"") != null);
+}
+
+test "workflow BSA analysis writes analysis JSONL" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const output_dir = try std.fs.path.join(allocator, &.{ root, "output" });
+    defer allocator.free(output_dir);
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+
+    const pdb_path = try std.fs.path.join(allocator, &.{ input_dir, "tiny_ab.pdb" });
+    defer allocator.free(pdb_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = pdb_path, .data = "ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "ATOM      2  CA  GLY A   1       1.500   0.000   0.000  1.00 20.00           C  \n" ++
+        "ATOM      3  N   ALA B   2       3.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "ATOM      4  CA  ALA B   2       4.500   0.000   0.000  1.00 20.00           C  \n" ++
+        "END\n" });
+
+    const workflow_path = try std.fs.path.join(allocator, &.{ root, "bsa.toml" });
+    defer allocator.free(workflow_path);
+    const workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "jsonl"
+        \\
+        \\[calculation]
+        \\n_points = 16
+        \\quiet = true
+        \\
+        \\[classifier]
+        \\type = "naccess"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\name = "interface_ab"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\level = "residue"
+    , .{ input_dir, output_dir });
+    defer allocator.free(workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = workflow_path });
+
+    const jsonl_path = try std.fs.path.join(allocator, &.{ output_dir, "interface_ab.jsonl" });
+    defer allocator.free(jsonl_path);
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, jsonl_path, allocator, .limited(8192));
+    defer allocator.free(content);
+
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"analysis\":\"bsa\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"delta_sasa_total\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"bsa\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"residue_delta_sasa\"") != null);
 }
 
 test "workflow mmCIF chain filters preserve long chain IDs" {

--- a/src/json_writer.zig
+++ b/src/json_writer.zig
@@ -637,6 +637,92 @@ pub fn fileResultWithResidueMapToJsonlLine(
     return std.json.Stringify.valueAlloc(allocator, entry, .{});
 }
 
+pub const BsaAnalysisJsonl = struct {
+    filename: []const u8,
+    name: []const u8,
+    partner_a: []const []const u8,
+    partner_b: []const []const u8,
+    sasa_partner_a: f64,
+    sasa_partner_b: f64,
+    sasa_complex: f64,
+    delta_sasa_total: f64,
+    bsa: f64,
+    delta_sasa_level: []const u8,
+    residue_chain: []const []const u8 = &.{},
+    residue_name: []const []const u8 = &.{},
+    residue_number: []const i32 = &.{},
+    residue_insertion_code: []const []const u8 = &.{},
+    residue_delta_sasa: []const f64 = &.{},
+};
+
+pub fn bsaAnalysisToJsonlLine(allocator: Allocator, row: BsaAnalysisJsonl) ![]u8 {
+    if (std.mem.eql(u8, row.delta_sasa_level, "residue")) {
+        const Entry = struct {
+            filename: []const u8,
+            analysis: []const u8,
+            name: []const u8,
+            partner_a: []const []const u8,
+            partner_b: []const []const u8,
+            sasa_partner_a: f64,
+            sasa_partner_b: f64,
+            sasa_complex: f64,
+            delta_sasa_total: f64,
+            bsa: f64,
+            delta_sasa_level: []const u8,
+            residue_chain: []const []const u8,
+            residue_name: []const []const u8,
+            residue_number: []const i32,
+            residue_insertion_code: []const []const u8,
+            residue_delta_sasa: []const f64,
+        };
+        return std.json.Stringify.valueAlloc(allocator, Entry{
+            .filename = row.filename,
+            .analysis = "bsa",
+            .name = row.name,
+            .partner_a = row.partner_a,
+            .partner_b = row.partner_b,
+            .sasa_partner_a = row.sasa_partner_a,
+            .sasa_partner_b = row.sasa_partner_b,
+            .sasa_complex = row.sasa_complex,
+            .delta_sasa_total = row.delta_sasa_total,
+            .bsa = row.bsa,
+            .delta_sasa_level = row.delta_sasa_level,
+            .residue_chain = row.residue_chain,
+            .residue_name = row.residue_name,
+            .residue_number = row.residue_number,
+            .residue_insertion_code = row.residue_insertion_code,
+            .residue_delta_sasa = row.residue_delta_sasa,
+        }, .{});
+    }
+
+    const Entry = struct {
+        filename: []const u8,
+        analysis: []const u8,
+        name: []const u8,
+        partner_a: []const []const u8,
+        partner_b: []const []const u8,
+        sasa_partner_a: f64,
+        sasa_partner_b: f64,
+        sasa_complex: f64,
+        delta_sasa_total: f64,
+        bsa: f64,
+        delta_sasa_level: []const u8,
+    };
+    return std.json.Stringify.valueAlloc(allocator, Entry{
+        .filename = row.filename,
+        .analysis = "bsa",
+        .name = row.name,
+        .partner_a = row.partner_a,
+        .partner_b = row.partner_b,
+        .sasa_partner_a = row.sasa_partner_a,
+        .sasa_partner_b = row.sasa_partner_b,
+        .sasa_complex = row.sasa_complex,
+        .delta_sasa_total = row.delta_sasa_total,
+        .bsa = row.bsa,
+        .delta_sasa_level = row.delta_sasa_level,
+    }, .{});
+}
+
 // Tests
 test "buildResidueMap groups consecutive atoms" {
     const allocator = std.testing.allocator;
@@ -790,6 +876,41 @@ test "fileResultWithResidueMapToJsonlLine serializes columnar residue arrays" {
         "{\"filename\":\"example.cif\",\"total_area\":13.75,\"atom_areas\":[10,2.5,1.25],\"residue_chain\":[\"A\",\"B\"],\"residue_name\":[\"MET\",\"ALA\"],\"residue_number\":[1,7],\"residue_insertion_code\":[\"\",\"\"],\"residue_atom_start\":[0,2],\"residue_atom_count\":[2,1],\"residue_sasa\":[12.5,1.25]}",
         line,
     );
+}
+
+test "BSA analysis JSONL includes total and residue delta fields" {
+    const allocator = std.testing.allocator;
+    const partner_a = [_][]const u8{"A"};
+    const partner_b = [_][]const u8{"B"};
+    const residue_chain = [_][]const u8{ "A", "B" };
+    const residue_name = [_][]const u8{ "GLY", "ALA" };
+    const residue_number = [_]i32{ 1, 2 };
+    const residue_insertion_code = [_][]const u8{ "", "" };
+    const residue_delta_sasa = [_]f64{ 3.0, 5.0 };
+
+    const line = try bsaAnalysisToJsonlLine(allocator, .{
+        .filename = "tiny.pdb",
+        .name = "interface_ab",
+        .partner_a = partner_a[0..],
+        .partner_b = partner_b[0..],
+        .sasa_partner_a = 10.0,
+        .sasa_partner_b = 20.0,
+        .sasa_complex = 14.0,
+        .delta_sasa_total = 16.0,
+        .bsa = 8.0,
+        .delta_sasa_level = "residue",
+        .residue_chain = residue_chain[0..],
+        .residue_name = residue_name[0..],
+        .residue_number = residue_number[0..],
+        .residue_insertion_code = residue_insertion_code[0..],
+        .residue_delta_sasa = residue_delta_sasa[0..],
+    });
+    defer allocator.free(line);
+
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"analysis\":\"bsa\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"delta_sasa_total\":16") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"bsa\":8") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_delta_sasa\":[3,5]") != null);
 }
 
 test "sasaResultToJson basic" {

--- a/src/workflow_manifest.zig
+++ b/src/workflow_manifest.zig
@@ -10,6 +10,7 @@ pub const WorkflowError = error{
     UnsafeJobName,
     InvalidFieldType,
     InvalidClassifierConfig,
+    InvalidAnalysisConfig,
     UnknownField,
     NoJobs,
 };
@@ -57,6 +58,14 @@ pub const ClassifierConfig = struct {
     sdf: ?[]const []const u8 = null,
 };
 
+pub const Analysis = struct {
+    type: ?[]const u8 = null,
+    name: ?[]const u8 = null,
+    partner_a: ?[]const []const u8 = null,
+    partner_b: ?[]const []const u8 = null,
+    level: ?[]const u8 = null,
+};
+
 pub const Job = struct {
     name: []const u8,
     chains: ?[]const []const u8 = null,
@@ -70,11 +79,16 @@ pub const Workflow = struct {
     output: Output = .{},
     calculation: Calculation = .{},
     classifier: ClassifierConfig = .{},
+    analysis: ?Analysis = null,
     jobs: []Job = &.{},
     is_legacy_batch_workflow: bool = false,
 
     pub fn deinit(self: *Workflow) void {
         if (self.classifier.sdf) |items| self.allocator.free(items);
+        if (self.analysis) |analysis| {
+            if (analysis.partner_a) |items| self.allocator.free(items);
+            if (analysis.partner_b) |items| self.allocator.free(items);
+        }
         for (self.jobs) |job| {
             if (job.chains) |chains| self.allocator.free(chains);
         }
@@ -130,6 +144,7 @@ fn parseOwned(allocator: Allocator, owned_content: []const u8) Error!Workflow {
         if (doc.getTable("output")) |table| workflow.output = try parseOutput(table);
         if (doc.getTable("calculation")) |table| workflow.calculation = try parseCalculation(table);
         if (doc.getTable("classifier")) |table| workflow.classifier = try parseClassifier(allocator, table);
+        if (doc.getTable("analysis")) |table| workflow.analysis = try parseAnalysis(allocator, table);
     }
 
     workflow.jobs = try parseJobs(allocator, doc.array_tables);
@@ -258,6 +273,23 @@ fn parseClassifier(allocator: Allocator, table: toml_parser.Table) Error!Classif
     };
 }
 
+fn parseAnalysis(allocator: Allocator, table: toml_parser.Table) Error!Analysis {
+    try rejectUnknownFields(table.entries, &.{ "type", "name", "partner_a", "partner_b", "level" });
+    const analysis = Analysis{
+        .type = try optionalString(table.entries, "type"),
+        .name = try optionalString(table.entries, "name"),
+        .partner_a = try optionalStringArray(allocator, table.entries, "partner_a"),
+        .partner_b = try optionalStringArray(allocator, table.entries, "partner_b"),
+        .level = try optionalString(table.entries, "level"),
+    };
+    errdefer {
+        if (analysis.partner_a) |items| allocator.free(items);
+        if (analysis.partner_b) |items| allocator.free(items);
+    }
+    try validateAnalysis(analysis);
+    return analysis;
+}
+
 fn validateClassifier(config: ClassifierConfig) WorkflowError!void {
     const classifier_type = config.type orelse return;
     if (std.mem.eql(u8, classifier_type, "custom")) {
@@ -273,6 +305,28 @@ fn validateClassifier(config: ClassifierConfig) WorkflowError!void {
 
 fn classifierAllowsCcdResources(classifier_type: []const u8) bool {
     return std.mem.eql(u8, classifier_type, "ccd") or std.mem.eql(u8, classifier_type, "protor");
+}
+
+fn validateAnalysis(analysis: Analysis) WorkflowError!void {
+    const analysis_type = analysis.type orelse return error.InvalidAnalysisConfig;
+    if (!std.mem.eql(u8, analysis_type, "bsa")) return error.InvalidAnalysisConfig;
+    if (analysis.name) |name| {
+        if (name.len == 0 or !isSafeJobName(name)) return error.InvalidAnalysisConfig;
+    }
+    const partner_a = analysis.partner_a orelse return error.InvalidAnalysisConfig;
+    const partner_b = analysis.partner_b orelse return error.InvalidAnalysisConfig;
+    if (partner_a.len == 0 or partner_b.len == 0) return error.InvalidAnalysisConfig;
+    for (partner_a) |chain| {
+        if (chain.len == 0) return error.InvalidAnalysisConfig;
+    }
+    for (partner_b) |chain| {
+        if (chain.len == 0) return error.InvalidAnalysisConfig;
+    }
+    if (analysis.level) |level| {
+        if (!std.mem.eql(u8, level, "total") and !std.mem.eql(u8, level, "residue")) {
+            return error.InvalidAnalysisConfig;
+        }
+    }
 }
 
 fn parseJobs(allocator: Allocator, array_tables: []const toml_parser.Document.ArrayTable) Error![]Job {
@@ -365,7 +419,8 @@ fn validateKnownDocumentShape(doc: toml_parser.Document, is_legacy: bool) Workfl
         if (std.mem.eql(u8, table.name, "input") or
             std.mem.eql(u8, table.name, "output") or
             std.mem.eql(u8, table.name, "calculation") or
-            std.mem.eql(u8, table.name, "classifier"))
+            std.mem.eql(u8, table.name, "classifier") or
+            std.mem.eql(u8, table.name, "analysis"))
         {
             continue;
         }
@@ -592,6 +647,63 @@ test "parse sectioned batch workflow with jobs" {
     try std.testing.expectEqualStrings("complex_AB", workflow.jobs[1].name);
     try std.testing.expectEqualStrings("B", workflow.jobs[1].chains.?[1]);
     try std.testing.expectEqual(true, workflow.jobs[1].auth_chain.?);
+}
+
+test "parse BSA analysis workflow" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "structures"
+        \\
+        \\[output]
+        \\dir = "results"
+        \\format = "jsonl"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\name = "interface_ab"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\level = "residue"
+    ;
+    var workflow = try parse(std.testing.allocator, input);
+    defer workflow.deinit();
+
+    try std.testing.expectEqualStrings("bsa", workflow.analysis.?.type.?);
+    try std.testing.expectEqualStrings("interface_ab", workflow.analysis.?.name.?);
+    try std.testing.expectEqual(@as(usize, 1), workflow.analysis.?.partner_a.?.len);
+    try std.testing.expectEqualStrings("A", workflow.analysis.?.partner_a.?[0]);
+    try std.testing.expectEqual(@as(usize, 1), workflow.analysis.?.partner_b.?.len);
+    try std.testing.expectEqualStrings("B", workflow.analysis.?.partner_b.?[0]);
+    try std.testing.expectEqualStrings("residue", workflow.analysis.?.level.?);
+}
+
+test "reject BSA analysis without both partners" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\partner_a = ["A"]
+    ;
+    try std.testing.expectError(error.InvalidAnalysisConfig, parse(std.testing.allocator, input));
+}
+
+test "reject BSA analysis invalid level" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\level = "chain"
+    ;
+    try std.testing.expectError(error.InvalidAnalysisConfig, parse(std.testing.allocator, input));
 }
 
 test "parse legacy flat batch manifest" {

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -100,6 +100,54 @@ zsasa batch --workflow bsa.toml
 
 For ordinary PDB, JSON, and unfiltered mmCIF/BinaryCIF workflow batch runs with compatible chain-ID settings, zsasa reuses each parsed input structure across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; eligible runs parse each input structure once and then compute each requested chain selection independently. Some inputs or settings, such as SDF files, per-job `auth_chain` changes, or mmCIF/BinaryCIF workflows with chain filters, use the compatibility job-first path instead so full chain-ID selection matches parser behavior.
 
+## BSA / ΔSASA Analysis
+
+Batch workflows can also write an analysis JSONL file for a two-partner interface:
+
+```toml
+version = 1
+kind = "workflow"
+
+[input]
+dir = "structures"
+
+[output]
+dir = "results"
+format = "jsonl"
+
+[calculation]
+algorithm = "sr"
+n_points = 100
+threads = 8
+
+[classifier]
+type = "ccd"
+
+[analysis]
+type = "bsa"
+name = "interface_ab"
+partner_a = ["A"]
+partner_b = ["B"]
+level = "residue"
+```
+
+Run it with:
+
+```bash
+zsasa batch --workflow bsa.toml
+```
+
+This writes `results/interface_ab.jsonl`, with one row per input structure. The initial implementation computes partner A, partner B, and the AB complex internally, then reports:
+
+```text
+delta_sasa_total = sasa_partner_a + sasa_partner_b - sasa_complex
+bsa = delta_sasa_total / 2
+```
+
+`ΔSASA` and `BSA` are deliberately separate fields. `delta_sasa_total` and `residue_delta_sasa` are not halved; `bsa` is the two-partner buried surface area after the `1/2` factor.
+
+BSA analysis JSONL uses analysis-specific fields such as `sasa_partner_a`, `sasa_partner_b`, `sasa_complex`, `delta_sasa_total`, `bsa`, and `residue_delta_sasa`. It does not use the normal SASA JSONL `total_area` and `atom_areas` fields, because those names are ambiguous for interface analysis.
+
 ## Override Precedence
 
 When the same setting appears in multiple places, zsasa applies this order:


### PR DESCRIPTION
## Summary
- Add `[analysis] type = "bsa"` workflow parsing for two-partner BSA/ΔSASA analyses.
- Add analysis-specific JSONL output with `delta_sasa_total`, `bsa`, and optional residue-level `residue_delta_sasa` fields.
- Document the BSA workflow and clarify that ΔSASA is unhalved while BSA applies the 1/2 factor.

## Test Plan
- `zig fmt --check src/`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa --help`
- `./zig-out/bin/zsasa --version`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json`
- BSA workflow CLI smoke test
- `cd website && npm ci && npm run build`
