### PR TITLE
fix: harden review backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,11 +8,37 @@ body:
         Thanks for taking the time to report this bug!
 
   - type: input
+    id: version
+    attributes:
+      label: zsasa Version
+      description: Output of `zsasa --version` or `python -c "import zsasa; print(zsasa.get_version())"`
+      placeholder: "0.6.0"
+    validations:
+      required: true
+
+  - type: input
     id: zig-version
     attributes:
-      label: Zig Version
-      description: Output of `zig version`
-      placeholder: "0.16.0"
+      label: Zig Version (source builds only)
+      description: Output of `zig version`, or "not installed" for wheels/binaries
+      placeholder: "0.16.0 or not installed"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation Method
+      options:
+        - PyPI wheel / pip / uv
+        - install.sh binary download
+        - install.sh source build
+        - Zig source build
+        - Homebrew
+        - Scoop
+        - conda-forge
+        - Docker
+        - Other
     validations:
       required: true
 
@@ -25,6 +51,7 @@ body:
         - Linux (aarch64)
         - macOS (Apple Silicon)
         - macOS (Intel)
+        - Windows
         - Windows (WSL)
         - Other
     validations:
@@ -40,8 +67,11 @@ body:
         - Python bindings
         - Shrake-Rupley algorithm
         - Lee-Richards algorithm
-        - File parsing (PDB/mmCIF/JSON)
+        - File parsing (PDB/mmCIF/BinaryCIF/SDF/MOL/JSON)
+        - Trajectory parsing (XTC/TRR/DCD/AMBER NetCDF)
         - Batch processing
+        - Packaging / installation
+        - Documentation
         - Other
     validations:
       required: true
@@ -60,7 +90,7 @@ body:
       label: Steps to Reproduce
       description: Minimal steps to reproduce the behavior
       placeholder: |
-        1. Run `zsasa input.pdb -o output.json`
+        1. Run `zsasa calc input.cif output.json`
         2. See error...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,7 +16,9 @@ body:
         - Performance
         - New algorithm or method
         - Input/output formats
+        - Trajectory formats
         - Python bindings
+        - Packaging / distribution
         - CLI interface
         - Analysis features
         - Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,51 @@ jobs:
       - name: Test validate mode
         run: ./zig-out/bin/zsasa calc --validate examples/1ubq.pdb
 
+  source_install:
+    runs-on: ubuntu-latest
+    name: Source install smoke
+    needs: [fmt]
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build sdist
+        working-directory: python
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --sdist
+
+      - name: Install from sdist and smoke test
+        shell: bash
+        run: |
+          python -m venv /tmp/zsasa-sdist-smoke
+          . /tmp/zsasa-sdist-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install python/dist/zsasa-*.tar.gz
+          zsasa --version
+          python - <<'PY_SMOKE'
+          import numpy as np
+          from zsasa import calculate_sasa, get_version
+
+          coords = np.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
+          radii = np.array([1.5, 1.5])
+          result = calculate_sasa(coords, radii)
+          assert get_version()
+          assert result.total_area > 0
+          PY_SMOKE
+
   python:
     strategy:
       fail-fast: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,26 @@
-name: Deploy Docs
+name: Docs
 
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - "website/**"
+      - "docs/**"
+      - "README.md"
+      - "python/README.md"
+      - "python/examples/README.md"
+      - "examples/README.md"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -59,6 +67,7 @@ jobs:
         run: npm run build
 
       - name: Copy benchmark assets into site
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p website/build/benchmarks/results
           for dir in plots md validation validation_md; do
@@ -68,22 +77,29 @@ jobs:
           done
 
       - name: Copy Zig autodoc into site
+        if: github.event_name != 'pull_request'
         run: cp -r zig-out/docs website/build/zig-autodoc
 
       - name: Copy Python autodoc into site
+        if: github.event_name != 'pull_request'
         run: cp -r /tmp/python-autodoc website/build/python-autodoc
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: website/build
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "Release tag to build/publish (must match vX.Y.Z)"
+        required: true
+        type: string
       target:
         description: "Publish target"
         required: true
@@ -31,11 +35,41 @@ permissions:
   contents: write
   packages: write
 
-# ---------- Phase 1: Build everything (preflight) ----------
-
 jobs:
+  prepare:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Resolve and validate release tag
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.release_tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+
+          if ! printf '%s' "${TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "release_tag must be exactly vX.Y.Z, got '${TAG}'" >&2
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using release tag ${TAG} (version ${VERSION})"
+
+  # ---------- Phase 1: Build everything (preflight) ----------
+
   build_wheels:
     name: Wheels (${{ matrix.os }})
+    needs: [prepare]
     if: >-
       github.event_name == 'push'
       || inputs.jobs == 'all'
@@ -49,6 +83,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -84,6 +120,7 @@ jobs:
 
   build_sdist:
     name: Source dist
+    needs: [prepare]
     if: >-
       github.event_name == 'push'
       || inputs.jobs == 'all'
@@ -93,11 +130,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install build
         run: pip install build
@@ -105,6 +149,25 @@ jobs:
       - name: Build sdist
         working-directory: python
         run: python -m build --sdist
+
+      - name: Smoke test sdist source install
+        shell: bash
+        run: |
+          python -m venv /tmp/zsasa-sdist-smoke
+          . /tmp/zsasa-sdist-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install python/dist/zsasa-*.tar.gz
+          zsasa --version
+          python - <<'PY'
+          import numpy as np
+          from zsasa import calculate_sasa, get_version
+
+          coords = np.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
+          radii = np.array([1.5, 1.5])
+          result = calculate_sasa(coords, radii)
+          assert get_version()
+          assert result.total_area > 0
+          PY
 
       - name: Upload sdist
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -114,11 +177,11 @@ jobs:
 
   build_cli:
     name: CLI (${{ matrix.target }})
+    needs: [prepare]
     if: >-
       github.event_name == 'push'
       || inputs.jobs == 'all'
       || inputs.jobs == 'github-release'
-      || inputs.jobs == 'package-managers'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -143,6 +206,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
@@ -164,8 +229,8 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           BINARY: ${{ matrix.binary }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           ASSET_NAME="zsasa-${VERSION}-${TARGET}"
           mkdir -p dist
           if [ "${TARGET}" = "windows-x86_64" ]; then
@@ -183,6 +248,7 @@ jobs:
 
   build_docker:
     name: Docker build (preflight)
+    needs: [prepare]
     if: >-
       github.event_name == 'push'
       || inputs.jobs == 'all'
@@ -192,6 +258,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Build Docker image (no push)
         uses: docker/build-push-action@v6
@@ -200,11 +268,11 @@ jobs:
           push: false
           tags: ghcr.io/n283t/zsasa:preflight
 
-  # ---------- Phase 2: Release (after all builds pass) ----------
+  # ---------- Phase 2: Release (after build gates pass) ----------
 
   publish:
     name: Publish to PyPI
-    needs: [build_wheels, build_sdist]
+    needs: [prepare, build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
@@ -248,7 +316,7 @@ jobs:
 
   github_release:
     name: GitHub Release
-    needs: [build_cli, build_docker]
+    needs: [prepare, build_cli]
     runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
@@ -256,16 +324,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Extract release notes from CHANGELOG
         id: notes
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          # Extract the section for this version from CHANGELOG.md
-          # Matches from "## [X.Y.Z]" to the next "## [" or end of file
           NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
-          # Write to file to preserve multiline
           echo "$NOTES" > /tmp/release_notes.md
+          if [ ! -s /tmp/release_notes.md ]; then
+            echo "No CHANGELOG.md section found for ${VERSION}" >&2
+            exit 1
+          fi
 
       - name: Download CLI artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -278,34 +350,45 @@ jobs:
         run: |
           cd dist
           sha256sum zsasa-*-linux-* zsasa-*-macos-* zsasa-*-windows-* > SHA256SUMS 2>/dev/null || true
-          if [ -f SHA256SUMS ] && [ -s SHA256SUMS ]; then
-            echo "Generated checksums:"
-            cat SHA256SUMS
+          if [ ! -s SHA256SUMS ]; then
+            echo "No release assets found for checksum generation" >&2
+            exit 1
           fi
+          cat SHA256SUMS
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
+          gh release create "${RELEASE_TAG}" \
+            --title "${RELEASE_TAG}" \
             --notes-file /tmp/release_notes.md \
             dist/*
 
   update_homebrew:
     name: Update Homebrew tap
-    needs: [github_release]
+    needs: [prepare, github_release]
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-      || (github.event_name == 'workflow_dispatch' && (inputs.jobs == 'all' || inputs.jobs == 'package-managers'))
+      always()
+      && needs.prepare.result == 'success'
+      && (
+        (
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+          || (github.event_name == 'workflow_dispatch' && inputs.jobs == 'all')
+        )
+        && needs.github_release.result == 'success'
+        || (github.event_name == 'workflow_dispatch' && inputs.jobs == 'package-managers')
+      )
 
     steps:
       - name: Download checksums
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          gh release download "$GITHUB_REF_NAME" \
+          gh release download "${RELEASE_TAG}" \
             --repo N283T/zsasa \
             --pattern "SHA256SUMS" \
             --dir .
@@ -318,8 +401,9 @@ jobs:
           path: homebrew-zsasa
 
       - name: Update Formula
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           FORMULA="homebrew-zsasa/Formula/zsasa.rb"
 
           LINUX_X86=$(grep "linux-x86_64" SHA256SUMS | awk '{print $1}')
@@ -343,8 +427,9 @@ jobs:
 
       - name: Commit and push
         working-directory: homebrew-zsasa
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/zsasa.rb
@@ -354,18 +439,27 @@ jobs:
 
   update_scoop:
     name: Update Scoop bucket
-    needs: [github_release]
+    needs: [prepare, github_release]
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-      || (github.event_name == 'workflow_dispatch' && (inputs.jobs == 'all' || inputs.jobs == 'package-managers'))
+      always()
+      && needs.prepare.result == 'success'
+      && (
+        (
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+          || (github.event_name == 'workflow_dispatch' && inputs.jobs == 'all')
+        )
+        && needs.github_release.result == 'success'
+        || (github.event_name == 'workflow_dispatch' && inputs.jobs == 'package-managers')
+      )
 
     steps:
       - name: Download checksums
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          gh release download "$GITHUB_REF_NAME" \
+          gh release download "${RELEASE_TAG}" \
             --repo N283T/zsasa \
             --pattern "SHA256SUMS" \
             --dir .
@@ -378,8 +472,9 @@ jobs:
           path: scoop-zsasa
 
       - name: Update manifest
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           WIN_HASH=$(grep "windows-x86_64" SHA256SUMS | awk '{print $1}')
           MANIFEST="scoop-zsasa/bucket/zsasa.json"
 
@@ -398,8 +493,9 @@ jobs:
 
       - name: Commit and push
         working-directory: scoop-zsasa
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add bucket/zsasa.json
@@ -409,7 +505,7 @@ jobs:
 
   docker:
     name: Docker push
-    needs: [build_docker]
+    needs: [prepare, build_docker]
     runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
@@ -420,6 +516,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -430,7 +528,7 @@ jobs:
 
       - name: Extract version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${{ needs.prepare.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ abstract: "High-performance Solvent Accessible Surface Area (SASA) calculator in
 authors:
   - family-names: "Nagae"
     given-names: "Tsubasa"
-version: "0.1.0"
-date-released: "2026-02-22"
+version: "0.6.0"
+date-released: "2026-05-21"
 license: MIT
 repository-code: "https://github.com/N283T/zsasa"
 url: "https://github.com/N283T/zsasa"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ print(f"Total SASA: {result.total_area:.2f} Å²")
 ### CLI
 
 ```bash
-# One-line install (downloads pre-built binary)
+# One-line install for Linux/macOS (downloads a pre-built binary unless Zig 0.16.0 is available)
 curl -fsSL https://raw.githubusercontent.com/N283T/zsasa/main/install.sh | sh
 
 # Or with custom install directory

--- a/build.zig
+++ b/build.zig
@@ -75,9 +75,11 @@ pub fn build(b: *std.Build) void {
     // Test step
     const mod_tests = b.addTest(.{ .root_module = mod });
     const exe_tests = b.addTest(.{ .root_module = exe.root_module });
+    const lib_tests = b.addTest(.{ .root_module = lib.root_module });
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&b.addRunArtifact(mod_tests).step);
     test_step.dependOn(&b.addRunArtifact(exe_tests).step);
+    test_step.dependOn(&b.addRunArtifact(lib_tests).step);
 
     // Docs step (zig autodoc)
     const docs_lib = b.addLibrary(.{

--- a/docs/superpowers/plans/2026-06-28-review-hardening.md
+++ b/docs/superpowers/plans/2026-06-28-review-hardening.md
@@ -1,0 +1,68 @@
+# Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the prioritized whole-repository review backlog for zsasa: safety gates, parser correctness, Python reliability/streaming, documentation, CI, release, and packaging polish.
+
+**Architecture:** Keep changes small and localized. Add regression tests before behavior changes, prefer shared validation helpers at public boundaries, and avoid schema changes unless explicitly covered by tests/docs. Split work into independent slices so subagents can operate on disjoint files and the controller can integrate and verify.
+
+**Tech Stack:** Zig 0.16 (`zig build test`, `zig fmt`), Python 3.11+ with NumPy/CFFI/Pytest/Ruff, GitHub Actions, Docusaurus docs, shell release tooling.
+
+---
+
+### Task 1: Zig safety gates and build coverage
+
+**Files:** `build.zig`, `src/format_detect.zig`, `src/c_api.zig`, `src/shrake_rupley.zig`, `src/lee_richards.zig`, `src/types.zig` if needed.
+
+- [ ] Add a failing build/test coverage check proving `src/c_api.zig` tests are not run by `zig build test`, then include the library module test in `build.zig` so C ABI tests run.
+- [ ] Add tests for uppercase compressed suffixes such as `MODEL.PDB.GZ` and `MODEL.CIF.ZST`, then make format detection case-insensitive for base and compression suffixes.
+- [ ] Add C ABI/Python-facing regression tests for NaN/Inf coordinates, radii, and probe radius returning invalid-input errors rather than producing NaN output.
+- [ ] Implement shared finite/range validation at C ABI and algorithm public boundaries without changing valid calculations.
+- [ ] Run focused Zig tests for touched files.
+
+### Task 2: Parser correctness
+
+**Files:** `src/pdb_parser.zig`, `src/mmcif_parser.zig`, `src/bcif_parser.zig`, `src/calc.zig`, `src/json_writer.zig`, `src/analysis.zig`, relevant parser tests/fixtures.
+
+- [ ] Add regression tests documenting the chosen model default semantics across PDB/mmCIF/BCIF; default should be documented and consistent with CLI docs.
+- [ ] Add altLoc regression tests where a later residue/site only has conformer `B`; it must not be dropped because an earlier site chose `A`.
+- [ ] Implement per-site altLoc selection, preferring blank/`A`/highest occupancy when available and otherwise keeping the only available conformer.
+- [ ] Add tests for default CCD vs explicit `--classifier=ccd` HETATM behavior in `calc`, then align with batch behavior or document any intentional difference.
+- [ ] Add tests for long mmCIF/BCIF chain IDs that share the first four characters; grouping/output must use full chain IDs when present.
+- [ ] Run focused parser and CLI tests.
+
+### Task 3: Python reliability and trajectory memory
+
+**Files:** `python/zsasa/sasa.py`, `python/zsasa/classifier.py`, `python/zsasa/integrations/*.py`, `python/zsasa/mdanalysis.py`, `python/zsasa/xtc.py`, `python/zsasa/dcd.py`, `python/zsasa/_ffi.py`, `python/tests/*`.
+
+- [ ] Add tests that `calculate_sasa` and batch APIs reject NaN/Inf coords/radii/probe and out-of-range integer parameters before CFFI calls.
+- [ ] Add integration tests for unknown atom radii policy; fail with clear atom identifiers or fall back through element-derived radii where elements are available.
+- [ ] Add MDAnalysis selection tests with nonzero/discontiguous residue indices, then remap selected residues densely for aggregation.
+- [ ] Add chunked/streaming trajectory processing APIs for XTC/DCD/MDAnalysis paths so large trajectories can compute totals/residue aggregates without retaining all atom areas.
+- [ ] Add Windows editable library discovery for `zig-out/bin`.
+- [ ] Run focused pytest and Ruff checks.
+
+### Task 4: Distribution, CI, release, docs polish
+
+**Files:** `.github/workflows/*.yml`, `python/pyproject.toml`, `python/hatch_build.py`, `packaging/conda-forge/meta.yaml`, `CITATION.cff`, `README.md`, `website/docs/**`, `python/examples/README.md`, `examples/README.md`, `.github/ISSUE_TEMPLATE/*.yml`.
+
+- [ ] Add PR docs/site validation so website changes are built before merge.
+- [ ] Harden manual publish workflow by requiring an explicit `vX.Y.Z` version/tag input and using it for assets/releases/tags.
+- [ ] Fix publish job dependencies so each manual job choice is runnable and release gates are explicit.
+- [ ] Ensure PyPI sdist/source installs include required Zig source/build files or add a validated source-install path; add CI smoke coverage.
+- [ ] Fix conda recipe license/source gap.
+- [ ] Sync docs for SDF/MOL/TRR/AMBER NetCDF, installer behavior, Python CCD defaults, stale links, fixture counts, issue templates, and `CITATION.cff` version metadata.
+- [ ] Run `npm run build` for docs when docs/site changes are present.
+
+### Task 5: Integration verification and publishing
+
+**Files:** whole repository.
+
+- [ ] Run `zig fmt --check src/`.
+- [ ] Run `zig build test`.
+- [ ] Run `zig build -Doptimize=ReleaseFast`.
+- [ ] Run CLI smoke tests: `--help`, `--version`, and example calc.
+- [ ] Run focused Python checks for changed Python surface.
+- [ ] Run website build if docs/site changed.
+- [ ] Review full diff for secrets, generated artifacts, and unintended tracked deletions.
+- [ ] Commit with conventional messages, push `feat/review-hardening`, open PR or merge only after verification and user-approved merge policy.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,14 @@
 # Example Files
 
-Sample structure files for testing zsasa.
+Sample structure files for testing zsasa. Counts include ATOM and HETATM coordinate records in the fixture files.
 
-| File | Format | Structure | Atoms |
-|------|--------|-----------|-------|
+| File | Format | Structure | Coordinate records |
+|------|--------|-----------|--------------------|
 | `1crn.pdb` | PDB | Crambin | 327 |
 | `1crn.cif.gz` | mmCIF (gzip) | Crambin | 327 |
 | `1ubq.pdb` | PDB | Ubiquitin | 660 |
 | `1ubq.cif` | mmCIF | Ubiquitin | 660 |
-| `3hhb.cif.gz` | mmCIF (gzip) | Hemoglobin | 4,779 |
+| `3hhb.cif.gz` | mmCIF (gzip) | Hemoglobin | 4,612 |
 
 ## Usage
 

--- a/packaging/conda-forge/meta.yaml
+++ b/packaging/conda-forge/meta.yaml
@@ -6,15 +6,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-x86_64  # [linux and x86_64]
-  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-aarch64  # [linux and aarch64]
-  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-x86_64  # [osx and x86_64]
-  url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-aarch64  # [osx and arm64]
-  sha256: 250c660de9d0de3f2ccb9e30c6aa8244ff5bb1ea92ac814549f27de1a71a3306  # [linux and x86_64]
-  sha256: 82e99edaef90906fc414de35aee1529649efce50fe82f06510a46c490946ff3e  # [linux and aarch64]
-  sha256: 97fdae690982d32bf5b6e7d78300480629a8d173acf55c9c0f849d038eeb44e9  # [osx and x86_64]
-  sha256: d25ff0904ef1300bc7b69affab780061055e0c5bf7f9f180983a708d381497a9  # [osx and arm64]
-  fn: zsasa
+  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-x86_64  # [linux and x86_64]
+    sha256: 250c660de9d0de3f2ccb9e30c6aa8244ff5bb1ea92ac814549f27de1a71a3306  # [linux and x86_64]
+    fn: zsasa  # [linux and x86_64]
+  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-linux-aarch64  # [linux and aarch64]
+    sha256: 82e99edaef90906fc414de35aee1529649efce50fe82f06510a46c490946ff3e  # [linux and aarch64]
+    fn: zsasa  # [linux and aarch64]
+  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-x86_64  # [osx and x86_64]
+    sha256: 97fdae690982d32bf5b6e7d78300480629a8d173acf55c9c0f849d038eeb44e9  # [osx and x86_64]
+    fn: zsasa  # [osx and x86_64]
+  - url: https://github.com/N283T/zsasa/releases/download/v{{ version }}/zsasa-{{ version }}-macos-aarch64  # [osx and arm64]
+    sha256: d25ff0904ef1300bc7b69affab780061055e0c5bf7f9f180983a708d381497a9  # [osx and arm64]
+    fn: zsasa  # [osx and arm64]
+  - url: https://raw.githubusercontent.com/N283T/zsasa/v{{ version }}/LICENSE
+    sha256: 452d2e27d011a6430b43ffe2321f4cb17867d7896a57c68d130cd8d012b49a0f
+    fn: LICENSE
 
 build:
   number: 0
@@ -37,7 +43,9 @@ about:
   description: |
     High-performance SASA calculation using Shrake-Rupley and Lee-Richards
     algorithms, implemented in Zig with SIMD acceleration.
+  doc_url: https://n283t.github.io/zsasa/
   dev_url: https://github.com/N283T/zsasa
+  source_url: https://github.com/N283T/zsasa
 
 extra:
   recipe-maintainers:

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -69,7 +69,7 @@ from zsasa import classify_atoms, ClassifierType
 residues = ["ALA", "ALA", "GLY"]
 atoms = ["CA", "O", "N"]
 
-result = classify_atoms(residues, atoms, ClassifierType.NACCESS)
+result = classify_atoms(residues, atoms, ClassifierType.CCD)
 print(result.radii)    # Per-atom radii
 print(result.classes)  # Polar/apolar classification
 ```
@@ -161,10 +161,10 @@ print(sasa.results.total_area)  # Per-frame total SASA in A^2
 | `n_slices` | `20` | Slices per atom (LR algorithm) |
 | `probe_radius` | `1.4` | Water probe radius in Angstroms |
 | `n_threads` | `0` | Number of threads (0 = auto-detect) |
-| `classifier` | `NACCESS` | Atom radius classifier |
+| `classifier` | `CCD` | Atom radius classifier for structure/Python classification APIs (`traj` defaults to NACCESS) |
 
 ## See Also
 
 - [Python API Documentation](../../website/docs/python-api/)
-- [CLI Documentation](../../docs/cli.md)
-- [Algorithm Details](../../docs/algorithm.md)
+- [CLI Documentation](../../website/docs/cli/commands.md)
+- [Algorithm Details](../../website/docs/guide/algorithms.mdx)

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -22,9 +22,12 @@ class ZigBuildHook(BuildHookInterface):
         # Mark as platform-specific wheel (required for .so/.dylib bundling)
         build_data["infer_tag"] = True
 
-        # Determine paths
-        root_dir = Path(self.root).parent  # Go up from python/ to project root
+        # Determine paths. In a repository checkout, pyproject.toml lives in
+        # python/ and Zig sources live one level up. In an sdist, the required
+        # Zig files are included next to pyproject.toml so source installs do
+        # not depend on files outside the extracted archive.
         python_dir = Path(self.root)
+        root_dir = self._find_zig_root(python_dir)
         package_dir = python_dir / "zsasa"
 
         # Platform-specific names
@@ -65,6 +68,17 @@ class ZigBuildHook(BuildHookInterface):
         # Include both artifacts in the wheel
         build_data["force_include"][str(lib_dst)] = f"zsasa/{lib_name}"
         build_data["force_include"][str(exe_dst)] = f"zsasa/{exe_name}"
+
+    def _find_zig_root(self, python_dir: Path) -> Path:
+        """Find the directory that contains the Zig build files."""
+        for candidate in (python_dir.parent, python_dir):
+            if candidate.joinpath("build.zig").is_file() and candidate.joinpath("src").is_dir():
+                return candidate
+        msg = (
+            "Zig source files were not found. Source installs require build.zig "
+            "and src/ to be present in the source distribution."
+        )
+        raise FileNotFoundError(msg)
 
     def _needs_build(self, src: Path, dst: Path) -> bool:
         """Check if a build is needed based on file existence and timestamps."""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,6 +54,20 @@ packages = ["zsasa"]
 [tool.hatch.build.targets.wheel.hooks.custom]
 path = "hatch_build.py"
 
+[tool.hatch.build.targets.sdist]
+include = [
+    "README.md",
+    "hatch_build.py",
+    "pyproject.toml",
+    "zsasa/**",
+]
+
+[tool.hatch.build.targets.sdist.force-include]
+"../build.zig" = "build.zig"
+"../build.zig.zon" = "build.zig.zon"
+"../src" = "src"
+"../LICENSE" = "LICENSE"
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100

--- a/python/tests/test_batch.py
+++ b/python/tests/test_batch.py
@@ -215,3 +215,62 @@ class TestCalculateSasaBatchValidation:
 
         with pytest.raises(ValueError, match="negative|positive"):
             calculate_sasa_batch(coords, radii)
+
+    @pytest.mark.parametrize(
+        ("coords", "radii", "kwargs", "match"),
+        [
+            (
+                np.array([[[np.inf, 0.0, 0.0]]], dtype=np.float32),
+                np.array([1.5], dtype=np.float32),
+                {},
+                "coordinates.*finite",
+            ),
+            (
+                np.array([[[0.0, 0.0, 0.0]]], dtype=np.float32),
+                np.array([np.nan], dtype=np.float32),
+                {},
+                "radii.*finite",
+            ),
+            (
+                np.array([[[0.0, 0.0, 0.0]]], dtype=np.float32),
+                np.array([1.5], dtype=np.float32),
+                {"probe_radius": np.nan},
+                "probe_radius.*finite",
+            ),
+            (
+                np.array([[[0.0, 0.0, 0.0]]], dtype=np.float32),
+                np.array([1.5], dtype=np.float32),
+                {"n_points": 2**32},
+                "n_points.*1.*4294967295",
+            ),
+            (
+                np.array([[[0.0, 0.0, 0.0]]], dtype=np.float32),
+                np.array([1.5], dtype=np.float32),
+                {"n_slices": 2**32},
+                "n_slices.*1.*4294967295",
+            ),
+            (
+                np.array([[[0.0, 0.0, 0.0]]], dtype=np.float32),
+                np.array([1.5], dtype=np.float32),
+                {"n_threads": 2**64},
+                "n_threads.*size_t",
+            ),
+        ],
+    )
+    def test_invalid_values_rejected_before_loading_library(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        coords: np.ndarray,
+        radii: np.ndarray,
+        kwargs: dict[str, object],
+        match: str,
+    ) -> None:
+        """Invalid numeric inputs should fail before any CFFI library lookup/call."""
+
+        def fail_get_lib() -> None:
+            pytest.fail("_get_lib should not be called for invalid input")
+
+        monkeypatch.setattr("zsasa.sasa._get_lib", fail_get_lib)
+
+        with pytest.raises(ValueError, match=match):
+            calculate_sasa_batch(coords, radii, **kwargs)

--- a/python/tests/test_dcd.py
+++ b/python/tests/test_dcd.py
@@ -7,8 +7,13 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from zsasa.dcd import DcdFrame, DcdReader, compute_sasa_trajectory
-from zsasa.xtc import TrajectorySasaResult
+from zsasa.dcd import (
+    DcdFrame,
+    DcdReader,
+    compute_sasa_trajectory,
+    compute_sasa_trajectory_summary,
+)
+from zsasa.xtc import TrajectorySasaResult, TrajectorySasaSummaryResult
 
 # Path to test data
 TEST_DATA_DIR = Path(__file__).parent.parent.parent / "test_data"
@@ -194,6 +199,18 @@ class TestComputeSasaTrajectory:
         # Total SASA for a small protein should be ~5000-10000 Å²
         assert np.all(result.total_areas > 100)
         assert np.all(result.total_areas < 50000)
+
+    def test_streaming_summary_matches_full_totals_without_atom_areas(
+        self,
+        radii: np.ndarray,
+    ) -> None:
+        """Streaming DCD summary should chunk frames and avoid retaining atom areas."""
+        full = compute_sasa_trajectory(DCD_FILE, radii, stop=4)
+        summary = compute_sasa_trajectory_summary(DCD_FILE, radii, stop=4, chunk_size=2)
+
+        assert isinstance(summary, TrajectorySasaSummaryResult)
+        assert not hasattr(summary, "atom_areas")
+        np.testing.assert_allclose(summary.total_areas, full.total_areas, rtol=1e-6)
 
 
 class TestDcdReaderClosed:

--- a/python/tests/test_ffi.py
+++ b/python/tests/test_ffi.py
@@ -1,0 +1,23 @@
+"""Tests for FFI library discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from zsasa import _ffi
+
+
+def test_windows_editable_install_finds_zig_out_bin(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Windows editable installs should discover Zig DLLs under zig-out/bin."""
+    dll_path = tmp_path.joinpath("zig-out", "bin", "zsasa.dll")
+    dll_path.parent.mkdir(parents=True)
+    dll_path.write_bytes(b"")
+
+    monkeypatch.delenv("ZSASA_LIB", raising=False)
+    monkeypatch.setattr(_ffi.sys, "platform", "win32")
+    monkeypatch.chdir(tmp_path)
+
+    assert _ffi._find_library() == dll_path

--- a/python/tests/test_integration_radii_policy.py
+++ b/python/tests/test_integration_radii_policy.py
@@ -1,0 +1,33 @@
+"""Tests for shared integration radius assignment policy."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from zsasa.classifier import ClassifierType
+from zsasa.integrations._types import AtomData, classify_atom_data
+
+
+def _atom_data(*, element: str) -> AtomData:
+    return AtomData(
+        coords=np.array([[0.0, 0.0, 0.0]], dtype=np.float64),
+        residue_names=["UNK"],
+        atom_names=["ZZ1"],
+        chain_ids=["A"],
+        residue_ids=[42],
+        elements=[element],
+    )
+
+
+def test_unknown_classifier_radius_falls_back_to_element_radius() -> None:
+    """Unknown residue/atom pairs should use element-derived radii when possible."""
+    classification = classify_atom_data(_atom_data(element="C"), ClassifierType.CCD)
+
+    assert classification.radii[0] == pytest.approx(1.70)
+
+
+def test_unknown_radius_without_element_fails_with_atom_identifier() -> None:
+    """Unknown radii should identify the atom clearly instead of leaking NaN to CFFI."""
+    with pytest.raises(ValueError, match=r"chain A residue 42 UNK atom ZZ1"):
+        classify_atom_data(_atom_data(element=""), ClassifierType.CCD)

--- a/python/tests/test_mdanalysis_integration.py
+++ b/python/tests/test_mdanalysis_integration.py
@@ -172,6 +172,35 @@ class TestSASAAnalysis:
             assert analysis.results.residue_area[frame, 0] == pytest.approx(res0_atoms, rel=0.01)
             assert analysis.results.residue_area[frame, 1] == pytest.approx(res1_atoms, rel=0.01)
 
+    def test_selected_residues_are_remapped_densely(self) -> None:
+        """Selections with nonzero/discontiguous resindices should aggregate into dense columns."""
+        universe = make_universe(n_atoms=6, n_residues=3, n_frames=1)
+
+        analysis = SASAAnalysis(universe, select="resid 2 or resid 3")
+        analysis.run()
+
+        assert analysis.results.atom_area.shape == (1, 4)
+        assert analysis.results.residue_area.shape == (1, 2)
+        assert analysis.results.residue_area[0, 0] == pytest.approx(
+            analysis.results.atom_area[0, :2].sum(),
+            rel=0.01,
+        )
+        assert analysis.results.residue_area[0, 1] == pytest.approx(
+            analysis.results.atom_area[0, 2:].sum(),
+            rel=0.01,
+        )
+
+    def test_streaming_run_can_skip_retaining_atom_areas(self, universe: mda.Universe) -> None:
+        """Chunked MDAnalysis runs should expose totals/residue aggregates without atom areas."""
+        analysis = SASAAnalysis(universe)
+        analysis.run(chunk_size=1, store_atom_areas=False)
+
+        assert analysis.n_frames == 3
+        assert analysis.results.atom_area is None
+        assert analysis.results.residue_area.shape == (3, 2)
+        assert analysis.results.total_area.shape == (3,)
+        assert np.all(analysis.results.total_area > 0)
+
     def test_total_matches_sum(self, universe: mda.Universe) -> None:
         """Test that total SASA matches atom SASA sum."""
         analysis = SASAAnalysis(universe)

--- a/python/tests/test_sasa.py
+++ b/python/tests/test_sasa.py
@@ -208,6 +208,65 @@ class TestInputValidation:
         with pytest.raises(ValueError, match="non-negative"):
             calculate_sasa(coords, radii)
 
+    @pytest.mark.parametrize(
+        ("coords", "radii", "kwargs", "match"),
+        [
+            (
+                np.array([[np.nan, 0.0, 0.0]]),
+                np.array([1.5]),
+                {},
+                "coords.*finite",
+            ),
+            (
+                np.array([[0.0, 0.0, 0.0]]),
+                np.array([np.inf]),
+                {},
+                "radii.*finite",
+            ),
+            (
+                np.array([[0.0, 0.0, 0.0]]),
+                np.array([1.5]),
+                {"probe_radius": np.inf},
+                "probe_radius.*finite",
+            ),
+            (
+                np.array([[0.0, 0.0, 0.0]]),
+                np.array([1.5]),
+                {"n_points": 2**32},
+                "n_points.*1.*4294967295",
+            ),
+            (
+                np.array([[0.0, 0.0, 0.0]]),
+                np.array([1.5]),
+                {"n_slices": 2**32},
+                "n_slices.*1.*4294967295",
+            ),
+            (
+                np.array([[0.0, 0.0, 0.0]]),
+                np.array([1.5]),
+                {"n_threads": 2**64},
+                "n_threads.*size_t",
+            ),
+        ],
+    )
+    def test_invalid_values_rejected_before_loading_library(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        coords: np.ndarray,
+        radii: np.ndarray,
+        kwargs: dict[str, object],
+        match: str,
+    ) -> None:
+        """Invalid numeric inputs should fail before any CFFI library lookup/call."""
+
+        def fail_get_lib() -> None:
+            pytest.fail("_get_lib should not be called for invalid input")
+
+        monkeypatch.setattr("zsasa.sasa._get_lib", fail_get_lib)
+
+        with pytest.raises(ValueError, match=match):
+            calculate_sasa(coords, radii, **kwargs)
+
 
 # =============================================================================
 # Classifier Tests

--- a/python/tests/test_xtc.py
+++ b/python/tests/test_xtc.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from zsasa.xtc import TrajectorySasaResult, XtcReader, compute_sasa_trajectory
+from zsasa.xtc import (
+    TrajectorySasaResult,
+    TrajectorySasaSummaryResult,
+    XtcReader,
+    compute_sasa_trajectory,
+    compute_sasa_trajectory_summary,
+)
 
 # Path to test data
 TEST_DATA_DIR = Path(__file__).parent.parent.parent / "test_data"
@@ -166,6 +172,18 @@ class TestComputeSasaTrajectory:
             result_4.atom_areas,
             decimal=4,
         )
+
+    def test_streaming_summary_matches_full_totals_without_atom_areas(
+        self,
+        radii: np.ndarray,
+    ) -> None:
+        """Streaming XTC summary should chunk frames and avoid retaining atom areas."""
+        full = compute_sasa_trajectory(XTC_FILE, radii, stop=4)
+        summary = compute_sasa_trajectory_summary(XTC_FILE, radii, stop=4, chunk_size=2)
+
+        assert isinstance(summary, TrajectorySasaSummaryResult)
+        assert not hasattr(summary, "atom_areas")
+        np.testing.assert_allclose(summary.total_areas, full.total_areas, rtol=1e-6)
 
 
 class TestXtcReaderClosed:

--- a/python/zsasa/_ffi.py
+++ b/python/zsasa/_ffi.py
@@ -232,14 +232,16 @@ def _find_library() -> Path:
     search_paths = [
         # Bundled in package (wheel installation)
         Path(__file__).parent / lib_name,
-        # Relative to this file (development: python/zsasa -> zig-out/lib)
+        # Relative to this file (development: python/zsasa -> zig-out/lib or bin)
         Path(__file__).parent.parent.parent / "zig-out" / "lib" / lib_name,
+        Path(__file__).parent.parent.parent / "zig-out" / "bin" / lib_name,
         # System paths
         Path("/usr/local/lib") / lib_name,
         Path("/usr/lib") / lib_name,
         # Current directory
         Path.cwd() / lib_name,
         Path.cwd() / "zig-out" / "lib" / lib_name,
+        Path.cwd() / "zig-out" / "bin" / lib_name,
     ]
 
     for path in search_paths:

--- a/python/zsasa/dcd.py
+++ b/python/zsasa/dcd.py
@@ -35,7 +35,14 @@ from numpy.typing import NDArray
 
 from zsasa._ffi import _get_lib
 from zsasa.sasa import calculate_sasa_batch
-from zsasa.xtc import TrajectorySasaResult
+from zsasa.xtc import (
+    TrajectorySasaResult,
+    TrajectorySasaSummaryResult,
+    _append_residue_areas,
+    _calculate_chunk,
+    _prepare_residue_mapping,
+    _validate_chunk_size,
+)
 
 if TYPE_CHECKING:
     from cffi import FFI
@@ -225,6 +232,96 @@ class DcdReader:
     def __del__(self) -> None:
         """Destructor - ensure file is closed."""
         self.close()
+
+
+def compute_sasa_trajectory_summary(
+    dcd_path: str | Path,
+    radii: NDArray[np.floating] | list[float],
+    *,
+    atom_to_residue: NDArray[np.integer] | list[int] | None = None,
+    probe_radius: float = 1.4,
+    n_points: int = 100,
+    algorithm: Literal["sr", "lr"] = "sr",
+    n_slices: int = 20,
+    n_threads: int = 0,
+    start: int = 0,
+    stop: int | None = None,
+    step: int = 1,
+    chunk_size: int = 16,
+    use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
+) -> TrajectorySasaSummaryResult:
+    """Compute DCD SASA totals/residue aggregates without retaining atom areas.
+
+    DCD coordinates are already in Angstroms. Frames are processed in chunks and
+    per-atom SASA arrays are discarded after aggregate values are accumulated.
+    """
+    radii = np.asarray(radii, dtype=np.float32)
+    chunk_size = _validate_chunk_size(chunk_size)
+
+    coords_chunk: list[NDArray[np.float32]] = []
+    total_chunks: list[NDArray[np.float32]] = []
+    residue_chunks: list[NDArray[np.float32]] = []
+    steps: list[int] = []
+    times: list[float] = []
+
+    def flush_chunk(mapping: NDArray[np.int32] | None, n_residues: int) -> None:
+        if not coords_chunk:
+            return
+        coords_angstrom = np.stack(coords_chunk, axis=0)
+        atom_areas = _calculate_chunk(
+            coords_angstrom,
+            radii,
+            probe_radius=probe_radius,
+            n_points=n_points,
+            algorithm=algorithm,
+            n_slices=n_slices,
+            n_threads=n_threads,
+            use_bitmask=use_bitmask,
+            bitmask_correction=bitmask_correction,
+            bitmask_correction_coeff=bitmask_correction_coeff,
+        )
+        total_chunks.append(atom_areas.sum(axis=1))
+        _append_residue_areas(residue_chunks, atom_areas, mapping, n_residues)
+        coords_chunk.clear()
+
+    with DcdReader(dcd_path) as reader:
+        if len(radii) != reader.natoms:
+            msg = f"radii length ({len(radii)}) doesn't match trajectory atoms ({reader.natoms})"
+            raise ValueError(msg)
+        mapping, n_residues = _prepare_residue_mapping(atom_to_residue, reader.natoms)
+
+        frame_idx = 0
+        for frame in reader:
+            if frame_idx < start:
+                frame_idx += 1
+                continue
+            if stop is not None and frame_idx >= stop:
+                break
+            if (frame_idx - start) % step != 0:
+                frame_idx += 1
+                continue
+
+            coords_chunk.append(frame.coords)
+            steps.append(frame.step)
+            times.append(frame.time)
+            if len(coords_chunk) == chunk_size:
+                flush_chunk(mapping, n_residues)
+            frame_idx += 1
+
+        flush_chunk(mapping, n_residues)
+
+    if not total_chunks:
+        msg = "No frames to process"
+        raise ValueError(msg)
+
+    return TrajectorySasaSummaryResult(
+        total_areas=np.concatenate(total_chunks).astype(np.float32, copy=False),
+        steps=np.array(steps, dtype=np.int32),
+        times=np.array(times, dtype=np.float32),
+        residue_areas=np.concatenate(residue_chunks) if residue_chunks else None,
+    )
 
 
 def compute_sasa_trajectory(

--- a/python/zsasa/integrations/_types.py
+++ b/python/zsasa/integrations/_types.py
@@ -11,11 +11,13 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
+from zsasa.classifier import ClassificationResult, ClassifierType, classify_atoms, guess_radius
 from zsasa.sasa import SasaResult
 
 __all__ = [
     "AtomData",
     "SasaResultWithAtoms",
+    "classify_atom_data",
 ]
 
 
@@ -76,3 +78,41 @@ class SasaResultWithAtoms(SasaResult):
             f"polar={self.polar_area:.1f}, apolar={self.apolar_area:.1f}, "
             f"n_atoms={len(self.atom_areas)})"
         )
+
+
+def _format_atom_identifier(atom_data: AtomData, index: int) -> str:
+    """Format a clear atom identifier for integration error messages."""
+    return (
+        f"chain {atom_data.chain_ids[index]} residue {atom_data.residue_ids[index]} "
+        f"{atom_data.residue_names[index]} atom {atom_data.atom_names[index]}"
+    )
+
+
+def classify_atom_data(
+    atom_data: AtomData,
+    classifier: ClassifierType = ClassifierType.CCD,
+) -> ClassificationResult:
+    """Classify integration atoms and resolve unknown radii safely.
+
+    Classifier misses are filled from element-derived radii when an element is
+    available. If neither the classifier nor element fallback can assign a
+    radius, a ValueError identifies the problematic atom instead of allowing a
+    NaN radius to reach the native calculator.
+    """
+    classification = classify_atoms(
+        atom_data.residue_names,
+        atom_data.atom_names,
+        classifier,
+    )
+
+    missing = np.nonzero(~np.isfinite(classification.radii))[0]
+    for index in missing:
+        element = atom_data.elements[index].strip()
+        radius = guess_radius(element) if element else None
+        if radius is None:
+            identifier = _format_atom_identifier(atom_data, int(index))
+            msg = f"Unknown radius for {identifier} (element={element!r})"
+            raise ValueError(msg)
+        classification.radii[index] = radius
+
+    return classification

--- a/python/zsasa/integrations/biopython.py
+++ b/python/zsasa/integrations/biopython.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
-from zsasa.classifier import AtomClass, ClassifierType, classify_atoms
-from zsasa.integrations._types import AtomData, SasaResultWithAtoms
+from zsasa.classifier import AtomClass, ClassifierType
+from zsasa.integrations._types import AtomData, SasaResultWithAtoms, classify_atom_data
 from zsasa.sasa import calculate_sasa
 
 if TYPE_CHECKING:
@@ -203,12 +203,8 @@ def calculate_sasa_from_model(
             apolar_area=0.0,
         )
 
-    # Classify atoms
-    classification = classify_atoms(
-        atom_data.residue_names,
-        atom_data.atom_names,
-        classifier,
-    )
+    # Classify atoms, falling back to element-derived radii when available.
+    classification = classify_atom_data(atom_data, classifier)
 
     # Calculate SASA
     sasa_result = calculate_sasa(

--- a/python/zsasa/integrations/biotite.py
+++ b/python/zsasa/integrations/biotite.py
@@ -24,8 +24,8 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
-from zsasa.classifier import AtomClass, ClassifierType, classify_atoms
-from zsasa.integrations._types import AtomData, SasaResultWithAtoms
+from zsasa.classifier import AtomClass, ClassifierType
+from zsasa.integrations._types import AtomData, SasaResultWithAtoms, classify_atom_data
 from zsasa.sasa import calculate_sasa
 
 if TYPE_CHECKING:
@@ -170,12 +170,8 @@ def calculate_sasa_from_atom_array(
             apolar_area=0.0,
         )
 
-    # Classify atoms
-    classification = classify_atoms(
-        atom_data.residue_names,
-        atom_data.atom_names,
-        classifier,
-    )
+    # Classify atoms, falling back to element-derived radii when available.
+    classification = classify_atom_data(atom_data, classifier)
 
     # Calculate SASA
     sasa_result = calculate_sasa(

--- a/python/zsasa/integrations/gemmi.py
+++ b/python/zsasa/integrations/gemmi.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
-from zsasa.classifier import AtomClass, ClassifierType, classify_atoms
-from zsasa.integrations._types import AtomData, SasaResultWithAtoms
+from zsasa.classifier import AtomClass, ClassifierType
+from zsasa.integrations._types import AtomData, SasaResultWithAtoms, classify_atom_data
 from zsasa.sasa import calculate_sasa
 
 if TYPE_CHECKING:
@@ -160,12 +160,8 @@ def calculate_sasa_from_model(
             apolar_area=0.0,
         )
 
-    # Classify atoms
-    classification = classify_atoms(
-        atom_data.residue_names,
-        atom_data.atom_names,
-        classifier,
-    )
+    # Classify atoms, falling back to element-derived radii when available.
+    classification = classify_atom_data(atom_data, classifier)
 
     # Calculate SASA
     sasa_result = calculate_sasa(

--- a/python/zsasa/mdanalysis.py
+++ b/python/zsasa/mdanalysis.py
@@ -163,12 +163,16 @@ class SASAAnalysis:
         # Pre-compute radii (reused across all frames)
         self._radii = _get_radii_from_atomgroup(self.atomgroup)
 
-        # Build atom-to-residue mapping
-        self._atom_to_residue = np.array(
+        # Build atom-to-residue mapping. MDAnalysis resindices belong to the
+        # whole Universe, so selections can be nonzero/discontiguous. Remap to
+        # dense 0..N-1 columns for residue aggregation.
+        raw_atom_to_residue = np.array(
             [atom.resindex for atom in self.atomgroup],
-            dtype=np.int32,
+            dtype=np.int64,
         )
-        self._n_residues = len(np.unique(self._atom_to_residue))
+        _, dense_atom_to_residue = np.unique(raw_atom_to_residue, return_inverse=True)
+        self._atom_to_residue = dense_atom_to_residue.astype(np.int32, copy=False)
+        self._n_residues = int(self._atom_to_residue.max()) + 1 if self._atom_to_residue.size else 0
 
         # Results container
         self.results = _Results()
@@ -189,6 +193,8 @@ class SASAAnalysis:
         algorithm: Literal["sr", "lr"] = "sr",
         n_slices: int = 20,
         n_threads: int = 0,
+        chunk_size: int | None = None,
+        store_atom_areas: bool = True,
         use_bitmask: bool = False,
         bitmask_correction: bool = False,
         bitmask_correction_coeff: float | None = None,
@@ -214,6 +220,12 @@ class SASAAnalysis:
             Number of slices per atom for LR algorithm (default: 20).
         n_threads : int, optional
             Number of threads (0 = auto-detect). Default: 0.
+        chunk_size : int, optional
+            Number of frames to process per native batch. None processes all
+            selected frames in one batch.
+        store_atom_areas : bool, optional
+            Store per-atom SASA in results.atom_area. Set False to retain only
+            totals and residue aggregates.
         use_bitmask : bool, optional
             Use bitmask LUT optimization for SR algorithm.
             Supports n_points 1..1024. Default: False.
@@ -239,69 +251,76 @@ class SASAAnalysis:
         if self.n_frames == 0:
             msg = "No frames to analyze"
             raise ValueError(msg)
+        if chunk_size is None:
+            chunk_size = self.n_frames
+        if chunk_size <= 0:
+            msg = f"chunk_size must be positive, got {chunk_size}"
+            raise ValueError(msg)
 
-        # Collect coordinates for all frames
         n_atoms = len(self.atomgroup)
-        coords = np.zeros((self.n_frames, n_atoms, 3), dtype=np.float32)
         times = np.zeros(self.n_frames, dtype=np.float64)
         frames = np.zeros(self.n_frames, dtype=np.int64)
+        atom_chunks: list[NDArray[np.float32]] = []
+        residue_chunks: list[NDArray[np.float32]] = []
+        total_chunks: list[NDArray[np.float32]] = []
 
-        for i, frame_idx in enumerate(frame_indices):
-            self._trajectory[frame_idx]
-            coords[i] = self.atomgroup.positions.astype(np.float32)
-            times[i] = self._trajectory.time
-            frames[i] = frame_idx
+        def calculate_chunk(coords: NDArray[np.float32]) -> NDArray[np.float32]:
+            if algorithm == "sr":
+                return calculate_sasa_batch(
+                    coords,
+                    self._radii,
+                    algorithm="sr",
+                    n_points=n_points,
+                    probe_radius=probe_radius,
+                    n_threads=n_threads,
+                    use_bitmask=use_bitmask,
+                    bitmask_correction=bitmask_correction,
+                    bitmask_correction_coeff=bitmask_correction_coeff,
+                ).atom_areas
+            if algorithm == "lr":
+                return calculate_sasa_batch(
+                    coords,
+                    self._radii,
+                    algorithm="lr",
+                    n_slices=n_slices,
+                    probe_radius=probe_radius,
+                    n_threads=n_threads,
+                    use_bitmask=use_bitmask,
+                    bitmask_correction=bitmask_correction,
+                    bitmask_correction_coeff=bitmask_correction_coeff,
+                ).atom_areas
+            msg = f"Unknown algorithm: {algorithm}. Use 'sr' or 'lr'."
+            raise ValueError(msg)
+
+        for chunk_start in range(0, self.n_frames, chunk_size):
+            chunk_indices = frame_indices[chunk_start : chunk_start + chunk_size]
+            coords = np.zeros((len(chunk_indices), n_atoms, 3), dtype=np.float32)
+
+            for offset, frame_idx in enumerate(chunk_indices):
+                self._trajectory[frame_idx]
+                coords[offset] = self.atomgroup.positions.astype(np.float32)
+                times[chunk_start + offset] = self._trajectory.time
+                frames[chunk_start + offset] = frame_idx
+
+            atom_areas = calculate_chunk(coords)
+            if store_atom_areas:
+                atom_chunks.append(atom_areas)
+
+            residue_areas = np.zeros((atom_areas.shape[0], self._n_residues), dtype=np.float32)
+            np.add.at(
+                residue_areas,
+                (np.arange(atom_areas.shape[0])[:, np.newaxis], self._atom_to_residue),
+                atom_areas,
+            )
+            residue_chunks.append(residue_areas)
+            total_chunks.append(atom_areas.sum(axis=1))
 
         self.times = times
         self.frames = frames
 
-        # Calculate SASA using batch API
-        if algorithm == "sr":
-            result = calculate_sasa_batch(
-                coords,
-                self._radii,
-                algorithm="sr",
-                n_points=n_points,
-                probe_radius=probe_radius,
-                n_threads=n_threads,
-                use_bitmask=use_bitmask,
-                bitmask_correction=bitmask_correction,
-                bitmask_correction_coeff=bitmask_correction_coeff,
-            )
-        elif algorithm == "lr":
-            result = calculate_sasa_batch(
-                coords,
-                self._radii,
-                algorithm="lr",
-                n_slices=n_slices,
-                probe_radius=probe_radius,
-                n_threads=n_threads,
-                use_bitmask=use_bitmask,
-                bitmask_correction=bitmask_correction,
-                bitmask_correction_coeff=bitmask_correction_coeff,
-            )
-        else:
-            msg = f"Unknown algorithm: {algorithm}. Use 'sr' or 'lr'."
-            raise ValueError(msg)
-
-        # Store per-atom SASA (already in Å²)
-        self.results.atom_area = result.atom_areas
-
-        # Aggregate to per-residue SASA
-        self.results.residue_area = np.zeros(
-            (self.n_frames, self._n_residues),
-            dtype=np.float32,
-        )
-        np.add.at(
-            self.results.residue_area,
-            (np.arange(self.n_frames)[:, np.newaxis], self._atom_to_residue),
-            result.atom_areas,
-        )
-
-        # Total SASA per frame
-        self.results.total_area = result.atom_areas.sum(axis=1)
-
-        # Mean total SASA
+        self.results.atom_area = np.concatenate(atom_chunks) if store_atom_areas else None
+        self.results.residue_area = np.concatenate(residue_chunks)
+        self.results.total_area = np.concatenate(total_chunks)
         self.results.mean_total_area = float(self.results.total_area.mean())
 
         return self
@@ -334,6 +353,7 @@ def compute_sasa(
     algorithm: Literal["sr", "lr"] = "sr",
     n_slices: int = 20,
     n_threads: int = 0,
+    chunk_size: int | None = None,
     mode: Literal["atom", "residue", "total"] = "atom",
     use_bitmask: bool = False,
     bitmask_correction: bool = False,
@@ -365,6 +385,9 @@ def compute_sasa(
         Number of slices for LR algorithm (default: 20).
     n_threads : int, optional
         Number of threads (0 = auto). Default: 0.
+    chunk_size : int, optional
+        Number of frames to process per native batch. None processes all
+        selected frames in one batch.
     mode : {"atom", "residue", "total"}, optional
         Output mode (default: "atom").
     use_bitmask : bool, optional
@@ -396,6 +419,8 @@ def compute_sasa(
         algorithm=algorithm,
         n_slices=n_slices,
         n_threads=n_threads,
+        chunk_size=chunk_size,
+        store_atom_areas=mode == "atom",
         use_bitmask=use_bitmask,
         bitmask_correction=bitmask_correction,
         bitmask_correction_coeff=bitmask_correction_coeff,

--- a/python/zsasa/sasa.py
+++ b/python/zsasa/sasa.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ctypes
+import operator
 from dataclasses import dataclass
 from typing import Literal
 
@@ -19,6 +21,72 @@ from zsasa._ffi import (
     _get_lib,
     _validate_bitmask_params,
 )
+
+_UINT32_MAX = 2**32 - 1
+_SIZE_T_MAX = 2 ** (ctypes.sizeof(ctypes.c_size_t) * 8) - 1
+
+
+def _validate_uint32_param(name: str, value: object) -> int:
+    """Validate an integer parameter passed to a C uint32_t argument."""
+    if isinstance(value, (bool, np.bool_)):
+        msg = f"{name} must be an integer in range 1..{_UINT32_MAX}, got {value}"
+        raise ValueError(msg)
+    try:
+        int_value = operator.index(value)  # type: ignore[arg-type]
+    except TypeError as e:
+        msg = f"{name} must be an integer in range 1..{_UINT32_MAX}, got {value}"
+        raise ValueError(msg) from e
+    if int_value <= 0:
+        msg = f"{name} must be positive, got {value}"
+        raise ValueError(msg)
+    if int_value > _UINT32_MAX:
+        msg = f"{name} must be an integer in range 1..{_UINT32_MAX}, got {value}"
+        raise ValueError(msg)
+    return int_value
+
+
+def _validate_size_t_param(name: str, value: object) -> int:
+    """Validate an integer parameter passed to a C size_t argument."""
+    if isinstance(value, (bool, np.bool_)):
+        msg = (
+            f"{name} must be a non-negative integer that fits size_t "
+            f"(0..{_SIZE_T_MAX}), got {value}"
+        )
+        raise ValueError(msg)
+    try:
+        int_value = operator.index(value)  # type: ignore[arg-type]
+    except TypeError as e:
+        msg = (
+            f"{name} must be a non-negative integer that fits size_t "
+            f"(0..{_SIZE_T_MAX}), got {value}"
+        )
+        raise ValueError(msg) from e
+    if not (0 <= int_value <= _SIZE_T_MAX):
+        msg = (
+            f"{name} must be a non-negative integer that fits size_t "
+            f"(0..{_SIZE_T_MAX}), got {value}"
+        )
+        raise ValueError(msg)
+    return int_value
+
+
+def _validate_positive_finite_float(name: str, value: float) -> float:
+    """Validate a positive finite floating-point scalar."""
+    float_value = float(value)
+    if not np.isfinite(float_value):
+        msg = f"{name} must be finite, got {value}"
+        raise ValueError(msg)
+    if float_value <= 0:
+        msg = f"{name} must be positive, got {value}"
+        raise ValueError(msg)
+    return float_value
+
+
+def _validate_finite_array(name: str, values: NDArray[np.floating]) -> None:
+    """Reject NaN/Inf arrays before passing data through CFFI."""
+    if not np.all(np.isfinite(values)):
+        msg = f"{name} must contain only finite values"
+        raise ValueError(msg)
 
 
 @dataclass
@@ -80,21 +148,12 @@ def calculate_sasa(
         >>> result = calculate_sasa(coords, radii)
         >>> print(f"Total: {result.total_area:.2f}")
     """
-    ffi, lib = _get_lib()
-
-    # Validate parameters
-    if n_points <= 0:
-        msg = f"n_points must be positive, got {n_points}"
-        raise ValueError(msg)
-    if n_slices <= 0:
-        msg = f"n_slices must be positive, got {n_slices}"
-        raise ValueError(msg)
-    if probe_radius <= 0:
-        msg = f"probe_radius must be positive, got {probe_radius}"
-        raise ValueError(msg)
-    if n_threads < 0:
-        msg = f"n_threads must be non-negative, got {n_threads}"
-        raise ValueError(msg)
+    # Validate parameters before loading the C library so invalid Python inputs
+    # never reach CFFI conversion or native code.
+    n_points = _validate_uint32_param("n_points", n_points)
+    n_slices = _validate_uint32_param("n_slices", n_slices)
+    probe_radius = _validate_positive_finite_float("probe_radius", probe_radius)
+    n_threads = _validate_size_t_param("n_threads", n_threads)
     if bitmask_correction and not use_bitmask:
         msg = "bitmask_correction=True requires use_bitmask=True"
         raise ValueError(msg)
@@ -121,9 +180,14 @@ def calculate_sasa(
         msg = f"radii must be ({n_atoms},) array, got shape {radii.shape}"
         raise ValueError(msg)
 
+    _validate_finite_array("coords", coords)
+    _validate_finite_array("radii", radii)
+
     if np.any(radii < 0):
         msg = "All radii must be non-negative"
         raise ValueError(msg)
+
+    ffi, lib = _get_lib()
 
     # Extract x, y, z as contiguous arrays
     x = np.ascontiguousarray(coords[:, 0])
@@ -310,21 +374,12 @@ def calculate_sasa_batch(
         >>> print(f"Shape: {result.atom_areas.shape}")  # (10, 100)
         >>> print(f"Total SASA per frame: {result.total_areas}")
     """
-    ffi, lib = _get_lib()
-
-    # Validate parameters
-    if n_points <= 0:
-        msg = f"n_points must be positive, got {n_points}"
-        raise ValueError(msg)
-    if n_slices <= 0:
-        msg = f"n_slices must be positive, got {n_slices}"
-        raise ValueError(msg)
-    if probe_radius <= 0:
-        msg = f"probe_radius must be positive, got {probe_radius}"
-        raise ValueError(msg)
-    if n_threads < 0:
-        msg = f"n_threads must be non-negative, got {n_threads}"
-        raise ValueError(msg)
+    # Validate parameters before loading the C library so invalid Python inputs
+    # never reach CFFI conversion or native code.
+    n_points = _validate_uint32_param("n_points", n_points)
+    n_slices = _validate_uint32_param("n_slices", n_slices)
+    probe_radius = _validate_positive_finite_float("probe_radius", probe_radius)
+    n_threads = _validate_size_t_param("n_threads", n_threads)
     if bitmask_correction and not use_bitmask:
         msg = "bitmask_correction=True requires use_bitmask=True"
         raise ValueError(msg)
@@ -353,9 +408,14 @@ def calculate_sasa_batch(
         msg = f"radii must be ({n_atoms},) array, got shape {radii.shape}"
         raise ValueError(msg)
 
+    _validate_finite_array("coordinates", coordinates)
+    _validate_finite_array("radii", radii)
+
     if np.any(radii < 0):
         msg = "All radii must be non-negative"
         raise ValueError(msg)
+
+    ffi, lib = _get_lib()
 
     # Allocate output array
     atom_areas = np.zeros((n_frames, n_atoms), dtype=np.float32)

--- a/python/zsasa/xtc.py
+++ b/python/zsasa/xtc.py
@@ -257,6 +257,200 @@ class TrajectorySasaResult:
         return f"TrajectorySasaResult(n_frames={self.n_frames}, n_atoms={self.n_atoms})"
 
 
+@dataclass
+class TrajectorySasaSummaryResult:
+    """Memory-efficient trajectory SASA summary.
+
+    Attributes:
+        total_areas: Total SASA per frame, shape (n_frames,) in Å².
+        steps: Step numbers for each processed frame.
+        times: Time values for each processed frame in ps.
+        residue_areas: Optional per-residue SASA, shape (n_frames, n_residues) in Å².
+    """
+
+    total_areas: NDArray[np.float32]
+    steps: NDArray[np.int32]
+    times: NDArray[np.float32]
+    residue_areas: NDArray[np.float32] | None = None
+
+    @property
+    def n_frames(self) -> int:
+        """Number of frames."""
+        return self.total_areas.shape[0]
+
+    @property
+    def n_residues(self) -> int:
+        """Number of residue columns, or zero when residue areas were not requested."""
+        return 0 if self.residue_areas is None else self.residue_areas.shape[1]
+
+    def __repr__(self) -> str:
+        return (
+            f"TrajectorySasaSummaryResult(n_frames={self.n_frames}, n_residues={self.n_residues})"
+        )
+
+
+def _validate_chunk_size(chunk_size: int) -> int:
+    if chunk_size <= 0:
+        msg = f"chunk_size must be positive, got {chunk_size}"
+        raise ValueError(msg)
+    return int(chunk_size)
+
+
+def _prepare_residue_mapping(
+    atom_to_residue: NDArray[np.integer] | list[int] | None,
+    n_atoms: int,
+) -> tuple[NDArray[np.int32] | None, int]:
+    """Validate and densely remap atom-to-residue indices."""
+    if atom_to_residue is None:
+        return None, 0
+
+    mapping = np.asarray(atom_to_residue, dtype=np.int64)
+    if mapping.shape != (n_atoms,):
+        msg = f"atom_to_residue must have shape ({n_atoms},), got {mapping.shape}"
+        raise ValueError(msg)
+    if np.any(mapping < 0):
+        msg = "atom_to_residue indices must be non-negative"
+        raise ValueError(msg)
+
+    _, dense = np.unique(mapping, return_inverse=True)
+    return dense.astype(np.int32, copy=False), int(dense.max()) + 1 if dense.size else 0
+
+
+def _append_residue_areas(
+    chunks: list[NDArray[np.float32]],
+    atom_areas: NDArray[np.float32],
+    atom_to_residue: NDArray[np.int32] | None,
+    n_residues: int,
+) -> None:
+    if atom_to_residue is None:
+        return
+    residue_areas = np.zeros((atom_areas.shape[0], n_residues), dtype=np.float32)
+    np.add.at(
+        residue_areas,
+        (np.arange(atom_areas.shape[0])[:, np.newaxis], atom_to_residue),
+        atom_areas,
+    )
+    chunks.append(residue_areas)
+
+
+def _calculate_chunk(
+    coords_angstrom: NDArray[np.float32],
+    radii: NDArray[np.float32],
+    *,
+    probe_radius: float,
+    n_points: int,
+    algorithm: Literal["sr", "lr"],
+    n_slices: int,
+    n_threads: int,
+    use_bitmask: bool,
+    bitmask_correction: bool,
+    bitmask_correction_coeff: float | None,
+) -> NDArray[np.float32]:
+    result = calculate_sasa_batch(
+        coords_angstrom,
+        radii,
+        algorithm=algorithm,
+        n_points=n_points,
+        n_slices=n_slices,
+        probe_radius=probe_radius,
+        n_threads=n_threads,
+        use_bitmask=use_bitmask,
+        bitmask_correction=bitmask_correction,
+        bitmask_correction_coeff=bitmask_correction_coeff,
+    )
+    return result.atom_areas
+
+
+def compute_sasa_trajectory_summary(
+    xtc_path: str | Path,
+    radii: NDArray[np.floating] | list[float],
+    *,
+    atom_to_residue: NDArray[np.integer] | list[int] | None = None,
+    probe_radius: float = 1.4,
+    n_points: int = 100,
+    algorithm: Literal["sr", "lr"] = "sr",
+    n_slices: int = 20,
+    n_threads: int = 0,
+    start: int = 0,
+    stop: int | None = None,
+    step: int = 1,
+    chunk_size: int = 16,
+    use_bitmask: bool = False,
+    bitmask_correction: bool = False,
+    bitmask_correction_coeff: float | None = None,
+) -> TrajectorySasaSummaryResult:
+    """Compute trajectory SASA totals/residue aggregates without retaining atom areas.
+
+    XTC coordinates are read and processed in chunks. Per-atom SASA arrays are
+    discarded after total and optional residue aggregates are accumulated.
+    """
+    radii = np.asarray(radii, dtype=np.float32)
+    chunk_size = _validate_chunk_size(chunk_size)
+
+    coords_chunk: list[NDArray[np.float32]] = []
+    total_chunks: list[NDArray[np.float32]] = []
+    residue_chunks: list[NDArray[np.float32]] = []
+    steps: list[int] = []
+    times: list[float] = []
+
+    def flush_chunk(mapping: NDArray[np.int32] | None, n_residues: int) -> None:
+        if not coords_chunk:
+            return
+        coords_angstrom = np.stack(coords_chunk, axis=0) * 10.0
+        atom_areas = _calculate_chunk(
+            coords_angstrom,
+            radii,
+            probe_radius=probe_radius,
+            n_points=n_points,
+            algorithm=algorithm,
+            n_slices=n_slices,
+            n_threads=n_threads,
+            use_bitmask=use_bitmask,
+            bitmask_correction=bitmask_correction,
+            bitmask_correction_coeff=bitmask_correction_coeff,
+        )
+        total_chunks.append(atom_areas.sum(axis=1))
+        _append_residue_areas(residue_chunks, atom_areas, mapping, n_residues)
+        coords_chunk.clear()
+
+    with XtcReader(xtc_path) as reader:
+        if len(radii) != reader.natoms:
+            msg = f"radii length ({len(radii)}) doesn't match trajectory atoms ({reader.natoms})"
+            raise ValueError(msg)
+        mapping, n_residues = _prepare_residue_mapping(atom_to_residue, reader.natoms)
+
+        frame_idx = 0
+        for frame in reader:
+            if frame_idx < start:
+                frame_idx += 1
+                continue
+            if stop is not None and frame_idx >= stop:
+                break
+            if (frame_idx - start) % step != 0:
+                frame_idx += 1
+                continue
+
+            coords_chunk.append(frame.coords)
+            steps.append(frame.step)
+            times.append(frame.time)
+            if len(coords_chunk) == chunk_size:
+                flush_chunk(mapping, n_residues)
+            frame_idx += 1
+
+        flush_chunk(mapping, n_residues)
+
+    if not total_chunks:
+        msg = "No frames to process"
+        raise ValueError(msg)
+
+    return TrajectorySasaSummaryResult(
+        total_areas=np.concatenate(total_chunks).astype(np.float32, copy=False),
+        steps=np.array(steps, dtype=np.int32),
+        times=np.array(times, dtype=np.float32),
+        residue_areas=np.concatenate(residue_chunks) if residue_chunks else None,
+    )
+
+
 def compute_sasa_trajectory(
     xtc_path: str | Path,
     radii: NDArray[np.floating] | list[float],

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -216,9 +216,22 @@ pub const ResidueResult = struct {
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *ResidueResult) void {
+        for (self.residues) |res| {
+            if (res.chain_id_full) |chain_id_full| {
+                self.allocator.free(chain_id_full);
+            }
+        }
         self.allocator.free(self.residues);
     }
 };
+
+fn freeResidueFullChainLabels(allocator: std.mem.Allocator, residues: []ResidueSasa) void {
+    for (residues) |res| {
+        if (res.chain_id_full) |chain_id_full| {
+            allocator.free(chain_id_full);
+        }
+    }
+}
 
 /// Aggregate atom SASA values to per-residue SASA.
 /// Atoms are grouped by (chain_id, residue_num, insertion_code).
@@ -248,6 +261,7 @@ pub fn aggregateByResidue(
     // Use a simple approach: collect unique residues and sum areas
     // For efficiency, we use a fixed-size buffer then convert to owned slice
     var residue_list = std.ArrayListUnmanaged(ResidueSasa).empty;
+    errdefer freeResidueFullChainLabels(allocator, residue_list.items);
     defer residue_list.deinit(allocator);
 
     for (0..n) |i| {
@@ -279,10 +293,16 @@ pub fn aggregateByResidue(
             residue_list.items[idx].sasa += atom_areas[i];
             residue_list.items[idx].atom_count += 1;
         } else {
+            const owned_chain_id_full = if (chain_ids_full) |full|
+                try allocator.dupe(u8, full[i])
+            else
+                null;
+            errdefer if (owned_chain_id_full) |chain_id_full| allocator.free(chain_id_full);
+
             // Add new residue
             try residue_list.append(allocator, ResidueSasa{
                 .chain_id = chain,
-                .chain_id_full = if (chain_ids_full) |full| full[i] else null,
+                .chain_id_full = owned_chain_id_full,
                 .residue_name = residue_names[i],
                 .residue_num = res_num,
                 .insertion_code = ins_code,
@@ -529,6 +549,50 @@ test "aggregateByResidue groups by full chain IDs when present" {
     try std.testing.expectEqual(@as(usize, 2), result.residues.len);
     try std.testing.expectEqualStrings("ABCD1", result.residues[0].chainLabel());
     try std.testing.expectEqualStrings("ABCD2", result.residues[1].chainLabel());
+}
+
+test "aggregateByResidue owns full chain labels independently of input" {
+    const allocator = std.testing.allocator;
+
+    const x = try allocator.alloc(f64, 1);
+    const y = try allocator.alloc(f64, 1);
+    const z = try allocator.alloc(f64, 1);
+    const r = try allocator.alloc(f64, 1);
+    const chain_id = try allocator.alloc(types.FixedString4, 1);
+    const chain_id_full = try allocator.alloc([]const u8, 1);
+    const residue = try allocator.alloc(types.FixedString5, 1);
+    const residue_num = try allocator.alloc(i32, 1);
+    const insertion_code = try allocator.alloc(types.FixedString4, 1);
+
+    x[0] = 0.0;
+    y[0] = 0.0;
+    z[0] = 0.0;
+    r[0] = 1.0;
+    chain_id[0] = types.FixedString4.fromSlice("ABCD");
+    chain_id_full[0] = try allocator.dupe(u8, "ABCD1");
+    residue[0] = types.FixedString5.fromSlice("ALA");
+    residue_num[0] = 1;
+    insertion_code[0] = types.FixedString4.fromSlice("");
+
+    var input = types.AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .chain_id = chain_id,
+        .chain_id_full = chain_id_full,
+        .residue = residue,
+        .residue_num = residue_num,
+        .insertion_code = insertion_code,
+        .allocator = allocator,
+    };
+
+    const atom_areas = [_]f64{10.0};
+    var result = try aggregateByResidue(allocator, input, atom_areas[0..]);
+    defer result.deinit();
+    input.deinit();
+
+    try std.testing.expectEqualStrings("ABCD1", result.residues[0].chainLabel());
 }
 
 test "MaxSASA lookup" {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -182,6 +182,7 @@ pub fn printPolarSummary(summary: PolarSummary) void {
 /// Per-residue SASA data
 pub const ResidueSasa = struct {
     chain_id: types.FixedString4,
+    chain_id_full: ?[]const u8 = null,
     residue_name: types.FixedString5,
     residue_num: i32,
     insertion_code: types.FixedString4,
@@ -202,6 +203,10 @@ pub const ResidueSasa = struct {
         } else {
             self.rsa = null;
         }
+    }
+
+    pub fn chainLabel(self: ResidueSasa) []const u8 {
+        return self.chain_id_full orelse self.chain_id.slice();
     }
 };
 
@@ -224,6 +229,7 @@ pub fn aggregateByResidue(
 ) !ResidueResult {
     // Check if we have the required residue info
     const chain_ids = input.chain_id orelse return error.MissingChainInfo;
+    const chain_ids_full = input.chain_id_full;
     const residue_names = input.residue orelse return error.MissingResidueInfo;
     const residue_nums = input.residue_num orelse return error.MissingResidueNumInfo;
     const insertion_codes = input.insertion_code orelse return error.MissingInsertionCodeInfo;
@@ -252,8 +258,15 @@ pub fn aggregateByResidue(
         // Find if this residue already exists
         var found_idx: ?usize = null;
         for (residue_list.items, 0..) |*res, j| {
+            const same_chain = if (chain_ids_full) |full|
+                if (res.chain_id_full) |res_full|
+                    std.mem.eql(u8, res_full, full[i])
+                else
+                    false
+            else
+                std.mem.eql(u8, res.chain_id.slice(), chain.slice());
             if (res.residue_num == res_num and
-                std.mem.eql(u8, res.chain_id.slice(), chain.slice()) and
+                same_chain and
                 std.mem.eql(u8, res.insertion_code.slice(), ins_code.slice()))
             {
                 found_idx = j;
@@ -269,6 +282,7 @@ pub fn aggregateByResidue(
             // Add new residue
             try residue_list.append(allocator, ResidueSasa{
                 .chain_id = chain,
+                .chain_id_full = if (chain_ids_full) |full| full[i] else null,
                 .residue_name = residue_names[i],
                 .residue_num = res_num,
                 .insertion_code = ins_code,
@@ -306,7 +320,7 @@ pub fn printResidueResults(residues: []const ResidueSasa) void {
 
         if (res.insertion_code.len > 0) {
             std.debug.print("{s:>5} {s:>4} {s:>5}{s:<1} {d:>10.2} {d:>6}\n", .{
-                res.chain_id.slice(),
+                res.chainLabel(),
                 res.residue_name.slice(),
                 num_str,
                 res.insertion_code.slice(),
@@ -315,7 +329,7 @@ pub fn printResidueResults(residues: []const ResidueSasa) void {
             });
         } else {
             std.debug.print("{s:>5} {s:>4} {s:>6} {d:>10.2} {d:>6}\n", .{
-                res.chain_id.slice(),
+                res.chainLabel(),
                 res.residue_name.slice(),
                 num_str,
                 res.sasa,
@@ -349,7 +363,7 @@ pub fn printResidueResultsWithRsa(residues: []const ResidueSasa) void {
 
         if (res.insertion_code.len > 0) {
             std.debug.print("{s:>5} {s:>4} {s:>5}{s:<1} {d:>10.2} {s:>6} {d:>6}\n", .{
-                res.chain_id.slice(),
+                res.chainLabel(),
                 res.residue_name.slice(),
                 num_str,
                 res.insertion_code.slice(),
@@ -359,7 +373,7 @@ pub fn printResidueResultsWithRsa(residues: []const ResidueSasa) void {
             });
         } else {
             std.debug.print("{s:>5} {s:>4} {s:>6} {d:>10.2} {s:>6} {d:>6}\n", .{
-                res.chain_id.slice(),
+                res.chainLabel(),
                 res.residue_name.slice(),
                 num_str,
                 res.sasa,
@@ -456,6 +470,65 @@ test "aggregateByResidue basic" {
     // GLY: RSA = 45.0 / 104.0 ≈ 0.433
     try std.testing.expect(result.residues[1].rsa != null);
     try std.testing.expectApproxEqRel(45.0 / 104.0, result.residues[1].rsa.?, 0.001);
+}
+
+test "aggregateByResidue groups by full chain IDs when present" {
+    const allocator = std.testing.allocator;
+
+    const x = try allocator.alloc(f64, 2);
+    defer allocator.free(x);
+    const y = try allocator.alloc(f64, 2);
+    defer allocator.free(y);
+    const z = try allocator.alloc(f64, 2);
+    defer allocator.free(z);
+    const r = try allocator.alloc(f64, 2);
+    defer allocator.free(r);
+    @memset(x, 0);
+    @memset(y, 0);
+    @memset(z, 0);
+    @memset(r, 1);
+
+    var chain_ids = try allocator.alloc(types.FixedString4, 2);
+    defer allocator.free(chain_ids);
+    chain_ids[0] = types.FixedString4.fromSlice("ABCD");
+    chain_ids[1] = types.FixedString4.fromSlice("ABCD");
+    const chain_ids_full = [_][]const u8{ "ABCD1", "ABCD2" };
+
+    var residue_names = try allocator.alloc(types.FixedString5, 2);
+    defer allocator.free(residue_names);
+    residue_names[0] = types.FixedString5.fromSlice("ALA");
+    residue_names[1] = types.FixedString5.fromSlice("ALA");
+
+    var residue_nums = try allocator.alloc(i32, 2);
+    defer allocator.free(residue_nums);
+    residue_nums[0] = 1;
+    residue_nums[1] = 1;
+
+    var insertion_codes = try allocator.alloc(types.FixedString4, 2);
+    defer allocator.free(insertion_codes);
+    insertion_codes[0] = types.FixedString4.fromSlice("");
+    insertion_codes[1] = types.FixedString4.fromSlice("");
+
+    const input = types.AtomInput{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .chain_id = chain_ids,
+        .chain_id_full = chain_ids_full[0..],
+        .residue = residue_names,
+        .residue_num = residue_nums,
+        .insertion_code = insertion_codes,
+        .allocator = allocator,
+    };
+    const atom_areas = [_]f64{ 10.0, 20.0 };
+
+    var result = try aggregateByResidue(allocator, input, atom_areas[0..]);
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), result.residues.len);
+    try std.testing.expectEqualStrings("ABCD1", result.residues[0].chainLabel());
+    try std.testing.expectEqualStrings("ABCD2", result.residues[1].chainLabel());
 }
 
 test "MaxSASA lookup" {

--- a/src/bcif_parser.zig
+++ b/src/bcif_parser.zig
@@ -560,6 +560,7 @@ const AtomSiteColumns = struct {
     pdbx_pdb_ins_code: ?usize = null,
     group_pdb: ?usize = null,
     label_alt_id: ?usize = null,
+    occupancy: ?usize = null,
     pdbx_pdb_model_num: ?usize = null,
 
     fn hasRequiredFields(self: AtomSiteColumns) bool {
@@ -733,62 +734,30 @@ pub const BcifParser = struct {
         defer residue_num_list.deinit(self.allocator);
         var insertion_code_list = std.ArrayListUnmanaged(types.FixedString4).empty;
         defer insertion_code_list.deinit(self.allocator);
+        var atom_records = std.ArrayListUnmanaged(AtomRecord).empty;
+        defer atom_records.deinit(self.allocator);
 
-        var first_alt_loc: ?u8 = null;
         var row: usize = 0;
         while (row < row_count) : (row += 1) {
-            if (!self.shouldIncludeAtom(decoded, columns, row, &first_alt_loc)) continue;
+            if (!self.shouldIncludeAtom(decoded, columns, row)) continue;
+            try atom_records.append(self.allocator, try self.atomRecordFromRow(decoded, columns, row));
+        }
 
-            const x = try scalarFloat(decoded[columns.cartn_x.?], row);
-            const y = try scalarFloat(decoded[columns.cartn_y.?], row);
-            const z = try scalarFloat(decoded[columns.cartn_z.?], row);
-            try x_list.append(self.allocator, x);
-            try y_list.append(self.allocator, y);
-            try z_list.append(self.allocator, z);
+        for (atom_records.items, 0..) |atom, i| {
+            if (!self.shouldKeepAltLoc(atom_records.items, i)) continue;
 
-            var element_enum = elem.Element.X;
-            if (columns.type_symbol) |type_col| {
-                if (scalarString(decoded[type_col], row)) |symbol| {
-                    element_enum = elem.fromSymbol(symbol);
-                }
-            }
-            try r_list.append(self.allocator, element_enum.vdwRadius());
-            try element_list.append(self.allocator, element_enum.atomicNumber());
-
-            if (columns.getResNameCol()) |res_col| {
-                try residue_list.append(self.allocator, types.FixedString5.fromSlice(scalarString(decoded[res_col], row) orelse "UNK"));
-            } else {
-                try residue_list.append(self.allocator, types.FixedString5.fromSlice("UNK"));
-            }
-
-            if (columns.getAtomNameCol()) |atom_col| {
-                try atom_name_list.append(self.allocator, types.FixedString4.fromSlice(scalarString(decoded[atom_col], row) orelse "X"));
-            } else {
-                try atom_name_list.append(self.allocator, types.FixedString4.fromSlice("X"));
-            }
-
-            if (columns.getChainCol(self.use_auth_chain)) |chain_col| {
-                const chain = scalarString(decoded[chain_col], row) orelse "";
-                try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(chain));
-                try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, chain));
-                has_extended_chain = has_extended_chain or chain.len > 4;
-            } else {
-                try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, ""));
-            }
-
-            if (columns.getResSeqCol()) |seq_col| {
-                const seq = scalarInt(decoded[seq_col], row) orelse 0;
-                try residue_num_list.append(self.allocator, std.math.cast(i32, seq) orelse 0);
-            } else {
-                try residue_num_list.append(self.allocator, 0);
-            }
-
-            if (columns.getInsCodeCol()) |ins_col| {
-                try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(scalarString(decoded[ins_col], row) orelse ""));
-            } else {
-                try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(""));
-            }
+            try x_list.append(self.allocator, atom.x);
+            try y_list.append(self.allocator, atom.y);
+            try z_list.append(self.allocator, atom.z);
+            try r_list.append(self.allocator, atom.radius);
+            try element_list.append(self.allocator, atom.element.atomicNumber());
+            try residue_list.append(self.allocator, types.FixedString5.fromSlice(atom.residue));
+            try atom_name_list.append(self.allocator, types.FixedString4.fromSlice(atom.atom_name));
+            try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(atom.chain_id));
+            try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, atom.chain_id));
+            has_extended_chain = has_extended_chain or atom.chain_id.len > 4;
+            try residue_num_list.append(self.allocator, atom.residue_num);
+            try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(atom.insertion_code));
         }
 
         const x = try x_list.toOwnedSlice(self.allocator);
@@ -849,7 +818,101 @@ pub const BcifParser = struct {
         return self.parse(mapped.data);
     }
 
-    fn shouldIncludeAtom(self: *BcifParser, decoded: []const DecodedColumn, columns: AtomSiteColumns, row: usize, first_alt_loc: *?u8) bool {
+    const AtomRecord = struct {
+        x: f64,
+        y: f64,
+        z: f64,
+        radius: f64,
+        element: elem.Element,
+        atom_name: []const u8,
+        residue: []const u8,
+        chain_id: []const u8,
+        residue_num: i32,
+        insertion_code: []const u8,
+        alt_loc: u8,
+        occupancy: f64,
+        model_num: ?u32,
+    };
+
+    fn atomRecordFromRow(self: *BcifParser, decoded: []const DecodedColumn, columns: AtomSiteColumns, row: usize) !AtomRecord {
+        const x = try scalarFloat(decoded[columns.cartn_x.?], row);
+        const y = try scalarFloat(decoded[columns.cartn_y.?], row);
+        const z = try scalarFloat(decoded[columns.cartn_z.?], row);
+
+        var element_enum = elem.Element.X;
+        if (columns.type_symbol) |type_col| {
+            if (scalarString(decoded[type_col], row)) |symbol| {
+                element_enum = elem.fromSymbol(symbol);
+            }
+        }
+
+        const atom_name = if (columns.getAtomNameCol()) |atom_col| scalarString(decoded[atom_col], row) orelse "X" else "X";
+        const residue = if (columns.getResNameCol()) |res_col| scalarString(decoded[res_col], row) orelse "UNK" else "UNK";
+        const chain_id = if (columns.getChainCol(self.use_auth_chain)) |chain_col| scalarString(decoded[chain_col], row) orelse "" else "";
+        const residue_num = if (columns.getResSeqCol()) |seq_col| blk: {
+            const seq = scalarInt(decoded[seq_col], row) orelse 0;
+            break :blk std.math.cast(i32, seq) orelse 0;
+        } else 0;
+        const insertion_code = if (columns.getInsCodeCol()) |ins_col| scalarString(decoded[ins_col], row) orelse "" else "";
+        const alt_loc: u8 = if (columns.label_alt_id) |alt_col| blk: {
+            const alt_id = scalarString(decoded[alt_col], row) orelse "";
+            break :blk if (alt_id.len == 0) ' ' else alt_id[0];
+        } else ' ';
+        const occupancy = if (columns.occupancy) |occ_col| scalarFloat(decoded[occ_col], row) catch 0.0 else 0.0;
+        const model_num = if (columns.pdbx_pdb_model_num) |model_col| blk: {
+            const model = scalarInt(decoded[model_col], row) orelse break :blk null;
+            break :blk std.math.cast(u32, model);
+        } else null;
+
+        return .{
+            .x = x,
+            .y = y,
+            .z = z,
+            .radius = element_enum.vdwRadius(),
+            .element = element_enum,
+            .atom_name = atom_name,
+            .residue = residue,
+            .chain_id = chain_id,
+            .residue_num = residue_num,
+            .insertion_code = insertion_code,
+            .alt_loc = alt_loc,
+            .occupancy = occupancy,
+            .model_num = model_num,
+        };
+    }
+
+    fn sameAltLocSite(a: AtomRecord, b: AtomRecord) bool {
+        return a.model_num == b.model_num and
+            a.residue_num == b.residue_num and
+            std.mem.eql(u8, a.chain_id, b.chain_id) and
+            std.mem.eql(u8, a.residue, b.residue) and
+            std.mem.eql(u8, a.insertion_code, b.insertion_code) and
+            std.mem.eql(u8, a.atom_name, b.atom_name);
+    }
+
+    fn shouldKeepAltLoc(self: *BcifParser, atoms: []const AtomRecord, index: usize) bool {
+        if (!self.first_alt_loc_only) return true;
+
+        const atom = atoms[index];
+        if (atom.alt_loc == ' ') return true;
+
+        var best_non_preferred: ?usize = null;
+        for (atoms, 0..) |other, other_index| {
+            if (!sameAltLocSite(atom, other)) continue;
+            if (other.alt_loc == ' ') return false;
+            if (other.alt_loc == 'A') return atom.alt_loc == 'A';
+            if (best_non_preferred) |best_index| {
+                if (other.occupancy > atoms[best_index].occupancy) {
+                    best_non_preferred = other_index;
+                }
+            } else {
+                best_non_preferred = other_index;
+            }
+        }
+        return best_non_preferred == index;
+    }
+
+    fn shouldIncludeAtom(self: *BcifParser, decoded: []const DecodedColumn, columns: AtomSiteColumns, row: usize) bool {
         if (self.atom_only) {
             if (columns.group_pdb) |col| {
                 const group = scalarString(decoded[col], row) orelse return false;
@@ -861,21 +924,6 @@ pub const BcifParser = struct {
             if (columns.type_symbol) |col| {
                 if (scalarString(decoded[col], row)) |symbol| {
                     if (std.mem.eql(u8, symbol, "H") or std.mem.eql(u8, symbol, "D")) return false;
-                }
-            }
-        }
-
-        if (self.first_alt_loc_only) {
-            if (columns.label_alt_id) |col| {
-                if (scalarString(decoded[col], row)) |alt_id| {
-                    if (alt_id.len > 0) {
-                        const alt_char = alt_id[0];
-                        if (first_alt_loc.*) |first| {
-                            if (alt_char != first) return false;
-                        } else {
-                            first_alt_loc.* = alt_char;
-                        }
-                    }
                 }
             }
         }
@@ -1373,6 +1421,8 @@ fn mapAtomSiteColumn(columns: *AtomSiteColumns, name: []const u8, idx: usize) vo
         columns.group_pdb = idx;
     } else if (eqlIgnoreCase(name, "label_alt_id")) {
         columns.label_alt_id = idx;
+    } else if (eqlIgnoreCase(name, "occupancy")) {
+        columns.occupancy = idx;
     } else if (eqlIgnoreCase(name, "pdbx_PDB_model_num")) {
         columns.pdbx_pdb_model_num = idx;
     }
@@ -1456,6 +1506,8 @@ const BuildBcifOptions = struct {
     null_first_model: bool = false,
     include_long_chain: bool = false,
     include_very_long_chain: bool = false,
+    include_alt_later_b_only: bool = false,
+    include_alt_across_models: bool = false,
 };
 
 fn buildMinimalBcif(options: BuildBcifOptions) ![]u8 {
@@ -1475,8 +1527,18 @@ fn buildMinimalBcif(options: BuildBcifOptions) ![]u8 {
         "ABCD"
     else
         "A";
-    try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = first_chain, .seq = 1, .x = 10.0, .y = 20.0, .z = 30.0, .model = 1 });
-    try rows.append(allocator, .{ .group = "ATOM", .element = "N", .atom = "N", .residue = "ALA", .chain = second_chain, .seq = 1, .x = 11.0, .y = 21.0, .z = 32.0, .model = 1 });
+    if (options.include_alt_across_models) {
+        try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = "A", .seq = 1, .alt = "A", .x = 10.0, .y = 20.0, .z = 30.0, .model = 1 });
+        try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = "A", .seq = 1, .alt = "B", .x = 12.0, .y = 22.0, .z = 32.0, .model = 1 });
+        try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = "A", .seq = 1, .alt = "B", .x = 14.0, .y = 24.0, .z = 34.0, .model = 2 });
+    } else if (options.include_alt_later_b_only) {
+        try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = "A", .seq = 1, .alt = "A", .x = 10.0, .y = 20.0, .z = 30.0, .model = 1 });
+        try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = "A", .seq = 1, .alt = "B", .x = 12.0, .y = 22.0, .z = 32.0, .model = 1 });
+        try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "GLY", .chain = "A", .seq = 2, .alt = "B", .x = 14.0, .y = 24.0, .z = 34.0, .model = 1 });
+    } else {
+        try rows.append(allocator, .{ .group = "ATOM", .element = "C", .atom = "CA", .residue = "ALA", .chain = first_chain, .seq = 1, .x = 10.0, .y = 20.0, .z = 30.0, .model = 1 });
+        try rows.append(allocator, .{ .group = "ATOM", .element = "N", .atom = "N", .residue = "ALA", .chain = second_chain, .seq = 1, .x = 11.0, .y = 21.0, .z = 32.0, .model = 1 });
+    }
     if (options.include_hydrogen) {
         try rows.append(allocator, .{ .group = "ATOM", .element = "H", .atom = "H", .residue = "ALA", .chain = "A", .seq = 1, .x = 12.0, .y = 22.0, .z = 33.0, .model = 1 });
     }
@@ -1521,7 +1583,7 @@ fn buildMinimalBcif(options: BuildBcifOptions) ![]u8 {
     if (!options.omit_chain) try packStringColumn(allocator, &bytes, "label_asym_id", rows.items, TestAtomRow.chainValue);
     try packIntColumn(allocator, &bytes, "label_seq_id", rows.items, TestAtomRow.seqValue, false);
     try packStringColumn(allocator, &bytes, "pdbx_PDB_ins_code", rows.items, TestAtomRow.emptyValue);
-    try packStringColumn(allocator, &bytes, "label_alt_id", rows.items, TestAtomRow.emptyValue);
+    try packStringColumn(allocator, &bytes, "label_alt_id", rows.items, TestAtomRow.altValue);
     if (!options.omit_model) try packIntColumn(allocator, &bytes, "pdbx_PDB_model_num", rows.items, TestAtomRow.modelValue, options.null_first_model);
     try packFloatColumn(allocator, &bytes, "Cartn_x", rows.items, TestAtomRow.xValue);
     try packFloatColumn(allocator, &bytes, "Cartn_y", rows.items, TestAtomRow.yValue);
@@ -1686,6 +1748,7 @@ const TestAtomRow = struct {
     y: f32,
     z: f32,
     model: i32,
+    alt: []const u8 = "",
 
     fn groupValue(row: TestAtomRow) []const u8 {
         return row.group;
@@ -1704,6 +1767,9 @@ const TestAtomRow = struct {
     }
     fn emptyValue(_: TestAtomRow) []const u8 {
         return "";
+    }
+    fn altValue(row: TestAtomRow) []const u8 {
+        return row.alt;
     }
     fn seqValue(row: TestAtomRow) i32 {
         return row.seq;
@@ -1941,6 +2007,58 @@ test "parse BinaryCIF with inline CCD data" {
     try std.testing.expectEqual(@as(u16, 0), comp.bonds[0].atom_idx_1);
     try std.testing.expectEqual(@as(u16, 1), comp.bonds[0].atom_idx_2);
     try std.testing.expectEqual(.double, comp.bonds[0].order);
+}
+
+test "parse BinaryCIF default model selection includes all models" {
+    const source = try buildMinimalBcif(.{ .include_second_model = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), input.atomCount());
+    try std.testing.expectEqualStrings("B", input.chain_id.?[2].slice());
+}
+
+test "parse BinaryCIF explicit model selection filters requested model" {
+    const source = try buildMinimalBcif(.{ .include_second_model = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    parser.model_num = 2;
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), input.atomCount());
+    try std.testing.expectEqualStrings("B", input.chain_id.?[0].slice());
+}
+
+test "parse BinaryCIF altLoc selection is per atom site and keeps later B-only sites" {
+    const source = try buildMinimalBcif(.{ .include_alt_later_b_only = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
+    try std.testing.expectEqual(@as(i32, 2), input.residue_num.?[1]);
+}
+
+test "parse BinaryCIF altLoc selection is scoped by model" {
+    const source = try buildMinimalBcif(.{ .include_alt_across_models = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
 }
 
 test "parse BinaryCIF applies filters" {

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -83,6 +83,51 @@ fn cIo() std.Io {
     return std.Io.Threaded.global_single_threaded.io();
 }
 
+fn isPositiveFinite(comptime T: type, value: T) bool {
+    return std.math.isFinite(value) and value > 0.0;
+}
+
+fn isNonNegativeFinite(comptime T: type, value: T) bool {
+    return std.math.isFinite(value) and value >= 0.0;
+}
+
+fn validateAtomArraysF64(
+    x: [*]const f64,
+    y: [*]const f64,
+    z: [*]const f64,
+    radii: [*]const f64,
+    n_atoms: usize,
+) bool {
+    for (0..n_atoms) |i| {
+        if (!std.math.isFinite(x[i]) or
+            !std.math.isFinite(y[i]) or
+            !std.math.isFinite(z[i]) or
+            !isNonNegativeFinite(f64, radii[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+fn validateBatchArraysF32(
+    coordinates: [*]const f32,
+    n_frames: usize,
+    n_atoms: usize,
+    radii: [*]const f32,
+) bool {
+    const frame_atoms = std.math.mul(usize, n_frames, n_atoms) catch return false;
+    const coordinate_count = std.math.mul(usize, frame_atoms, 3) catch return false;
+
+    for (coordinates[0..coordinate_count]) |coordinate| {
+        if (!std.math.isFinite(coordinate)) return false;
+    }
+    for (radii[0..n_atoms]) |radius| {
+        if (!isNonNegativeFinite(f32, radius)) return false;
+    }
+    return true;
+}
+
 /// Get library version string.
 export fn zsasa_version() callconv(.c) [*:0]const u8 {
     return VERSION;
@@ -115,7 +160,9 @@ export fn zsasa_calc_sr(
     total_area: *f64,
 ) callconv(.c) c_int {
     // Validate input
-    if (n_atoms == 0 or n_points == 0 or probe_radius <= 0.0) {
+    if (n_atoms == 0 or n_points == 0 or !isPositiveFinite(f64, probe_radius) or
+        !validateAtomArraysF64(x, y, z, radii, n_atoms))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -189,7 +236,9 @@ export fn zsasa_calc_sr_bitmask(
     atom_areas: [*]f64,
     total_area: *f64,
 ) callconv(.c) c_int {
-    if (n_atoms == 0 or n_points == 0 or probe_radius <= 0.0) {
+    if (n_atoms == 0 or n_points == 0 or !isPositiveFinite(f64, probe_radius) or
+        !validateAtomArraysF64(x, y, z, radii, n_atoms))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -245,7 +294,10 @@ export fn zsasa_calc_sr_bitmask_corrected(
     atom_areas: [*]f64,
     total_area: *f64,
 ) callconv(.c) c_int {
-    if (n_atoms == 0 or n_points == 0 or probe_radius <= 0.0 or correction_coeff < 0.0 or !std.math.isFinite(correction_coeff)) {
+    if (n_atoms == 0 or n_points == 0 or !isPositiveFinite(f64, probe_radius) or
+        correction_coeff < 0.0 or !std.math.isFinite(correction_coeff) or
+        !validateAtomArraysF64(x, y, z, radii, n_atoms))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -408,7 +460,9 @@ fn calculateBatch(
     algorithm: BatchAlgorithm,
 ) c_int {
     // Validate input
-    if (n_frames == 0 or n_atoms == 0 or param == 0 or probe_radius <= 0.0) {
+    if (n_frames == 0 or n_atoms == 0 or param == 0 or !isPositiveFinite(f32, probe_radius) or
+        !validateBatchArraysF32(coordinates, n_frames, n_atoms, radii))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -674,7 +728,9 @@ fn calculateBatchF32(
     atom_areas: [*]f32,
     algorithm: BatchAlgorithm,
 ) c_int {
-    if (n_frames == 0 or n_atoms == 0 or param == 0 or probe_radius <= 0.0) {
+    if (n_frames == 0 or n_atoms == 0 or param == 0 or !isPositiveFinite(f32, probe_radius) or
+        !validateBatchArraysF32(coordinates, n_frames, n_atoms, radii))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -880,7 +936,10 @@ fn calculateBatchBitmask(
     correction_coeff: f64,
     atom_areas: [*]f32,
 ) c_int {
-    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or probe_radius <= 0.0 or correction_coeff < 0.0 or !std.math.isFinite(correction_coeff)) {
+    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or !isPositiveFinite(f32, probe_radius) or
+        correction_coeff < 0.0 or !std.math.isFinite(correction_coeff) or
+        !validateBatchArraysF32(coordinates, n_frames, n_atoms, radii))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -1054,7 +1113,10 @@ fn calculateBatchBitmaskF32(
     correction_coeff: f64,
     atom_areas: [*]f32,
 ) c_int {
-    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or probe_radius <= 0.0 or correction_coeff < 0.0 or !std.math.isFinite(correction_coeff)) {
+    if (n_frames == 0 or n_atoms == 0 or n_points == 0 or !isPositiveFinite(f32, probe_radius) or
+        correction_coeff < 0.0 or !std.math.isFinite(correction_coeff) or
+        !validateBatchArraysF32(coordinates, n_frames, n_atoms, radii))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -1276,7 +1338,9 @@ export fn zsasa_calc_lr(
     total_area: *f64,
 ) callconv(.c) c_int {
     // Validate input
-    if (n_atoms == 0 or n_slices == 0 or probe_radius <= 0.0) {
+    if (n_atoms == 0 or n_slices == 0 or !isPositiveFinite(f64, probe_radius) or
+        !validateAtomArraysF64(x, y, z, radii, n_atoms))
+    {
         return ZSASA_ERROR_INVALID_INPUT;
     }
 
@@ -1737,6 +1801,41 @@ test "zsasa_calc_sr with empty input returns error" {
     try std.testing.expectEqual(ZSASA_ERROR_INVALID_INPUT, result);
 }
 
+test "zsasa_calc_sr rejects non-finite inputs" {
+    var x = [_]f64{0.0};
+    var y = [_]f64{0.0};
+    var z = [_]f64{0.0};
+    var radii = [_]f64{1.5};
+    var atom_areas = [_]f64{0.0};
+    var total_area: f64 = 0.0;
+
+    x[0] = std.math.nan(f64);
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_sr(&x, &y, &z, &radii, 1, 100, 1.4, 1, &atom_areas, &total_area),
+    );
+
+    x[0] = 0.0;
+    y[0] = std.math.inf(f64);
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_sr(&x, &y, &z, &radii, 1, 100, 1.4, 1, &atom_areas, &total_area),
+    );
+
+    y[0] = 0.0;
+    radii[0] = std.math.nan(f64);
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_sr(&x, &y, &z, &radii, 1, 100, 1.4, 1, &atom_areas, &total_area),
+    );
+
+    radii[0] = 1.5;
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_sr(&x, &y, &z, &radii, 1, 100, std.math.inf(f64), 1, &atom_areas, &total_area),
+    );
+}
+
 test "zsasa_calc_sr single atom" {
     const x = [_]f64{0.0};
     const y = [_]f64{0.0};
@@ -1789,6 +1888,34 @@ test "zsasa_calc_lr single atom" {
     // Expected: 4π * (1.5 + 1.4)² ≈ 105.68 Ų
     try std.testing.expect(total_area > 100.0 and total_area < 110.0);
     try std.testing.expectEqual(total_area, atom_areas[0]);
+}
+
+test "zsasa_calc_lr rejects non-finite inputs" {
+    var x = [_]f64{0.0};
+    var y = [_]f64{0.0};
+    var z = [_]f64{0.0};
+    var radii = [_]f64{1.5};
+    var atom_areas = [_]f64{0.0};
+    var total_area: f64 = 0.0;
+
+    z[0] = -std.math.inf(f64);
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_lr(&x, &y, &z, &radii, 1, 20, 1.4, 1, &atom_areas, &total_area),
+    );
+
+    z[0] = 0.0;
+    radii[0] = std.math.inf(f64);
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_lr(&x, &y, &z, &radii, 1, 20, 1.4, 1, &atom_areas, &total_area),
+    );
+
+    radii[0] = 1.5;
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_lr(&x, &y, &z, &radii, 1, 20, std.math.nan(f64), 1, &atom_areas, &total_area),
+    );
 }
 
 test "zsasa_calc_sr_bitmask single atom" {
@@ -1858,6 +1985,31 @@ test "zsasa_calc_sr_bitmask with unsupported n_points returns error" {
     try std.testing.expectEqual(ZSASA_ERROR_UNSUPPORTED_N_POINTS, result);
 }
 
+test "zsasa_calc_sr_batch rejects non-finite inputs" {
+    var coordinates = [_]f32{ 0.0, 0.0, 0.0 };
+    var radii = [_]f32{1.5};
+    var atom_areas = [_]f32{0.0};
+
+    coordinates[0] = std.math.nan(f32);
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_sr_batch(&coordinates, 1, 1, &radii, 100, 1.4, 1, &atom_areas),
+    );
+
+    coordinates[0] = 0.0;
+    radii[0] = std.math.inf(f32);
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_sr_batch(&coordinates, 1, 1, &radii, 100, 1.4, 1, &atom_areas),
+    );
+
+    radii[0] = 1.5;
+    try std.testing.expectEqual(
+        ZSASA_ERROR_INVALID_INPUT,
+        zsasa_calc_sr_batch(&coordinates, 1, 1, &radii, 100, std.math.inf(f32), 1, &atom_areas),
+    );
+}
+
 test "zsasa_calc_sr_batch_bitmask basic" {
     // 2 frames, 1 atom each
     const coordinates = [_]f32{
@@ -1896,7 +2048,7 @@ test "zsasa_calc_sr_batch_bitmask with unsupported n_points returns error" {
         1,
         1,
         &radii,
-        100, // Not supported
+        2000, // Not supported
         1.4,
         1,
         &atom_areas,
@@ -2562,7 +2714,7 @@ export fn zsasa_batch_dir_process(
         setError(error_code, ZSASA_ERROR_INVALID_INPUT);
         return null;
     }
-    if (n_points == 0 or !(probe_radius > 0.0)) {
+    if (n_points == 0 or !isPositiveFinite(f64, probe_radius)) {
         setError(error_code, ZSASA_ERROR_INVALID_INPUT);
         return null;
     }

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -1204,51 +1204,82 @@ fn applyBuiltinClassifier(
 /// Delegates to sdf_parser.loadSdfComponents.
 const loadSdfComponents = sdf_parser.loadSdfComponents;
 
-/// Print per-chain SASA results
-fn printPerChainResults(chain_ids: []const types.FixedString4, atom_areas: []const f64) void {
-    // Use a simple approach: iterate through to find unique chains and sum areas
-    // For efficiency, we'll use a fixed-size buffer for up to 64 unique chains
-    const max_chains = 64;
-    var chain_names: [max_chains]types.FixedString4 = undefined;
-    var chain_areas: [max_chains]f64 = undefined;
-    var chain_counts: [max_chains]usize = undefined;
+const ChainSasaSummary = struct {
+    chain_id: types.FixedString4,
+    chain_id_full: ?[]const u8 = null,
+    area: f64,
+    atom_count: usize,
+
+    fn label(self: ChainSasaSummary) []const u8 {
+        return self.chain_id_full orelse self.chain_id.slice();
+    }
+};
+
+fn sameChainSummary(summary: ChainSasaSummary, chain_id: types.FixedString4, chain_id_full: ?[]const u8) bool {
+    if (chain_id_full) |full| {
+        if (summary.chain_id_full) |summary_full| {
+            return std.mem.eql(u8, summary_full, full);
+        }
+        return false;
+    }
+    if (summary.chain_id_full != null) return false;
+    return std.mem.eql(u8, summary.chain_id.slice(), chain_id.slice());
+}
+
+fn buildPerChainSummaries(
+    chain_ids: []const types.FixedString4,
+    chain_ids_full: ?[]const []const u8,
+    atom_areas: []const f64,
+    summaries: []ChainSasaSummary,
+) usize {
     var num_chains: usize = 0;
-    var warned_overflow = false;
 
     for (chain_ids, 0..) |chain_id, i| {
-        // Find if this chain already exists
+        const full = if (chain_ids_full) |full_ids| full_ids[i] else null;
         var found_idx: ?usize = null;
-        for (0..num_chains) |j| {
-            if (std.mem.eql(u8, chain_names[j].slice(), chain_id.slice())) {
+        for (summaries[0..num_chains], 0..) |summary, j| {
+            if (sameChainSummary(summary, chain_id, full)) {
                 found_idx = j;
                 break;
             }
         }
 
         if (found_idx) |idx| {
-            // Add to existing chain
-            chain_areas[idx] += atom_areas[i];
-            chain_counts[idx] += 1;
-        } else if (num_chains < max_chains) {
-            // Add new chain
-            chain_names[num_chains] = chain_id;
-            chain_areas[num_chains] = atom_areas[i];
-            chain_counts[num_chains] = 1;
+            summaries[idx].area += atom_areas[i];
+            summaries[idx].atom_count += 1;
+        } else if (num_chains < summaries.len) {
+            summaries[num_chains] = .{
+                .chain_id = chain_id,
+                .chain_id_full = full,
+                .area = atom_areas[i],
+                .atom_count = 1,
+            };
             num_chains += 1;
-        } else if (!warned_overflow) {
-            // Warn once when limit is exceeded
-            std.debug.print("Warning: More than {d} unique chains; some chains omitted from summary\n", .{max_chains});
-            warned_overflow = true;
         }
+    }
+
+    return num_chains;
+}
+
+/// Print per-chain SASA results
+fn printPerChainResults(chain_ids: []const types.FixedString4, chain_ids_full: ?[]const []const u8, atom_areas: []const f64) void {
+    // Use a simple approach: iterate through to find unique chains and sum areas
+    // For efficiency, we'll use a fixed-size buffer for up to 64 unique chains
+    const max_chains = 64;
+    var summaries: [max_chains]ChainSasaSummary = undefined;
+    const num_chains = buildPerChainSummaries(chain_ids, chain_ids_full, atom_areas, summaries[0..]);
+
+    if (chain_ids.len > 0 and num_chains == max_chains) {
+        std.debug.print("Warning: More than {d} unique chains; some chains omitted from summary\n", .{max_chains});
     }
 
     if (num_chains > 0) {
         std.debug.print("\nPer-chain SASA:\n", .{});
         for (0..num_chains) |i| {
             std.debug.print("  {s}: {d:.2} Å² ({d} atoms)\n", .{
-                chain_names[i].slice(),
-                chain_areas[i],
-                chain_counts[i],
+                summaries[i].label(),
+                summaries[i].area,
+                summaries[i].atom_count,
             });
         }
     }
@@ -1646,7 +1677,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
 
         // Print per-chain results if chain info is available
         if (input.chain_id) |chain_ids| {
-            printPerChainResults(chain_ids, result.atom_areas);
+            printPerChainResults(chain_ids, input.chain_id_full, result.atom_areas);
         }
 
         // Print per-residue results if requested
@@ -2099,6 +2130,27 @@ test "calc default CCD includes HETATM like explicit CCD" {
 
     try std.testing.expectEqual(@as(usize, 2), try readAtomAreasLenFromJson(allocator, default_out));
     try std.testing.expectEqual(@as(usize, 2), try readAtomAreasLenFromJson(allocator, explicit_out));
+}
+
+test "per-chain summaries prefer full chain IDs over truncated prefixes" {
+    const chain_ids = [_]types.FixedString4{
+        types.FixedString4.fromSlice("ABCD"),
+        types.FixedString4.fromSlice("ABCD"),
+        types.FixedString4.fromSlice("ABCD"),
+    };
+    const chain_ids_full = [_][]const u8{ "ABCD1", "ABCD2", "ABCD1" };
+    const atom_areas = [_]f64{ 10.0, 20.0, 5.0 };
+    var summaries: [4]ChainSasaSummary = undefined;
+
+    const n = buildPerChainSummaries(chain_ids[0..], chain_ids_full[0..], atom_areas[0..], summaries[0..]);
+
+    try std.testing.expectEqual(@as(usize, 2), n);
+    try std.testing.expectEqualStrings("ABCD1", summaries[0].label());
+    try std.testing.expectEqual(@as(f64, 15.0), summaries[0].area);
+    try std.testing.expectEqual(@as(usize, 2), summaries[0].atom_count);
+    try std.testing.expectEqualStrings("ABCD2", summaries[1].label());
+    try std.testing.expectEqual(@as(f64, 20.0), summaries[1].area);
+    try std.testing.expectEqual(@as(usize, 1), summaries[1].atom_count);
 }
 
 test "calc workflow applies fields when CLI did not override" {

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -1226,13 +1226,19 @@ fn sameChainSummary(summary: ChainSasaSummary, chain_id: types.FixedString4, cha
     return std.mem.eql(u8, summary.chain_id.slice(), chain_id.slice());
 }
 
+const PerChainBuildResult = struct {
+    count: usize,
+    overflow: bool,
+};
+
 fn buildPerChainSummaries(
     chain_ids: []const types.FixedString4,
     chain_ids_full: ?[]const []const u8,
     atom_areas: []const f64,
     summaries: []ChainSasaSummary,
-) usize {
+) PerChainBuildResult {
     var num_chains: usize = 0;
+    var overflow = false;
 
     for (chain_ids, 0..) |chain_id, i| {
         const full = if (chain_ids_full) |full_ids| full_ids[i] else null;
@@ -1255,10 +1261,12 @@ fn buildPerChainSummaries(
                 .atom_count = 1,
             };
             num_chains += 1;
+        } else {
+            overflow = true;
         }
     }
 
-    return num_chains;
+    return .{ .count = num_chains, .overflow = overflow };
 }
 
 /// Print per-chain SASA results
@@ -1267,9 +1275,10 @@ fn printPerChainResults(chain_ids: []const types.FixedString4, chain_ids_full: ?
     // For efficiency, we'll use a fixed-size buffer for up to 64 unique chains
     const max_chains = 64;
     var summaries: [max_chains]ChainSasaSummary = undefined;
-    const num_chains = buildPerChainSummaries(chain_ids, chain_ids_full, atom_areas, summaries[0..]);
+    const build_result = buildPerChainSummaries(chain_ids, chain_ids_full, atom_areas, summaries[0..]);
+    const num_chains = build_result.count;
 
-    if (chain_ids.len > 0 and num_chains == max_chains) {
+    if (build_result.overflow) {
         std.debug.print("Warning: More than {d} unique chains; some chains omitted from summary\n", .{max_chains});
     }
 
@@ -2142,9 +2151,10 @@ test "per-chain summaries prefer full chain IDs over truncated prefixes" {
     const atom_areas = [_]f64{ 10.0, 20.0, 5.0 };
     var summaries: [4]ChainSasaSummary = undefined;
 
-    const n = buildPerChainSummaries(chain_ids[0..], chain_ids_full[0..], atom_areas[0..], summaries[0..]);
+    const build_result = buildPerChainSummaries(chain_ids[0..], chain_ids_full[0..], atom_areas[0..], summaries[0..]);
 
-    try std.testing.expectEqual(@as(usize, 2), n);
+    try std.testing.expectEqual(@as(usize, 2), build_result.count);
+    try std.testing.expect(!build_result.overflow);
     try std.testing.expectEqualStrings("ABCD1", summaries[0].label());
     try std.testing.expectEqual(@as(f64, 15.0), summaries[0].area);
     try std.testing.expectEqual(@as(usize, 2), summaries[0].atom_count);

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -1317,9 +1317,12 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
         std.debug.print("Usage: zsasa calc [OPTIONS] [input] [output.json]\n", .{});
         return error.MissingArgument;
     };
+    const input_format = format_detect.detectInputFormat(input_path);
+    const effective_classifier: ?ClassifierType = effective_args.classifier_type orelse
+        if (effective_args.config_path == null and input_format != .json) .ccd else null;
 
     // CCD classifier implies HETATM inclusion (the whole point is classifying non-standard residues)
-    if (effective_args.classifier_type) |ct| {
+    if (effective_classifier) |ct| {
         if (ct == .ccd and !effective_args.include_hetatm) {
             effective_args.include_hetatm = true;
         }
@@ -1387,9 +1390,6 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
     // Apply classifier (--config takes precedence over --classifier)
     // Default: ccd for PDB/mmCIF input (ProtOr-compatible with CCD extension)
     timer = std.Io.Timestamp.now(io, .awake);
-    const input_format = format_detect.detectInputFormat(effective_args.input_path.?);
-    const effective_classifier: ?ClassifierType = effective_args.classifier_type orelse
-        if (effective_args.config_path == null and input_format != .json) .ccd else null;
 
     if (effective_args.config_path != null or effective_classifier != null) {
         // Warn if both are specified
@@ -2051,6 +2051,54 @@ test "ensureCalcOutputParentDir creates nested output parent directories" {
 
     try ensureCalcOutputParentDir(std.testing.io, output_path);
     _ = try tmp_dir.dir.statFile(std.testing.io, "nested/deeper", .{});
+}
+
+fn readAtomAreasLenFromJson(allocator: std.mem.Allocator, path: []const u8) !usize {
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, path, allocator, .limited(4096));
+    defer allocator.free(content);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
+    defer parsed.deinit();
+    return parsed.value.object.get("atom_areas").?.array.items.len;
+}
+
+test "calc default CCD includes HETATM like explicit CCD" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const pdb_path = try std.fs.path.join(allocator, &.{ root, "hetatm.pdb" });
+    defer allocator.free(pdb_path);
+    const default_out = try std.fs.path.join(allocator, &.{ root, "default.json" });
+    defer allocator.free(default_out);
+    const explicit_out = try std.fs.path.join(allocator, &.{ root, "explicit.json" });
+    defer allocator.free(explicit_out);
+
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = pdb_path, .data = "ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "HETATM    2  O   HOH A   2      20.000   0.000   0.000  1.00 20.00           O  \n" ++
+        "END\n" });
+
+    try run(allocator, std.testing.io, .{
+        .input_path = pdb_path,
+        .output_path = default_out,
+        .n_threads = 1,
+        .n_points = 8,
+        .quiet = true,
+    });
+    try run(allocator, std.testing.io, .{
+        .input_path = pdb_path,
+        .output_path = explicit_out,
+        .n_threads = 1,
+        .n_points = 8,
+        .classifier_type = .ccd,
+        .quiet = true,
+    });
+
+    try std.testing.expectEqual(@as(usize, 2), try readAtomAreasLenFromJson(allocator, default_out));
+    try std.testing.expectEqual(@as(usize, 2), try readAtomAreasLenFromJson(allocator, explicit_out));
 }
 
 test "calc workflow applies fields when CLI did not override" {

--- a/src/compressed.zig
+++ b/src/compressed.zig
@@ -7,11 +7,11 @@ const zstd = @import("zstd.zig");
 pub const ReadError = gzip.GzipError || zstd.ZstdError || error{NotCompressed};
 
 pub fn isGzip(path: []const u8) bool {
-    return std.mem.endsWith(u8, path, ".gz");
+    return std.ascii.endsWithIgnoreCase(path, ".gz");
 }
 
 pub fn isZstd(path: []const u8) bool {
-    return std.mem.endsWith(u8, path, ".zst");
+    return std.ascii.endsWithIgnoreCase(path, ".zst");
 }
 
 pub fn isCompressed(path: []const u8) bool {
@@ -27,6 +27,31 @@ pub fn read(allocator: std.mem.Allocator, path: []const u8) ReadError![]u8 {
 
 test "isCompressed recognizes gzip and zstd" {
     try std.testing.expect(isCompressed("file.cif.gz"));
+    try std.testing.expect(isCompressed("file.cif.GZ"));
     try std.testing.expect(isCompressed("file.cif.zst"));
+    try std.testing.expect(isCompressed("file.cif.ZST"));
     try std.testing.expect(!isCompressed("file.cif"));
+}
+
+test "read accepts uppercase gzip extension" {
+    const allocator = std.testing.allocator;
+
+    const gz_data = [_]u8{
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+        0x01, 0x0c, 0x00, 0xf3, 0xff, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
+        0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a, 0xd5, 0xe0, 0x39,
+        0xb7, 0x0c, 0x00, 0x00, 0x00,
+    };
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "test.PDB.GZ", .data = &gz_data });
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "test.PDB.GZ", allocator);
+    defer allocator.free(tmp_path);
+
+    const content = try read(allocator, tmp_path);
+    defer allocator.free(content);
+
+    try std.testing.expectEqualStrings("Hello world\n", content);
 }

--- a/src/format_detect.zig
+++ b/src/format_detect.zig
@@ -39,29 +39,18 @@ pub const supported_extensions = [_][]const u8{
 
 /// Check if filename has a supported structure file extension
 pub fn isSupportedFile(name: []const u8) bool {
-    // Check lowercase extensions
     for (supported_extensions) |ext| {
-        if (std.mem.endsWith(u8, name, ext)) return true;
+        if (std.ascii.endsWithIgnoreCase(name, ext)) return true;
     }
-    // Check uppercase extensions (.PDB, .CIF, .ENT)
-    if (std.mem.endsWith(u8, name, ".PDB")) return true;
-    if (std.mem.endsWith(u8, name, ".CIF")) return true;
-    if (std.mem.endsWith(u8, name, ".ENT")) return true;
-    if (std.mem.endsWith(u8, name, ".JSON")) return true;
-    if (std.mem.endsWith(u8, name, ".BCIF")) return true;
-    if (std.mem.endsWith(u8, name, ".MMCIF")) return true;
-    if (std.mem.endsWith(u8, name, ".mmCIF")) return true;
-    if (std.mem.endsWith(u8, name, ".SDF")) return true;
-    if (std.mem.endsWith(u8, name, ".MOL")) return true;
     return false;
 }
 
 /// Strip supported compression extension from path.
 fn stripCompressionExt(path: []const u8) []const u8 {
-    if (std.mem.endsWith(u8, path, ".gz")) {
+    if (std.ascii.endsWithIgnoreCase(path, ".gz")) {
         return path[0 .. path.len - 3];
     }
-    if (std.mem.endsWith(u8, path, ".zst")) {
+    if (std.ascii.endsWithIgnoreCase(path, ".zst")) {
         return path[0 .. path.len - 4];
     }
     return path;
@@ -72,27 +61,19 @@ pub fn detectInputFormat(path: []const u8) InputFormat {
     const base = stripCompressionExt(path);
 
     // BinaryCIF formats (detect before mmCIF)
-    if (std.mem.endsWith(u8, base, ".bcif")) return .bcif;
-    if (std.mem.endsWith(u8, base, ".BCIF")) return .bcif;
+    if (std.ascii.endsWithIgnoreCase(base, ".bcif")) return .bcif;
 
     // mmCIF formats
-    if (std.mem.endsWith(u8, base, ".cif")) return .mmcif;
-    if (std.mem.endsWith(u8, base, ".mmcif")) return .mmcif;
-    if (std.mem.endsWith(u8, base, ".CIF")) return .mmcif;
-    if (std.mem.endsWith(u8, base, ".MMCIF")) return .mmcif;
-    if (std.mem.endsWith(u8, base, ".mmCIF")) return .mmcif;
+    if (std.ascii.endsWithIgnoreCase(base, ".cif")) return .mmcif;
+    if (std.ascii.endsWithIgnoreCase(base, ".mmcif")) return .mmcif;
 
     // PDB formats
-    if (std.mem.endsWith(u8, base, ".pdb")) return .pdb;
-    if (std.mem.endsWith(u8, base, ".PDB")) return .pdb;
-    if (std.mem.endsWith(u8, base, ".ent")) return .pdb;
-    if (std.mem.endsWith(u8, base, ".ENT")) return .pdb;
+    if (std.ascii.endsWithIgnoreCase(base, ".pdb")) return .pdb;
+    if (std.ascii.endsWithIgnoreCase(base, ".ent")) return .pdb;
 
     // SDF/MOL formats
-    if (std.mem.endsWith(u8, base, ".sdf")) return .sdf;
-    if (std.mem.endsWith(u8, base, ".SDF")) return .sdf;
-    if (std.mem.endsWith(u8, base, ".mol")) return .sdf;
-    if (std.mem.endsWith(u8, base, ".MOL")) return .sdf;
+    if (std.ascii.endsWithIgnoreCase(base, ".sdf")) return .sdf;
+    if (std.ascii.endsWithIgnoreCase(base, ".mol")) return .sdf;
 
     // Default to JSON
     return .json;
@@ -154,6 +135,18 @@ test "detectInputFormat handles .gz compressed files" {
     try std.testing.expectEqual(InputFormat.mmcif, detectInputFormat("file.cif.zst"));
     try std.testing.expectEqual(InputFormat.json, detectInputFormat("file.json.gz"));
     try std.testing.expectEqual(InputFormat.json, detectInputFormat("file.json.zst"));
+}
+
+test "format detection handles uppercase compressed suffixes" {
+    try std.testing.expect(isSupportedFile("MODEL.PDB.GZ"));
+    try std.testing.expect(isSupportedFile("MODEL.CIF.ZST"));
+    try std.testing.expect(isSupportedFile("MODEL.BCIF.GZ"));
+    try std.testing.expect(isSupportedFile("MODEL.SDF.ZST"));
+
+    try std.testing.expectEqual(InputFormat.pdb, detectInputFormat("MODEL.PDB.GZ"));
+    try std.testing.expectEqual(InputFormat.mmcif, detectInputFormat("MODEL.CIF.ZST"));
+    try std.testing.expectEqual(InputFormat.bcif, detectInputFormat("MODEL.BCIF.GZ"));
+    try std.testing.expectEqual(InputFormat.sdf, detectInputFormat("MODEL.SDF.ZST"));
 }
 
 test "isSupportedFile accepts SDF/MOL files" {

--- a/src/json_writer.zig
+++ b/src/json_writer.zig
@@ -470,6 +470,7 @@ pub fn writeSasaResult(allocator: Allocator, io: std.Io, result: SasaResult, pat
 pub const ResidueMap = struct {
     allocator: Allocator,
     residue_chain: []const types.FixedString4,
+    residue_chain_full: ?[]const []const u8 = null,
     residue_name: []const types.FixedString5,
     residue_number: []const i32,
     residue_insertion_code: []const types.FixedString4,
@@ -483,6 +484,10 @@ pub const ResidueMap = struct {
 
     pub fn deinit(self: *ResidueMap) void {
         self.allocator.free(self.residue_chain);
+        if (self.residue_chain_full) |chains| {
+            for (chains) |chain| self.allocator.free(chain);
+            self.allocator.free(chains);
+        }
         self.allocator.free(self.residue_name);
         self.allocator.free(self.residue_number);
         self.allocator.free(self.residue_insertion_code);
@@ -495,14 +500,20 @@ pub const ResidueMap = struct {
 
 fn sameResidue(
     chain_ids: []const types.FixedString4,
+    chain_ids_full: ?[]const []const u8,
     residue_names: []const types.FixedString5,
     residue_nums: []const i32,
     insertion_codes: []const types.FixedString4,
     a: usize,
     b: usize,
 ) bool {
+    const same_chain = if (chain_ids_full) |full|
+        std.mem.eql(u8, full[a], full[b])
+    else
+        std.mem.eql(u8, chain_ids[a].slice(), chain_ids[b].slice());
+
     return residue_nums[a] == residue_nums[b] and
-        std.mem.eql(u8, chain_ids[a].slice(), chain_ids[b].slice()) and
+        same_chain and
         std.mem.eql(u8, residue_names[a].slice(), residue_names[b].slice()) and
         std.mem.eql(u8, insertion_codes[a].slice(), insertion_codes[b].slice());
 }
@@ -512,6 +523,7 @@ pub fn buildResidueMap(allocator: Allocator, input: AtomInput, atom_areas: []con
     if (atom_areas.len != n) return error.LengthMismatch;
 
     const chain_ids = input.chain_id orelse return error.MissingChainInfo;
+    const chain_ids_full = input.chain_id_full;
     const residue_names = input.residue orelse return error.MissingResidueInfo;
     const residue_nums = input.residue_num orelse return error.MissingResidueNumInfo;
     const insertion_codes = input.insertion_code orelse return error.MissingInsertionCodeInfo;
@@ -522,11 +534,18 @@ pub fn buildResidueMap(allocator: Allocator, input: AtomInput, atom_areas: []con
         const start = i;
         residue_count += 1;
         i += 1;
-        while (i < n and sameResidue(chain_ids, residue_names, residue_nums, insertion_codes, start, i)) : (i += 1) {}
+        while (i < n and sameResidue(chain_ids, chain_ids_full, residue_names, residue_nums, insertion_codes, start, i)) : (i += 1) {}
     }
 
     const residue_chain = try allocator.alloc(types.FixedString4, residue_count);
     errdefer allocator.free(residue_chain);
+    const residue_chain_full: ?[][]const u8 = if (chain_ids_full != null)
+        try allocator.alloc([]const u8, residue_count)
+    else
+        null;
+    errdefer if (residue_chain_full) |chains| {
+        allocator.free(chains);
+    };
     const residue_name = try allocator.alloc(types.FixedString5, residue_count);
     errdefer allocator.free(residue_name);
     const residue_number = try allocator.alloc(i32, residue_count);
@@ -542,15 +561,24 @@ pub fn buildResidueMap(allocator: Allocator, input: AtomInput, atom_areas: []con
 
     i = 0;
     var residue_idx: usize = 0;
+    var residue_full_initialized: usize = 0;
+    errdefer if (residue_chain_full) |chains| {
+        for (chains[0..residue_full_initialized]) |chain| allocator.free(chain);
+    };
     while (i < n) : (residue_idx += 1) {
         const start = i;
         var sasa = atom_areas[i];
         i += 1;
-        while (i < n and sameResidue(chain_ids, residue_names, residue_nums, insertion_codes, start, i)) : (i += 1) {
+        while (i < n and sameResidue(chain_ids, chain_ids_full, residue_names, residue_nums, insertion_codes, start, i)) : (i += 1) {
             sasa += atom_areas[i];
         }
 
         residue_chain[residue_idx] = chain_ids[start];
+        if (residue_chain_full) |chains| {
+            const full = chain_ids_full.?[start];
+            chains[residue_idx] = try allocator.dupe(u8, full);
+            residue_full_initialized += 1;
+        }
         residue_name[residue_idx] = residue_names[start];
         residue_number[residue_idx] = residue_nums[start];
         residue_insertion_code[residue_idx] = insertion_codes[start];
@@ -562,6 +590,7 @@ pub fn buildResidueMap(allocator: Allocator, input: AtomInput, atom_areas: []con
     return .{
         .allocator = allocator,
         .residue_chain = residue_chain,
+        .residue_chain_full = residue_chain_full,
         .residue_name = residue_name,
         .residue_number = residue_number,
         .residue_insertion_code = residue_insertion_code,
@@ -603,7 +632,10 @@ pub fn fileResultWithResidueMapToJsonlLine(
     defer allocator.free(residue_insertion_code);
 
     for (0..residue_map.len()) |i| {
-        residue_chain[i] = residue_map.residue_chain[i].slice();
+        residue_chain[i] = if (residue_map.residue_chain_full) |chains|
+            chains[i]
+        else
+            residue_map.residue_chain[i].slice();
         residue_name[i] = residue_map.residue_name[i].slice();
         residue_insertion_code[i] = residue_map.residue_insertion_code[i].slice();
     }
@@ -835,6 +867,57 @@ test "buildResidueMap keeps non-contiguous repeated residues as separate ranges"
     try std.testing.expectEqual(@as(usize, 1), map.residue_atom_count[2]);
     try std.testing.expectEqualStrings("MET", map.residue_name[0].slice());
     try std.testing.expectEqualStrings("MET", map.residue_name[2].slice());
+}
+
+test "buildResidueMap groups and outputs full chain IDs when present" {
+    const allocator = std.testing.allocator;
+
+    const x = [_]f64{ 0, 1 };
+    const y = [_]f64{ 0, 0 };
+    const z = [_]f64{ 0, 0 };
+    var r = [_]f64{ 1, 1 };
+    const chain = [_]types.FixedString4{
+        types.FixedString4.fromSlice("ABCD"),
+        types.FixedString4.fromSlice("ABCD"),
+    };
+    const chain_full = [_][]const u8{ "ABCD1", "ABCD2" };
+    const residue = [_]types.FixedString5{
+        types.FixedString5.fromSlice("ALA"),
+        types.FixedString5.fromSlice("ALA"),
+    };
+    const residue_num = [_]i32{ 1, 1 };
+    const insertion = [_]types.FixedString4{
+        types.FixedString4.fromSlice(""),
+        types.FixedString4.fromSlice(""),
+    };
+    const atom_areas = [_]f64{ 10.0, 20.0 };
+
+    const input = types.AtomInput{
+        .x = x[0..],
+        .y = y[0..],
+        .z = z[0..],
+        .r = r[0..],
+        .chain_id = chain[0..],
+        .chain_id_full = chain_full[0..],
+        .residue = residue[0..],
+        .residue_num = residue_num[0..],
+        .insertion_code = insertion[0..],
+        .allocator = allocator,
+    };
+
+    var map = try buildResidueMap(allocator, input, atom_areas[0..]);
+    defer map.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), map.len());
+
+    const json = try fileResultWithResidueMapToJsonlLine(allocator, "long.cif", 30.0, atom_areas[0..], map);
+    defer allocator.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    const chains = parsed.value.object.get("residue_chain").?.array;
+    try std.testing.expectEqualStrings("ABCD1", chains.items[0].string);
+    try std.testing.expectEqualStrings("ABCD2", chains.items[1].string);
 }
 
 test "fileResultWithResidueMapToJsonlLine serializes columnar residue arrays" {

--- a/src/lee_richards.zig
+++ b/src/lee_richards.zig
@@ -46,6 +46,9 @@ pub fn calculateSasa(
             .allocator = allocator,
         };
     }
+    if (config.n_slices == 0) return error.InvalidInput;
+    try types.validateProbeRadius(f64, config.probe_radius);
+    try input.validateFiniteAndRange();
 
     // Convert to Vec3 positions for neighbor list
     const positions = try allocator.alloc(Vec3, n_atoms);
@@ -536,6 +539,9 @@ pub fn calculateSasaParallel(
             .allocator = allocator,
         };
     }
+    if (config.n_slices == 0) return error.InvalidInput;
+    try types.validateProbeRadius(f64, config.probe_radius);
+    try input.validateFiniteAndRange();
 
     // Auto-detect thread count if 0
     const actual_threads = if (n_threads == 0)
@@ -1066,6 +1072,9 @@ pub fn LeeRichardsGen(comptime T: type) type {
                     .allocator = allocator,
                 };
             }
+            if (config.n_slices == 0) return error.InvalidInput;
+            try types.validateProbeRadius(T, config.probe_radius);
+            try input.validateFiniteAndRange();
 
             // Convert to Vec positions (cast from f64)
             const positions = try allocator.alloc(Vec, n_atoms);
@@ -1150,6 +1159,9 @@ pub fn LeeRichardsGen(comptime T: type) type {
                     .allocator = allocator,
                 };
             }
+            if (config.n_slices == 0) return error.InvalidInput;
+            try types.validateProbeRadius(T, config.probe_radius);
+            try input.validateFiniteAndRange();
 
             // Auto-detect thread count if 0
             const actual_threads = if (n_threads == 0)
@@ -1338,6 +1350,74 @@ test "single atom SASA" {
     // Expected: 4π(1.5 + 1.4)² = 4π(2.9)² ≈ 105.68
     const expected = 4.0 * std.math.pi * 2.9 * 2.9;
     try std.testing.expectApproxEqRel(expected, result.total_area, 0.01);
+}
+
+test "calculateSasa rejects non-finite inputs" {
+    const allocator = std.testing.allocator;
+    const y = [_]f64{0.0};
+    const z = [_]f64{0.0};
+
+    {
+        const x = [_]f64{std.math.nan(f64)};
+        const r = [_]f64{1.5};
+        const input = AtomInput{
+            .x = &x,
+            .y = &y,
+            .z = &z,
+            .r = @constCast(&r),
+            .allocator = allocator,
+        };
+        try std.testing.expectError(error.InvalidInput, calculateSasa(allocator, input, .{}));
+    }
+
+    {
+        const x = [_]f64{0.0};
+        const r = [_]f64{std.math.inf(f64)};
+        const input = AtomInput{
+            .x = &x,
+            .y = &y,
+            .z = &z,
+            .r = @constCast(&r),
+            .allocator = allocator,
+        };
+        try std.testing.expectError(error.InvalidInput, calculateSasa(allocator, input, .{}));
+    }
+
+    {
+        const x = [_]f64{0.0};
+        const r = [_]f64{1.5};
+        const input = AtomInput{
+            .x = &x,
+            .y = &y,
+            .z = &z,
+            .r = @constCast(&r),
+            .allocator = allocator,
+        };
+        try std.testing.expectError(
+            error.InvalidInput,
+            calculateSasa(allocator, input, .{ .probe_radius = std.math.inf(f64) }),
+        );
+    }
+}
+
+test "calculateSasaParallel rejects non-finite inputs" {
+    const allocator = std.testing.allocator;
+    const x = [_]f64{0.0};
+    const y = [_]f64{0.0};
+    const z = [_]f64{0.0};
+    const r = [_]f64{1.5};
+    const input = AtomInput{
+        .x = &x,
+        .y = &y,
+        .z = &z,
+        .r = @constCast(&r),
+        .allocator = allocator,
+    };
+
+    try std.testing.expectError(
+        error.InvalidInput,
+        calculateSasaParallel(allocator, input, .{ .probe_radius = std.math.nan(f64) }, 2),
+    );
 }
 
 test "parallel calculation matches serial" {

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -64,6 +64,7 @@ const AtomSiteColumns = struct {
     pdbx_pdb_ins_code: ?usize = null,
     group_pdb: ?usize = null,
     label_alt_id: ?usize = null,
+    occupancy: ?usize = null,
     pdbx_pdb_model_num: ?usize = null,
 
     /// Check if required coordinate fields are present
@@ -254,6 +255,8 @@ pub const MmcifParser = struct {
                             columns.group_pdb = col_index;
                         } else if (eqlIgnoreCase(field, "label_alt_id")) {
                             columns.label_alt_id = col_index;
+                        } else if (eqlIgnoreCase(field, "occupancy")) {
+                            columns.occupancy = col_index;
                         } else if (eqlIgnoreCase(field, "pdbx_PDB_model_num")) {
                             columns.pdbx_pdb_model_num = col_index;
                         }
@@ -324,12 +327,13 @@ pub const MmcifParser = struct {
         defer residue_num_list.deinit(self.allocator);
         var insertion_code_list = std.ArrayListUnmanaged(types.FixedString4).empty;
         defer insertion_code_list.deinit(self.allocator);
+        var atom_records = std.ArrayListUnmanaged(AtomRecord).empty;
+        defer atom_records.deinit(self.allocator);
 
         // Buffer for current row values
         var row_values = try self.allocator.alloc([]const u8, num_cols);
         defer self.allocator.free(row_values);
 
-        var first_alt_loc: ?u8 = null;
         var col: usize = 0;
 
         // We need to re-read from the beginning of values since findAtomSiteLoop
@@ -347,99 +351,10 @@ pub const MmcifParser = struct {
 
                     if (col >= num_cols) {
                         // Complete row - process it
-                        const should_include = try self.shouldIncludeAtom(
-                            row_values,
-                            columns,
-                            &first_alt_loc,
-                        );
+                        const should_include = try self.shouldIncludeAtom(row_values, columns);
 
                         if (should_include) {
-                            // Parse coordinates
-                            const x = try parseFloat(row_values[columns.cartn_x.?]);
-                            const y = try parseFloat(row_values[columns.cartn_y.?]);
-                            const z = try parseFloat(row_values[columns.cartn_z.?]);
-
-                            try x_list.append(self.allocator, x);
-                            try y_list.append(self.allocator, y);
-                            try z_list.append(self.allocator, z);
-
-                            // Get element and radius
-                            var element_enum = elem.Element.X;
-                            if (columns.type_symbol) |type_col| {
-                                const symbol = row_values[type_col];
-                                if (!cif.isNull(symbol)) {
-                                    element_enum = elem.fromSymbol(symbol);
-                                }
-                            }
-
-                            // Use VdW radius as default (classifier will override)
-                            try r_list.append(self.allocator, element_enum.vdwRadius());
-                            try element_list.append(self.allocator, element_enum.atomicNumber());
-
-                            // Get residue name
-                            if (columns.getResNameCol()) |res_col| {
-                                const res = row_values[res_col];
-                                if (cif.isNull(res)) {
-                                    try residue_list.append(self.allocator, types.FixedString5.fromSlice("UNK"));
-                                } else {
-                                    try residue_list.append(self.allocator, types.FixedString5.fromSlice(res));
-                                }
-                            } else {
-                                try residue_list.append(self.allocator, types.FixedString5.fromSlice("UNK"));
-                            }
-
-                            // Get atom name
-                            if (columns.getAtomNameCol()) |atom_col| {
-                                const name = row_values[atom_col];
-                                if (cif.isNull(name)) {
-                                    try atom_name_list.append(self.allocator, types.FixedString4.fromSlice("X"));
-                                } else {
-                                    try atom_name_list.append(self.allocator, types.FixedString4.fromSlice(name));
-                                }
-                            } else {
-                                try atom_name_list.append(self.allocator, types.FixedString4.fromSlice("X"));
-                            }
-
-                            // Get chain ID
-                            if (columns.getChainCol(self.use_auth_chain)) |chain_col| {
-                                const chain = row_values[chain_col];
-                                if (cif.isNull(chain)) {
-                                    try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                                    try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, ""));
-                                } else {
-                                    try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(chain));
-                                    try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, chain));
-                                    has_extended_chain = has_extended_chain or chain.len > 4;
-                                }
-                            } else {
-                                try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                                try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, ""));
-                            }
-
-                            // Get residue sequence number
-                            if (columns.getResSeqCol()) |seq_col| {
-                                const seq_str = row_values[seq_col];
-                                if (cif.isNull(seq_str)) {
-                                    try residue_num_list.append(self.allocator, 0);
-                                } else {
-                                    const seq_num = std.fmt.parseInt(i32, seq_str, 10) catch 0;
-                                    try residue_num_list.append(self.allocator, seq_num);
-                                }
-                            } else {
-                                try residue_num_list.append(self.allocator, 0);
-                            }
-
-                            // Get insertion code
-                            if (columns.getInsCodeCol()) |ins_col| {
-                                const ins_code = row_values[ins_col];
-                                if (cif.isNull(ins_code)) {
-                                    try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                                } else {
-                                    try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(ins_code));
-                                }
-                            } else {
-                                try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(""));
-                            }
+                            try atom_records.append(self.allocator, try self.atomRecordFromRow(row_values, columns));
                         }
 
                         col = 0;
@@ -455,6 +370,23 @@ pub const MmcifParser = struct {
                 },
                 else => {},
             }
+        }
+
+        for (atom_records.items, 0..) |atom, i| {
+            if (!self.shouldKeepAltLoc(atom_records.items, i)) continue;
+
+            try x_list.append(self.allocator, atom.x);
+            try y_list.append(self.allocator, atom.y);
+            try z_list.append(self.allocator, atom.z);
+            try r_list.append(self.allocator, atom.radius);
+            try element_list.append(self.allocator, atom.element.atomicNumber());
+            try residue_list.append(self.allocator, types.FixedString5.fromSlice(atom.residue));
+            try atom_name_list.append(self.allocator, types.FixedString4.fromSlice(atom.atom_name));
+            try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(atom.chain_id));
+            try chain_id_full_list.append(self.allocator, try self.allocator.dupe(u8, atom.chain_id));
+            has_extended_chain = has_extended_chain or atom.chain_id.len > 4;
+            try residue_num_list.append(self.allocator, atom.residue_num);
+            try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(atom.insertion_code));
         }
 
         // Convert to AtomInput
@@ -510,12 +442,127 @@ pub const MmcifParser = struct {
         };
     }
 
+    const AtomRecord = struct {
+        x: f64,
+        y: f64,
+        z: f64,
+        radius: f64,
+        element: elem.Element,
+        atom_name: []const u8,
+        residue: []const u8,
+        chain_id: []const u8,
+        residue_num: i32,
+        insertion_code: []const u8,
+        alt_loc: u8,
+        occupancy: f64,
+        model_num: ?u32,
+    };
+
+    fn atomRecordFromRow(self: *MmcifParser, row_values: []const []const u8, columns: AtomSiteColumns) !AtomRecord {
+        const x = try parseFloat(row_values[columns.cartn_x.?]);
+        const y = try parseFloat(row_values[columns.cartn_y.?]);
+        const z = try parseFloat(row_values[columns.cartn_z.?]);
+
+        var element_enum = elem.Element.X;
+        if (columns.type_symbol) |type_col| {
+            const symbol = row_values[type_col];
+            if (!cif.isNull(symbol)) {
+                element_enum = elem.fromSymbol(symbol);
+            }
+        }
+
+        const residue = if (columns.getResNameCol()) |res_col| blk: {
+            const res = row_values[res_col];
+            break :blk if (cif.isNull(res)) "UNK" else res;
+        } else "UNK";
+
+        const atom_name = if (columns.getAtomNameCol()) |atom_col| blk: {
+            const name = row_values[atom_col];
+            break :blk if (cif.isNull(name)) "X" else name;
+        } else "X";
+
+        const chain_id = if (columns.getChainCol(self.use_auth_chain)) |chain_col| blk: {
+            const chain = row_values[chain_col];
+            break :blk if (cif.isNull(chain)) "" else chain;
+        } else "";
+
+        const residue_num = if (columns.getResSeqCol()) |seq_col| blk: {
+            const seq_str = row_values[seq_col];
+            break :blk if (cif.isNull(seq_str)) 0 else std.fmt.parseInt(i32, seq_str, 10) catch 0;
+        } else 0;
+
+        const insertion_code = if (columns.getInsCodeCol()) |ins_col| blk: {
+            const ins_code = row_values[ins_col];
+            break :blk if (cif.isNull(ins_code)) "" else ins_code;
+        } else "";
+
+        const alt_loc: u8 = if (columns.label_alt_id) |alt_col| blk: {
+            const alt_id = row_values[alt_col];
+            break :blk if (cif.isNull(alt_id) or alt_id.len == 0) ' ' else alt_id[0];
+        } else ' ';
+
+        const occupancy = if (columns.occupancy) |occ_col| blk: {
+            const occ = row_values[occ_col];
+            break :blk if (cif.isNull(occ)) 0.0 else std.fmt.parseFloat(f64, occ) catch 0.0;
+        } else 0.0;
+        const model_num = if (columns.pdbx_pdb_model_num) |model_col| blk: {
+            const model = row_values[model_col];
+            break :blk if (cif.isNull(model)) null else std.fmt.parseInt(u32, model, 10) catch null;
+        } else null;
+
+        return .{
+            .x = x,
+            .y = y,
+            .z = z,
+            .radius = element_enum.vdwRadius(),
+            .element = element_enum,
+            .atom_name = atom_name,
+            .residue = residue,
+            .chain_id = chain_id,
+            .residue_num = residue_num,
+            .insertion_code = insertion_code,
+            .alt_loc = alt_loc,
+            .occupancy = occupancy,
+            .model_num = model_num,
+        };
+    }
+
+    fn sameAltLocSite(a: AtomRecord, b: AtomRecord) bool {
+        return a.model_num == b.model_num and
+            a.residue_num == b.residue_num and
+            std.mem.eql(u8, a.chain_id, b.chain_id) and
+            std.mem.eql(u8, a.residue, b.residue) and
+            std.mem.eql(u8, a.insertion_code, b.insertion_code) and
+            std.mem.eql(u8, a.atom_name, b.atom_name);
+    }
+
+    fn shouldKeepAltLoc(self: *MmcifParser, atoms: []const AtomRecord, index: usize) bool {
+        if (!self.first_alt_loc_only) return true;
+
+        const atom = atoms[index];
+        if (atom.alt_loc == ' ') return true;
+
+        var best_non_preferred: ?usize = null;
+        for (atoms, 0..) |other, other_index| {
+            if (!sameAltLocSite(atom, other)) continue;
+            if (other.alt_loc == ' ') return false;
+            if (other.alt_loc == 'A') return atom.alt_loc == 'A';
+            if (best_non_preferred) |best_index| {
+                if (other.occupancy > atoms[best_index].occupancy) {
+                    best_non_preferred = other_index;
+                }
+            } else {
+                best_non_preferred = other_index;
+            }
+        }
+        return best_non_preferred == index;
+    }
+
     /// Check if an atom should be included based on filters
     fn shouldIncludeAtom(
         self: *MmcifParser,
         row_values: []const []const u8,
         columns: AtomSiteColumns,
-        first_alt_loc: *?u8,
     ) !bool {
         // Check group_PDB filter (ATOM vs HETATM)
         if (self.atom_only) {
@@ -533,23 +580,6 @@ pub const MmcifParser = struct {
                 const symbol = row_values[col];
                 if (!cif.isNull(symbol) and (std.mem.eql(u8, symbol, "H") or std.mem.eql(u8, symbol, "D"))) {
                     return false;
-                }
-            }
-        }
-
-        // Check alternate location filter
-        if (self.first_alt_loc_only) {
-            if (columns.label_alt_id) |col| {
-                const alt_id = row_values[col];
-                if (!cif.isNull(alt_id) and alt_id.len > 0) {
-                    const alt_char = alt_id[0];
-                    if (first_alt_loc.*) |first| {
-                        if (alt_char != first) {
-                            return false;
-                        }
-                    } else {
-                        first_alt_loc.* = alt_char;
-                    }
                 }
             }
         }
@@ -857,6 +887,124 @@ test "parse with HETATM filter (default atom_only=true)" {
     defer input2.deinit();
 
     try std.testing.expectEqual(@as(usize, 3), input2.atomCount());
+}
+
+test "parse mmCIF default model selection includes all models" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.pdbx_PDB_model_num
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CA ALA A 1 1 10.0 20.0 30.0
+        \\2 C CA GLY B 2 2 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectEqualStrings("A", input.chain_id.?[0].slice());
+    try std.testing.expectEqualStrings("B", input.chain_id.?[1].slice());
+}
+
+test "parse mmCIF explicit model selection filters requested model" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.pdbx_PDB_model_num
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CA ALA A 1 1 10.0 20.0 30.0
+        \\2 C CA GLY B 2 2 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    parser.model_num = 2;
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), input.atomCount());
+    try std.testing.expectEqualStrings("B", input.chain_id.?[0].slice());
+}
+
+test "parse mmCIF altLoc selection is per atom site and keeps later B-only sites" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.occupancy
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CA ALA A 1 A 0.60 10.0 20.0 30.0
+        \\2 C CA ALA A 1 B 0.40 12.0 22.0 32.0
+        \\3 C CA GLY A 2 B 0.50 14.0 24.0 34.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
+    try std.testing.expectEqual(@as(i32, 2), input.residue_num.?[1]);
+}
+
+test "parse mmCIF altLoc selection is scoped by model" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.occupancy
+        \\_atom_site.pdbx_PDB_model_num
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CA ALA A 1 A 0.60 1 10.0 20.0 30.0
+        \\2 C CA ALA A 1 B 0.40 1 12.0 22.0 32.0
+        \\3 C CA ALA A 1 B 0.50 2 14.0 24.0 34.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
 }
 
 test "parse with hydrogen filter (default skip_hydrogens=true)" {

--- a/src/pdb_parser.zig
+++ b/src/pdb_parser.zig
@@ -60,7 +60,7 @@ pub const PdbParser = struct {
     skip_hydrogens: bool = true,
     /// Filter to include only first alternate location
     first_alt_loc_only: bool = true,
-    /// Model number to extract (null = first model)
+    /// Model number to extract (null = all models)
     model_num: ?u32 = null,
     /// Chain IDs to include (null = all chains)
     chain_filter: ?[]const []const u8 = null,
@@ -92,6 +92,8 @@ pub const PdbParser = struct {
         defer residue_num_list.deinit(self.allocator);
         var insertion_code_list = std.ArrayListUnmanaged(types.FixedString4).empty;
         defer insertion_code_list.deinit(self.allocator);
+        var atom_records = std.ArrayListUnmanaged(AtomRecord).empty;
+        defer atom_records.deinit(self.allocator);
 
         // Pre-allocate based on estimated atom count (PDB line ~80 chars)
         const estimated_atoms = source.len / 80;
@@ -106,8 +108,8 @@ pub const PdbParser = struct {
         try residue_num_list.ensureTotalCapacity(self.allocator, estimated_atoms);
         try insertion_code_list.ensureTotalCapacity(self.allocator, estimated_atoms);
 
-        // Track alt location for filtering
-        var first_alt_loc: u8 = ' ';
+        // Track model filtering. By default all models are included, matching
+        // the calc CLI's documented `--model` default.
         var current_model: ?u32 = null;
         var in_target_model = true;
 
@@ -120,16 +122,11 @@ pub const PdbParser = struct {
                 if (self.model_num) |target| {
                     in_target_model = (current_model == target);
                 } else {
-                    // No model specified: use first model only
-                    in_target_model = (current_model == 1 or current_model == null);
+                    in_target_model = true;
                 }
                 continue;
             }
             if (std.mem.startsWith(u8, line, "ENDMDL")) {
-                if (self.model_num == null and current_model != null) {
-                    // First model complete, stop parsing
-                    break;
-                }
                 continue;
             }
 
@@ -143,7 +140,8 @@ pub const PdbParser = struct {
             if (self.atom_only and is_hetatm) continue;
 
             // Parse atom record
-            const atom = try self.parseAtomRecord(line) orelse continue;
+            var atom = try self.parseAtomRecord(line) orelse continue;
+            atom.model_num = current_model;
 
             // Hydrogen filtering (also skip deuterium D, an isotope of H)
             if (self.skip_hydrogens) {
@@ -152,17 +150,6 @@ pub const PdbParser = struct {
                 if (line.len >= 78) {
                     const elem_sym = std.mem.trim(u8, line[76..78], " ");
                     if (std.mem.eql(u8, elem_sym, "D")) continue;
-                }
-            }
-
-            // Alt location filtering
-            if (self.first_alt_loc_only) {
-                if (atom.alt_loc != ' ') {
-                    if (first_alt_loc == ' ') {
-                        first_alt_loc = atom.alt_loc;
-                    } else if (atom.alt_loc != first_alt_loc) {
-                        continue;
-                    }
                 }
             }
 
@@ -178,19 +165,26 @@ pub const PdbParser = struct {
                 if (!found) continue;
             }
 
-            // Add atom data
-            try x_list.append(self.allocator, atom.x);
-            try y_list.append(self.allocator, atom.y);
-            try z_list.append(self.allocator, atom.z);
-            try r_list.append(self.allocator, atom.radius);
-            try element_list.append(self.allocator, atom.element.atomicNumber());
+            try atom_records.append(self.allocator, atom);
+        }
 
-            // Use FixedString4 - no per-atom allocation needed
-            try atom_name_list.append(self.allocator, types.FixedString4.fromSlice(atom.atom_name));
-            try residue_list.append(self.allocator, types.FixedString5.fromSlice(atom.residue));
-            try chain_id_list.append(self.allocator, types.FixedString4.fromSlice(atom.chain_id));
-            try residue_num_list.append(self.allocator, atom.residue_num);
-            try insertion_code_list.append(self.allocator, types.FixedString4.fromSlice(atom.insertion_code));
+        for (atom_records.items, 0..) |atom, i| {
+            if (!self.shouldKeepAltLoc(atom_records.items, i)) continue;
+
+            try appendAtomRecord(
+                self.allocator,
+                atom,
+                &x_list,
+                &y_list,
+                &z_list,
+                &r_list,
+                &element_list,
+                &atom_name_list,
+                &residue_list,
+                &chain_id_list,
+                &residue_num_list,
+                &insertion_code_list,
+            );
         }
 
         if (x_list.items.len == 0) {
@@ -238,7 +232,66 @@ pub const PdbParser = struct {
         residue_num: i32,
         insertion_code: []const u8,
         alt_loc: u8,
+        occupancy: f64,
+        model_num: ?u32 = null,
     };
+
+    fn appendAtomRecord(
+        allocator: Allocator,
+        atom: AtomRecord,
+        x_list: *std.ArrayListUnmanaged(f64),
+        y_list: *std.ArrayListUnmanaged(f64),
+        z_list: *std.ArrayListUnmanaged(f64),
+        r_list: *std.ArrayListUnmanaged(f64),
+        element_list: *std.ArrayListUnmanaged(u8),
+        atom_name_list: *std.ArrayListUnmanaged(types.FixedString4),
+        residue_list: *std.ArrayListUnmanaged(types.FixedString5),
+        chain_id_list: *std.ArrayListUnmanaged(types.FixedString4),
+        residue_num_list: *std.ArrayListUnmanaged(i32),
+        insertion_code_list: *std.ArrayListUnmanaged(types.FixedString4),
+    ) !void {
+        try x_list.append(allocator, atom.x);
+        try y_list.append(allocator, atom.y);
+        try z_list.append(allocator, atom.z);
+        try r_list.append(allocator, atom.radius);
+        try element_list.append(allocator, atom.element.atomicNumber());
+        try atom_name_list.append(allocator, types.FixedString4.fromSlice(atom.atom_name));
+        try residue_list.append(allocator, types.FixedString5.fromSlice(atom.residue));
+        try chain_id_list.append(allocator, types.FixedString4.fromSlice(atom.chain_id));
+        try residue_num_list.append(allocator, atom.residue_num);
+        try insertion_code_list.append(allocator, types.FixedString4.fromSlice(atom.insertion_code));
+    }
+
+    fn sameAltLocSite(a: AtomRecord, b: AtomRecord) bool {
+        return a.model_num == b.model_num and
+            a.residue_num == b.residue_num and
+            std.mem.eql(u8, a.chain_id, b.chain_id) and
+            std.mem.eql(u8, a.residue, b.residue) and
+            std.mem.eql(u8, a.insertion_code, b.insertion_code) and
+            std.mem.eql(u8, a.atom_name, b.atom_name);
+    }
+
+    fn shouldKeepAltLoc(self: *PdbParser, atoms: []const AtomRecord, index: usize) bool {
+        if (!self.first_alt_loc_only) return true;
+
+        const atom = atoms[index];
+        if (atom.alt_loc == ' ') return true;
+
+        var best_non_preferred: ?usize = null;
+        for (atoms, 0..) |other, other_index| {
+            if (!sameAltLocSite(atom, other)) continue;
+            if (other.alt_loc == ' ') return false;
+            if (other.alt_loc == 'A') return atom.alt_loc == 'A';
+            if (best_non_preferred) |best_index| {
+                if (other.occupancy > atoms[best_index].occupancy) {
+                    best_non_preferred = other_index;
+                }
+            } else {
+                best_non_preferred = other_index;
+            }
+        }
+        return best_non_preferred == index;
+    }
 
     /// Parse a single ATOM/HETATM record
     fn parseAtomRecord(self: *PdbParser, line: []const u8) !?AtomRecord {
@@ -270,6 +323,10 @@ pub const PdbParser = struct {
 
         // Extract other fields
         const alt_loc: u8 = if (line.len > 16) line[16] else ' ';
+        const occupancy = if (line.len >= 60)
+            std.fmt.parseFloat(f64, std.mem.trim(u8, line[54..60], " ")) catch 0.0
+        else
+            0.0;
         const residue_raw = if (line.len >= 20) line[17..20] else "   ";
         const residue = std.mem.trim(u8, residue_raw, " ");
 
@@ -301,6 +358,7 @@ pub const PdbParser = struct {
             .residue_num = residue_num,
             .insertion_code = insertion_code,
             .alt_loc = alt_loc,
+            .occupancy = occupancy,
         };
     }
 };
@@ -469,6 +527,115 @@ test "PdbParser include HETATM" {
     defer input.deinit();
 
     try testing.expectEqual(@as(usize, 4), input.atomCount());
+}
+
+test "PdbParser default model selection includes all models" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const pdb_content =
+        \\MODEL        1
+        \\ATOM      1  CA  ALA A   1      10.000  20.000  30.000  1.00 10.00           C
+        \\ENDMDL
+        \\MODEL        2
+        \\ATOM      2  CA  GLY B   2      11.000  21.000  31.000  1.00 10.00           C
+        \\ENDMDL
+        \\END
+    ;
+
+    var parser = PdbParser.init(allocator);
+    var input = try parser.parse(pdb_content);
+    defer input.deinit();
+
+    try testing.expectEqual(@as(usize, 2), input.atomCount());
+    try testing.expectEqualStrings("A", input.chain_id.?[0].slice());
+    try testing.expectEqualStrings("B", input.chain_id.?[1].slice());
+}
+
+test "PdbParser explicit model selection filters requested model" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const pdb_content =
+        \\MODEL        1
+        \\ATOM      1  CA  ALA A   1      10.000  20.000  30.000  1.00 10.00           C
+        \\ENDMDL
+        \\MODEL        2
+        \\ATOM      2  CA  GLY B   2      11.000  21.000  31.000  1.00 10.00           C
+        \\ENDMDL
+        \\END
+    ;
+
+    var parser = PdbParser.init(allocator);
+    parser.model_num = 2;
+    var input = try parser.parse(pdb_content);
+    defer input.deinit();
+
+    try testing.expectEqual(@as(usize, 1), input.atomCount());
+    try testing.expectEqualStrings("B", input.chain_id.?[0].slice());
+}
+
+test "PdbParser altLoc selection is per atom site and keeps later B-only sites" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const pdb_content =
+        \\ATOM      1  CA AALA A   1      10.000  20.000  30.000  0.60 10.00           C
+        \\ATOM      2  CA BALA A   1      12.000  22.000  32.000  0.40 10.00           C
+        \\ATOM      3  CA BGLY A   2      14.000  24.000  34.000  0.50 10.00           C
+        \\END
+    ;
+
+    var parser = PdbParser.init(allocator);
+    var input = try parser.parse(pdb_content);
+    defer input.deinit();
+
+    try testing.expectEqual(@as(usize, 2), input.atomCount());
+    try testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
+    try testing.expectEqual(@as(i32, 2), input.residue_num.?[1]);
+}
+
+test "PdbParser altLoc selection falls back to highest occupancy without blank or A" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const pdb_content =
+        \\ATOM      1  CA BALA A   1      10.000  20.000  30.000  0.40 10.00           C
+        \\ATOM      2  CA CALA A   1      12.000  22.000  32.000  0.70 10.00           C
+        \\END
+    ;
+
+    var parser = PdbParser.init(allocator);
+    var input = try parser.parse(pdb_content);
+    defer input.deinit();
+
+    try testing.expectEqual(@as(usize, 1), input.atomCount());
+    try testing.expectApproxEqAbs(@as(f64, 12.0), input.x[0], 0.001);
+}
+
+test "PdbParser altLoc selection is scoped by model" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const pdb_content =
+        \\MODEL        1
+        \\ATOM      1  CA AALA A   1      10.000  20.000  30.000  0.60 10.00           C
+        \\ATOM      2  CA BALA A   1      12.000  22.000  32.000  0.40 10.00           C
+        \\ENDMDL
+        \\MODEL        2
+        \\ATOM      3  CA BALA A   1      14.000  24.000  34.000  0.50 10.00           C
+        \\ENDMDL
+        \\END
+    ;
+
+    var parser = PdbParser.init(allocator);
+    var input = try parser.parse(pdb_content);
+    defer input.deinit();
+
+    try testing.expectEqual(@as(usize, 2), input.atomCount());
+    try testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
 }
 
 test "PdbParser atom_only filter (default)" {

--- a/src/shrake_rupley.zig
+++ b/src/shrake_rupley.zig
@@ -287,6 +287,9 @@ pub fn calculateSasa(
 ) !SasaResult {
     const n_atoms = input.atomCount();
     if (n_atoms == 0) return error.NoAtoms;
+    if (config.n_points == 0) return error.InvalidInput;
+    try types.validateProbeRadius(f64, config.probe_radius);
+    try input.validateFiniteAndRange();
 
     // Generate test points
     const test_points_array = try test_points.generateTestPoints(allocator, config.n_points);
@@ -408,6 +411,9 @@ pub fn calculateSasaParallel(
 ) !SasaResult {
     const n_atoms = input.atomCount();
     if (n_atoms == 0) return error.NoAtoms;
+    if (config.n_points == 0) return error.InvalidInput;
+    try types.validateProbeRadius(f64, config.probe_radius);
+    try input.validateFiniteAndRange();
 
     // Auto-detect thread count if 0
     const actual_threads = if (n_threads == 0)
@@ -718,6 +724,9 @@ pub fn ShrakeRupleyGen(comptime T: type) type {
         ) !Result {
             const n_atoms = input.atomCount();
             if (n_atoms == 0) return error.NoAtoms;
+            if (config.n_points == 0) return error.InvalidInput;
+            try types.validateProbeRadius(T, config.probe_radius);
+            try input.validateFiniteAndRange();
 
             // Generate test points
             const test_points_array = try TestPointsGen.generate(allocator, config.n_points);
@@ -792,6 +801,9 @@ pub fn ShrakeRupleyGen(comptime T: type) type {
         ) !Result {
             const n_atoms = input.atomCount();
             if (n_atoms == 0) return error.NoAtoms;
+            if (config.n_points == 0) return error.InvalidInput;
+            try types.validateProbeRadius(T, config.probe_radius);
+            try input.validateFiniteAndRange();
 
             // Auto-detect thread count if 0
             const actual_threads = if (n_threads == 0)
@@ -1119,6 +1131,74 @@ test "calculateSasa - no atoms error" {
 
     const result = calculateSasa(allocator, input, config);
     try std.testing.expectError(error.NoAtoms, result);
+}
+
+test "calculateSasa rejects non-finite inputs" {
+    const allocator = std.testing.allocator;
+    const y = [_]f64{0.0};
+    const z = [_]f64{0.0};
+
+    {
+        const x = [_]f64{std.math.nan(f64)};
+        const r = [_]f64{1.5};
+        const input = AtomInput{
+            .x = &x,
+            .y = &y,
+            .z = &z,
+            .r = @constCast(&r),
+            .allocator = allocator,
+        };
+        try std.testing.expectError(error.InvalidInput, calculateSasa(allocator, input, .{}));
+    }
+
+    {
+        const x = [_]f64{0.0};
+        const r = [_]f64{std.math.inf(f64)};
+        const input = AtomInput{
+            .x = &x,
+            .y = &y,
+            .z = &z,
+            .r = @constCast(&r),
+            .allocator = allocator,
+        };
+        try std.testing.expectError(error.InvalidInput, calculateSasa(allocator, input, .{}));
+    }
+
+    {
+        const x = [_]f64{0.0};
+        const r = [_]f64{1.5};
+        const input = AtomInput{
+            .x = &x,
+            .y = &y,
+            .z = &z,
+            .r = @constCast(&r),
+            .allocator = allocator,
+        };
+        try std.testing.expectError(
+            error.InvalidInput,
+            calculateSasa(allocator, input, .{ .probe_radius = std.math.inf(f64) }),
+        );
+    }
+}
+
+test "calculateSasaParallel rejects non-finite inputs" {
+    const allocator = std.testing.allocator;
+    const x = [_]f64{0.0};
+    const y = [_]f64{0.0};
+    const z = [_]f64{0.0};
+    const r = [_]f64{1.5};
+    const input = AtomInput{
+        .x = &x,
+        .y = &y,
+        .z = &z,
+        .r = @constCast(&r),
+        .allocator = allocator,
+    };
+
+    try std.testing.expectError(
+        error.InvalidInput,
+        calculateSasaParallel(allocator, input, .{ .probe_radius = std.math.nan(f64) }, 2),
+    );
 }
 
 test "optimized vs original - same results" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -216,6 +216,26 @@ pub const AtomInput = struct {
             self.chain_id != null and self.insertion_code != null;
     }
 
+    /// Validate that required coordinate/radius arrays are aligned and finite.
+    /// Radii must be non-negative; zero-radius points are accepted.
+    pub fn validateFiniteAndRange(self: AtomInput) !void {
+        const n_atoms = self.atomCount();
+        if (self.y.len != n_atoms or self.z.len != n_atoms or self.r.len != n_atoms) {
+            return error.InvalidInput;
+        }
+
+        for (0..n_atoms) |i| {
+            if (!std.math.isFinite(self.x[i]) or
+                !std.math.isFinite(self.y[i]) or
+                !std.math.isFinite(self.z[i]) or
+                !std.math.isFinite(self.r[i]) or
+                self.r[i] < 0.0)
+            {
+                return error.InvalidInput;
+            }
+        }
+    }
+
     /// Free allocated memory
     pub fn deinit(self: *AtomInput) void {
         self.allocator.free(self.x);
@@ -309,6 +329,13 @@ pub const Config = ConfigGen(f64);
 /// Single precision Config
 pub const Configf32 = ConfigGen(f32);
 
+/// Validate a positive, finite probe radius at public calculation boundaries.
+pub fn validateProbeRadius(comptime T: type, probe_radius: T) !void {
+    if (!std.math.isFinite(probe_radius) or !(probe_radius > 0.0)) {
+        return error.InvalidInput;
+    }
+}
+
 // Tests
 test "Vec3 add" {
     const v1 = Vec3{ .x = 1.0, .y = 2.0, .z = 3.0 };
@@ -375,6 +402,23 @@ test "AtomInput atomCount" {
     try std.testing.expectEqual(@as(usize, 3), input.atomCount());
 }
 
+test "AtomInput validateFiniteAndRange rejects invalid numeric inputs" {
+    const allocator = std.testing.allocator;
+    const x = [_]f64{0.0};
+    const y = [_]f64{std.math.inf(f64)};
+    const z = [_]f64{0.0};
+    const r = [_]f64{1.5};
+    const input = AtomInput{
+        .x = &x,
+        .y = &y,
+        .z = &z,
+        .r = @constCast(&r),
+        .allocator = allocator,
+    };
+
+    try std.testing.expectError(error.InvalidInput, input.validateFiniteAndRange());
+}
+
 test "SasaResult deinit" {
     const allocator = std.testing.allocator;
 
@@ -396,6 +440,12 @@ test "Config default values" {
 
     try std.testing.expectEqual(@as(u32, 100), config.n_points);
     try std.testing.expectEqual(@as(f64, 1.4), config.probe_radius);
+}
+
+test "validateProbeRadius rejects non-positive or non-finite values" {
+    try std.testing.expectError(error.InvalidInput, validateProbeRadius(f64, 0.0));
+    try std.testing.expectError(error.InvalidInput, validateProbeRadius(f64, std.math.nan(f64)));
+    try validateProbeRadius(f32, 1.4);
 }
 
 test "Config custom values" {

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -129,10 +129,10 @@ For batch custom classifier configs, use a workflow `[classifier]` section. See 
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--classifier=TYPE` | Built-in classifier: `ccd`, `protor`, `naccess`, or `oons` | calc/batch: `ccd` for PDB/mmCIF, none for JSON; traj: `naccess` |
+| `--classifier=TYPE` | Built-in classifier: `ccd`, `protor`, `naccess`, or `oons` | calc/batch: `ccd` for PDB/mmCIF/BinaryCIF/SDF/MOL, none for JSON; traj: `naccess` |
 | `--ccd=FILE` | External CCD dictionary (CIF text or ZSDC binary) | none |
 
-When `--classifier` is used, atom radii are assigned based on residue and atom names. For PDB/mmCIF input, `ccd` is used by default. When `--classifier=ccd` is used, HETATM records are included automatically without needing `--include-hetatm`.
+When `--classifier` is used, atom radii are assigned based on residue and atom names. For PDB/mmCIF/BinaryCIF/SDF/MOL input, `ccd` is used by default. When `--classifier=ccd` is used, HETATM records are included automatically without needing `--include-hetatm`.
 
 See [Classifiers](../guide/classifiers.mdx) for detailed classifier documentation.
 
@@ -281,7 +281,7 @@ Most [common options](#common-options) apply, plus the trajectory-specific optio
 
 ### Atom Filtering
 
-By default, hydrogen atoms and HETATM records are excluded (matching FreeSASA/RustSASA defaults).
+By default, hydrogen atoms are excluded. HETATM records are included automatically with the default CCD classifier for structure inputs; use `--classifier=naccess`/`protor`/`oons` plus `--include-hetatm` when you need explicit non-CCD HETATM handling.
 
 ```bash
 # Include hydrogen atoms

--- a/website/docs/cli/input.md
+++ b/website/docs/cli/input.md
@@ -12,6 +12,7 @@ The input format is auto-detected from the file extension.
 | `.cif`, `.cif.gz`, `.cif.zst`, `.mmcif`, `.mmcif.gz`, `.mmcif.zst`, `.CIF`, `.mmCIF` | mmCIF |
 | `.bcif`, `.bcif.gz`, `.bcif.zst`, `.BCIF` | BinaryCIF (`_atom_site` support) |
 | `.pdb`, `.pdb.gz`, `.pdb.zst`, `.PDB`, `.ent`, `.ent.gz`, `.ent.zst`, `.ENT` | PDB |
+| `.sdf`, `.sdf.gz`, `.sdf.zst`, `.mol`, `.mol.gz`, `.mol.zst` | SDF/MOL small molecules |
 
 ## JSON Format
 
@@ -79,6 +80,10 @@ BinaryCIF input decodes `_atom_site` for SASA calculation and uses embedded `_ch
 
 Standard PDB format files are supported with ATOM and HETATM records.
 
+## SDF/MOL Format
+
+SDF and MOL files are supported for small-molecule SASA. V2000 and V3000 records are accepted, and batch mode expands multi-molecule SDF files so each molecule is calculated independently. Use `--mol=NAME_OR_INDEX` to select one molecule from a multi-molecule SDF.
+
 ## Trajectory Formats
 
 For the `traj` subcommand, the following trajectory formats are supported:
@@ -86,7 +91,9 @@ For the `traj` subcommand, the following trajectory formats are supported:
 | Extension | Format | Coordinates |
 |-----------|--------|-------------|
 | `.xtc` | GROMACS XTC | nm (auto-converted to Å) |
+| `.trr` | GROMACS TRR | nm (auto-converted to Å) |
 | `.dcd` | NAMD/CHARMM DCD | Å |
+| `.nc`, `.ncdf` | AMBER NetCDF | Å |
 
 A topology file (PDB or mmCIF) is required alongside the trajectory to provide atom names and radii classification.
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -47,7 +47,7 @@ cd zsasa
 zig build -Doptimize=ReleaseFast
 ```
 
-The binary is at `./zig-out/bin/zsasa` (source build) or `~/.local/bin/zsasa` (install.sh).
+The binary is at `./zig-out/bin/zsasa` (source build) or `~/.local/bin/zsasa` (install.sh). The installer supports Linux and macOS. It downloads the latest release by default, or `VERSION=X.Y.Z` when pinned. If Zig 0.16.0 and `git` are available, it builds the tagged source release locally; otherwise it downloads the matching pre-built binary and verifies `SHA256SUMS` when available.
 
 :::note
 If you have both the standalone binary and the Python package installed, the one that appears first in your `PATH` will be used. To avoid confusion, use only one installation method for the CLI.


### PR DESCRIPTION
## Summary

- harden Zig/C/Python public input validation and include C ABI tests in `zig build test`
- fix parser correctness around model defaults, altLoc selection, HETATM/CCD behavior, compressed suffixes, and full chain IDs
- harden Python bindings/integrations with finite/range validation, unknown-radii policy, MDAnalysis residue remapping, streaming trajectory helpers, and Windows dev DLL discovery
- strengthen docs, CI, release workflow dispatch, sdist/source install coverage, conda license metadata, examples, issue templates, and citation metadata

## Validation

- `zig fmt --check src/ build.zig`
- `zig build test --summary all` — 1586/1589 tests passed, 3 skipped
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa --help`
- `./zig-out/bin/zsasa --version`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json`
- `cd python && uv run ruff format --check .`
- `cd python && uv run ruff check .`
- `cd python && uv run pytest tests/ -q` — 199 passed, 15 skipped
- `cd website && npm run build`
- `git diff --check origin/main...HEAD`
