### PR TITLE
fix: gate inline CCD parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ProtOr classifier**: make `--classifier=protor` use static ProtOr-compatible radii without loading inline, external, or SDF-derived CCD resources. This provides a faster protein-only path for mmCIF/PDB inputs such as AFDB models.
+
+### Fixed
+
+- **mmCIF batch parsing**: skip per-file inline CCD extraction in batch mode and avoid scanning mmCIF files for inline CCD data when no `_chem_comp_atom` category is present.
+
 ## [0.7.1] - 2026-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **mmCIF batch parsing**: skip per-file inline CCD extraction in batch mode and avoid scanning mmCIF files for inline CCD data when no `_chem_comp_atom` category is present.
+- **mmCIF batch parsing**: keep per-file inline CCD extraction for `batch --classifier=ccd` when `_chem_comp_atom` data is present, but fast-skip AFDB-like mmCIF files without inline CCD categories.
 
 ## [0.7.1] - 2026-06-29
 

--- a/python/README.md
+++ b/python/README.md
@@ -45,7 +45,7 @@ print(f"Total: {result.total_area:.1f} Å²")
 - **Two algorithms**: Shrake-Rupley and Lee-Richards, with bitmask LUT optimization
 - **Selectable precision**: f64 (default) or f32
 - **Multi-threading**: Automatic parallelization
-- **Atom classification**: NACCESS, ProtOr, OONS classifiers
+- **Atom classification**: CCD, ProtOr, NACCESS, and OONS classifiers
 - **Analysis**: Per-residue aggregation, RSA, polar/nonpolar classification
 - **Batch processing**: `process_directory()` for proteome-scale datasets
 - **MD trajectory**: [MDTraj](https://github.com/mdtraj/mdtraj) and [MDAnalysis](https://github.com/MDAnalysis/mdanalysis) integrations; use [pyztraj](https://github.com/N283T/ztraj) for direct trajectory-file I/O

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -13,7 +13,6 @@ const bitmask_lut = @import("bitmask_lut.zig");
 const lee_richards = @import("lee_richards.zig");
 const classifier = @import("classifier.zig");
 const classifier_parser = @import("classifier_parser.zig");
-// classifier_protor removed — ProtOr is now an alias for CCD
 const classifier_naccess = @import("classifier_naccess.zig");
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
@@ -614,6 +613,10 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
             parser.use_auth_chain = config.use_auth_chain;
+            // Batch classification currently uses shared external/SDF CCD
+            // resources, not per-file inline CCD dictionaries. Avoid decoding
+            // inline CCD categories for every structure.
+            parser.parse_inline_ccd = false;
             break :blk parser.parseFile(io, path);
         },
         .mmcif => blk: {
@@ -622,6 +625,10 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
             parser.use_auth_chain = config.use_auth_chain;
+            // Batch classification currently uses shared external/SDF CCD
+            // resources, not per-file inline CCD dictionaries. Avoid scanning
+            // each mmCIF twice.
+            parser.parse_inline_ccd = false;
             break :blk parser.parseFile(io, path);
         },
         .pdb => blk: {
@@ -657,11 +664,12 @@ fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType, sdf_ccd: ?*cons
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
-    // For CCD/ProtOr: create classifier instance and feed external CCD components
+    // CCD and ProtOr share the static ProtOr-compatible table. Only CCD may
+    // extend it with runtime component topology.
     var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd or ct == .protor) classifier_ccd.CcdClassifier.init(input.allocator) else null;
     defer if (ccd_clf) |*c| c.deinit();
 
-    if (ccd_clf != null) {
+    if (ct == .ccd and ccd_clf != null) {
         // Deduplicate: collect unique non-hardcoded residues
         var needed: std.StringHashMapUnmanaged(void) = .empty;
         defer needed.deinit(input.allocator);
@@ -2809,7 +2817,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --algorithm=ALGO    Algorithm: sr (shrake-rupley), lr (lee-richards)
         \\                        Default: sr
         \\    --classifier=TYPE   Built-in classifier: ccd, protor, naccess, oons
-        \\                        Default: ccd (protor is an alias for ccd)
+        \\                        Default: ccd (protor uses static ProtOr radii only)
         \\    --ccd=PATH          External CCD dictionary file (.zsdc or .cif[.gz|.zst])
         \\                        Used with --classifier=ccd for non-standard residues
         \\    --sdf=PATH          SDF file with bond topology for CCD classifier
@@ -2989,7 +2997,7 @@ fn parseWorkflowFile(allocator: Allocator, io: std.Io, path: []const u8) !workfl
 
 fn classifierUsesCcdResources(effective_classifier_type: ?ClassifierType) bool {
     const classifier_type = effective_classifier_type orelse return false;
-    return classifier_type == .ccd or classifier_type == .protor;
+    return classifier_type == .ccd;
 }
 
 fn resolveWorkflowCcdPath(args: BatchArgs, classifier_config: workflow_manifest.ClassifierConfig, effective_classifier_type: ?ClassifierType) ?[]const u8 {
@@ -4535,9 +4543,9 @@ test "batch resource resolver only loads CCD resources for CCD classifiers" {
     try std.testing.expectEqual(@as(usize, 0), resolveWorkflowSdfPaths(workflow_only_args, workflow_sdf_paths[0..], .oons).len);
     try std.testing.expectEqual(@as(usize, 0), resolveWorkflowSdfPaths(workflow_only_args, workflow_sdf_paths[0..], null).len);
     try std.testing.expectEqualStrings("workflow.zsdc", resolveWorkflowCcdPath(workflow_only_args, classifier_config, .ccd).?);
-    try std.testing.expectEqualStrings("workflow.zsdc", resolveWorkflowCcdPath(workflow_only_args, classifier_config, .protor).?);
+    try std.testing.expect(resolveWorkflowCcdPath(workflow_only_args, classifier_config, .protor) == null);
     try std.testing.expectEqual(@as(usize, 1), resolveWorkflowSdfPaths(workflow_only_args, workflow_sdf_paths[0..], .ccd).len);
-    try std.testing.expectEqual(@as(usize, 1), resolveWorkflowSdfPaths(workflow_only_args, workflow_sdf_paths[0..], .protor).len);
+    try std.testing.expectEqual(@as(usize, 0), resolveWorkflowSdfPaths(workflow_only_args, workflow_sdf_paths[0..], .protor).len);
 
     var explicit_resource_args = BatchArgs{
         .classifier_explicit = true,

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -603,40 +603,56 @@ fn copySelectedAtomInput(allocator: Allocator, input: AtomInput, chains: ?[]cons
 }
 
 /// Read input file with auto-format detection
-fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: BatchConfig) !AtomInput {
+const ParsedInput = struct {
+    input: AtomInput,
+    inline_ccd: ?ccd_parser.ComponentDict = null,
+
+    fn deinit(self: *ParsedInput) void {
+        self.input.deinit();
+        if (self.inline_ccd) |*dict| {
+            dict.deinit();
+            self.inline_ccd = null;
+        }
+    }
+
+    fn inlineCcdPtr(self: *const ParsedInput) ?*const ccd_parser.ComponentDict {
+        if (self.inline_ccd != null) return &self.inline_ccd.?;
+        return null;
+    }
+};
+
+fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: BatchConfig) !ParsedInput {
     const format = format_detect.detectInputFormat(path);
     return switch (format) {
-        .json => json_parser.readAtomInputFromFile(allocator, io, path),
+        .json => .{ .input = try json_parser.readAtomInputFromFile(allocator, io, path) },
         .bcif => blk: {
             var parser = bcif_parser.BcifParser.init(allocator);
+            errdefer parser.deinitCcd();
             parser.skip_hydrogens = !config.include_hydrogens;
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
             parser.use_auth_chain = config.use_auth_chain;
-            // Batch classification currently uses shared external/SDF CCD
-            // resources, not per-file inline CCD dictionaries. Avoid decoding
-            // inline CCD categories for every structure.
-            parser.parse_inline_ccd = false;
-            break :blk parser.parseFile(io, path);
+            parser.parse_inline_ccd = classifierUsesCcdResources(config.classifier_type);
+            const input = try parser.parseFile(io, path);
+            break :blk .{ .input = input, .inline_ccd = parser.takeInlineCcd() };
         },
         .mmcif => blk: {
             var parser = mmcif_parser.MmcifParser.init(allocator);
+            errdefer parser.deinitCcd();
             parser.skip_hydrogens = !config.include_hydrogens;
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
             parser.use_auth_chain = config.use_auth_chain;
-            // Batch classification currently uses shared external/SDF CCD
-            // resources, not per-file inline CCD dictionaries. Avoid scanning
-            // each mmCIF twice.
-            parser.parse_inline_ccd = false;
-            break :blk parser.parseFile(io, path);
+            parser.parse_inline_ccd = classifierUsesCcdResources(config.classifier_type);
+            const input = try parser.parseFile(io, path);
+            break :blk .{ .input = input, .inline_ccd = parser.takeInlineCcd() };
         },
         .pdb => blk: {
             var parser = pdb_parser.PdbParser.init(allocator);
             parser.skip_hydrogens = !config.include_hydrogens;
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
-            break :blk parser.parseFile(io, path);
+            break :blk .{ .input = try parser.parseFile(io, path) };
         },
         .sdf => blk: {
             const source = if (compressed.isCompressed(path))
@@ -653,13 +669,19 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             const molecules = try sdf_parser.parse(allocator, source);
             defer sdf_parser.freeMolecules(allocator, molecules);
 
-            break :blk try sdf_parser.toAtomInput(allocator, molecules, !config.include_hydrogens);
+            break :blk .{ .input = try sdf_parser.toAtomInput(allocator, molecules, !config.include_hydrogens) };
         },
     };
 }
 
 /// Apply built-in classifier to replace radii based on residue/atom names
-fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType, sdf_ccd: ?*const ccd_parser.ComponentDict, external_ccd: ?*const ccd_parser.ComponentDict) !void {
+fn applyBuiltinClassifier(
+    input: *AtomInput,
+    ct: ClassifierType,
+    sdf_ccd: ?*const ccd_parser.ComponentDict,
+    inline_ccd: ?*const ccd_parser.ComponentDict,
+    external_ccd: ?*const ccd_parser.ComponentDict,
+) !void {
     const n = input.atomCount();
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
@@ -681,7 +703,7 @@ fn applyBuiltinClassifier(input: *AtomInput, ct: ClassifierType, sdf_ccd: ?*cons
         }
 
         if (needed.count() > 0) {
-            const dicts: [2]?*const ccd_parser.ComponentDict = .{ sdf_ccd, external_ccd };
+            const dicts: [3]?*const ccd_parser.ComponentDict = .{ sdf_ccd, inline_ccd, external_ccd };
             for (dicts) |maybe_dict| {
                 if (maybe_dict) |dict| {
                     var it = needed.keyIterator();
@@ -948,17 +970,17 @@ fn processOneFile(
     };
 
     // Read and parse input (auto-detect format from extension)
-    var input = readInputFile(arena, io, input_path, config) catch |err| {
+    var parsed = readInputFile(arena, io, input_path, config) catch |err| {
         result.status = .err;
         result.error_msg = std.fmt.allocPrint(result_allocator, "read/parse failed: {s}", .{@errorName(err)}) catch null;
         return result;
     };
-    defer input.deinit();
+    defer parsed.deinit();
 
     // Apply classifier for PDB/mmCIF input (skip JSON unless classification info exists).
     if (config.custom_classifier) |custom_classifier| {
-        if (input.hasClassificationInfo()) {
-            applyCustomClassifier(&input, custom_classifier, config.quiet) catch |err| {
+        if (parsed.input.hasClassificationInfo()) {
+            applyCustomClassifier(&parsed.input, custom_classifier, config.quiet) catch |err| {
                 result.status = .err;
                 result.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return result;
@@ -966,8 +988,8 @@ fn processOneFile(
         }
     } else if (config.classifier_type) |ct| {
         const format = format_detect.detectInputFormat(input_path);
-        if (format != .json and input.hasClassificationInfo()) {
-            applyBuiltinClassifier(&input, ct, config.sdf_ccd, config.external_ccd) catch |err| {
+        if (format != .json and parsed.input.hasClassificationInfo()) {
+            applyBuiltinClassifier(&parsed.input, ct, config.sdf_ccd, parsed.inlineCcdPtr(), config.external_ccd) catch |err| {
                 result.status = .err;
                 result.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return result;
@@ -981,7 +1003,7 @@ fn processOneFile(
             arena,
             io,
             result_allocator,
-            input,
+            parsed.input,
             output_dir,
             filename,
             config,
@@ -995,7 +1017,7 @@ fn processOneFile(
             arena,
             io,
             result_allocator,
-            input,
+            parsed.input,
             output_dir,
             filename,
             config,
@@ -1120,7 +1142,7 @@ fn processOneSdfMoleculeInner(
         if (input.hasClassificationInfo()) {
             // Merge SDF-derived dict with external CCD if available
             const effective_sdf_ccd = sdf_ccd orelse config.sdf_ccd;
-            applyBuiltinClassifier(input, ct, effective_sdf_ccd, config.external_ccd) catch |err| {
+            applyBuiltinClassifier(input, ct, effective_sdf_ccd, null, config.external_ccd) catch |err| {
                 res.status = .err;
                 res.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return res;
@@ -3224,39 +3246,39 @@ fn runWorkflowBsaAnalysis(
 
         var source_config = config;
         source_config.chain_filter = null;
-        var source_input = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
+        var source_parsed = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
             failed += 1;
             std.debug.print("Error running BSA analysis '{s}' on '{s}': read/parse failed: {s}\n", .{ name, filename, @errorName(err) });
             _ = arena.reset(.retain_capacity);
             continue;
         };
 
-        workflowClassifySourceInput(&source_input, input_path, source_config) catch |err| {
+        workflowClassifySourceInput(&source_parsed.input, source_parsed.inlineCcdPtr(), input_path, source_config) catch |err| {
             failed += 1;
             std.debug.print("Error running BSA analysis '{s}' on '{s}': classifier failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         };
 
-        const partner_a_input = copySelectedAtomInput(arena.allocator(), source_input, partner_a) catch |err| {
+        const partner_a_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, partner_a) catch |err| {
             failed += 1;
             std.debug.print("Error running BSA analysis '{s}' on '{s}': partner A selection failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         };
-        const partner_b_input = copySelectedAtomInput(arena.allocator(), source_input, partner_b) catch |err| {
+        const partner_b_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, partner_b) catch |err| {
             failed += 1;
             std.debug.print("Error running BSA analysis '{s}' on '{s}': partner B selection failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         };
-        const complex_input = copySelectedAtomInput(arena.allocator(), source_input, complex_chains) catch |err| {
+        const complex_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, complex_chains) catch |err| {
             failed += 1;
             std.debug.print("Error running BSA analysis '{s}' on '{s}': complex selection failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         };
@@ -3278,26 +3300,26 @@ fn runWorkflowBsaAnalysis(
         if (partner_a_result.status != .ok or partner_b_result.status != .ok or complex_result.status != .ok) {
             failed += 1;
             std.debug.print("Error running BSA analysis '{s}' on '{s}': SASA calculation failed\n", .{ name, filename });
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         }
 
         const partner_a_areas = partner_a_result.atom_areas orelse {
             failed += 1;
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         };
         const partner_b_areas = partner_b_result.atom_areas orelse {
             failed += 1;
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         };
         const complex_areas = complex_result.atom_areas orelse {
             failed += 1;
-            source_input.deinit();
+            source_parsed.deinit();
             _ = arena.reset(.retain_capacity);
             continue;
         };
@@ -3322,7 +3344,7 @@ fn runWorkflowBsaAnalysis(
             residue_arrays = buildBsaResidueDeltaArrays(arena.allocator(), complex_input, atom_delta_sasa) catch |err| {
                 failed += 1;
                 std.debug.print("Error running BSA analysis '{s}' on '{s}': residue delta map failed: {s}\n", .{ name, filename, @errorName(err) });
-                source_input.deinit();
+                source_parsed.deinit();
                 _ = arena.reset(.retain_capacity);
                 continue;
             };
@@ -3348,7 +3370,7 @@ fn runWorkflowBsaAnalysis(
 
         successful += 1;
         total_sasa_time_ns += partner_a_result.sasa_time_ns + partner_b_result.sasa_time_ns + complex_result.sasa_time_ns;
-        source_input.deinit();
+        source_parsed.deinit();
         _ = arena.reset(.retain_capacity);
     }
 
@@ -3397,6 +3419,7 @@ fn workflowMarkAllJobsFailed(ctx: *WorkflowParallelContext) void {
 
 fn workflowClassifySourceInput(
     input: *AtomInput,
+    inline_ccd: ?*const ccd_parser.ComponentDict,
     input_path: []const u8,
     config: BatchConfig,
 ) !void {
@@ -3407,7 +3430,7 @@ fn workflowClassifySourceInput(
     } else if (config.classifier_type) |ct| {
         const format = format_detect.detectInputFormat(input_path);
         if (format != .json and input.hasClassificationInfo()) {
-            try applyBuiltinClassifier(input, ct, config.sdf_ccd, config.external_ccd);
+            try applyBuiltinClassifier(input, ct, config.sdf_ccd, inline_ccd, config.external_ccd);
         }
     }
 }
@@ -3431,7 +3454,7 @@ fn workflowParallelWorker(ctx: *WorkflowParallelContext) void {
 
         var source_config = ctx.resource_config;
         source_config.chain_filter = null;
-        var source_input = readInputFile(arena.allocator(), ctx.io, input_path, source_config) catch |err| {
+        var source_parsed = readInputFile(arena.allocator(), ctx.io, input_path, source_config) catch |err| {
             workflowMarkAllJobsFailed(ctx);
             for (ctx.runtimes) |runtime| {
                 std.debug.print("Error running workflow job '{s}' on '{s}': read/parse failed: {s}\n", .{ runtime.state.name, filename, @errorName(err) });
@@ -3441,12 +3464,12 @@ fn workflowParallelWorker(ctx: *WorkflowParallelContext) void {
             continue;
         };
 
-        workflowClassifySourceInput(&source_input, input_path, source_config) catch |err| {
+        workflowClassifySourceInput(&source_parsed.input, source_parsed.inlineCcdPtr(), input_path, source_config) catch |err| {
             workflowMarkAllJobsFailed(ctx);
             for (ctx.runtimes) |runtime| {
                 std.debug.print("Error running workflow job '{s}' on '{s}': classifier failed: {s}\n", .{ runtime.state.name, filename, @errorName(err) });
             }
-            source_input.deinit();
+            source_parsed.deinit();
             _ = ctx.processed_count.fetchAdd(1, .release);
             _ = arena.reset(.retain_capacity);
             continue;
@@ -3456,7 +3479,7 @@ fn workflowParallelWorker(ctx: *WorkflowParallelContext) void {
         for (ctx.jobs, 0..) |job, job_index| {
             var runtime = &ctx.runtimes[job_index];
             const selected_chains: ?[]const []const u8 = if (format == .json) null else job.chains;
-            var selected_input = copySelectedAtomInput(arena.allocator(), source_input, selected_chains) catch |err| {
+            var selected_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, selected_chains) catch |err| {
                 _ = runtime.counter.failed.fetchAdd(1, .monotonic);
                 std.debug.print("Error running workflow job '{s}' on '{s}': selection failed: {s}\n", .{ runtime.state.name, filename, @errorName(err) });
                 continue;
@@ -3485,7 +3508,7 @@ fn workflowParallelWorker(ctx: *WorkflowParallelContext) void {
             result.residue_map = null;
         }
 
-        source_input.deinit();
+        source_parsed.deinit();
         _ = ctx.processed_count.fetchAdd(1, .release);
         _ = arena.reset(.retain_capacity);
     }
@@ -3835,7 +3858,7 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
 
         var source_config = resource_config;
         source_config.chain_filter = null;
-        var source_input = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
+        var source_parsed = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
             for (states) |*state| {
                 state.failed += 1;
                 std.debug.print("Error running workflow job '{s}' on '{s}': read/parse failed: {s}\n", .{ state.name, filename, @errorName(err) });
@@ -3845,26 +3868,26 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
         };
 
         if (source_config.custom_classifier) |custom| {
-            if (source_input.hasClassificationInfo()) {
-                applyCustomClassifier(&source_input, custom, source_config.quiet) catch |err| {
+            if (source_parsed.input.hasClassificationInfo()) {
+                applyCustomClassifier(&source_parsed.input, custom, source_config.quiet) catch |err| {
                     for (states) |*state| {
                         state.failed += 1;
                         std.debug.print("Error running workflow job '{s}' on '{s}': classifier failed: {s}\n", .{ state.name, filename, @errorName(err) });
                     }
-                    source_input.deinit();
+                    source_parsed.deinit();
                     _ = arena.reset(.retain_capacity);
                     continue;
                 };
             }
         } else if (source_config.classifier_type) |ct| {
             const format = format_detect.detectInputFormat(input_path);
-            if (format != .json and source_input.hasClassificationInfo()) {
-                applyBuiltinClassifier(&source_input, ct, source_config.sdf_ccd, source_config.external_ccd) catch |err| {
+            if (format != .json and source_parsed.input.hasClassificationInfo()) {
+                applyBuiltinClassifier(&source_parsed.input, ct, source_config.sdf_ccd, source_parsed.inlineCcdPtr(), source_config.external_ccd) catch |err| {
                     for (states) |*state| {
                         state.failed += 1;
                         std.debug.print("Error running workflow job '{s}' on '{s}': classifier failed: {s}\n", .{ state.name, filename, @errorName(err) });
                     }
-                    source_input.deinit();
+                    source_parsed.deinit();
                     _ = arena.reset(.retain_capacity);
                     continue;
                 };
@@ -3875,7 +3898,7 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
             var state = &states[job_index];
 
             const selected_chains: ?[]const []const u8 = if (format_detect.detectInputFormat(input_path) == .json) null else job.chains;
-            var selected_input = copySelectedAtomInput(arena.allocator(), source_input, selected_chains) catch |err| {
+            var selected_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, selected_chains) catch |err| {
                 state.failed += 1;
                 std.debug.print("Error running workflow job '{s}' on '{s}': selection failed: {s}\n", .{ state.name, filename, @errorName(err) });
                 continue;
@@ -3912,7 +3935,7 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
             result.residue_map = null;
         }
 
-        source_input.deinit();
+        source_parsed.deinit();
         _ = arena.reset(.retain_capacity);
     }
 
@@ -4564,6 +4587,73 @@ test "batch resource resolver only loads CCD resources for CCD classifiers" {
     const resolved_sdf_paths = resolveWorkflowSdfPaths(explicit_resource_args, workflow_sdf_paths[0..], .ccd);
     try std.testing.expectEqual(@as(usize, 1), resolved_sdf_paths.len);
     try std.testing.expectEqualStrings("cli.sdf", resolved_sdf_paths[0]);
+}
+
+test "batch mmCIF CCD classifier uses inline CCD while ProtOr skips it" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root_path = root_buf[0..root_len];
+    const cif_path = try std.fs.path.join(allocator, &.{ root_path, "ligand.cif" });
+    defer allocator.free(cif_path);
+
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = cif_path,
+        .data =
+        \\data_LIGAND
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\_chem_comp_atom.pdbx_aromatic_flag
+        \\_chem_comp_atom.pdbx_leaving_atom_flag
+        \\LIG C1 C N N
+        \\LIG N1 N N N
+        \\#
+        \\loop_
+        \\_chem_comp_bond.comp_id
+        \\_chem_comp_bond.atom_id_1
+        \\_chem_comp_bond.atom_id_2
+        \\_chem_comp_bond.value_order
+        \\LIG C1 N1 SING
+        \\#
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.group_PDB
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C C1 LIG HETATM 0.0 0.0 0.0
+        \\2 N N1 LIG HETATM 2.0 0.0 0.0
+        \\#
+        \\
+        ,
+    });
+
+    var ccd_parsed = try readInputFile(allocator, std.testing.io, cif_path, .{
+        .classifier_type = .ccd,
+        .include_hetatm = true,
+    });
+    defer ccd_parsed.deinit();
+    try std.testing.expect(ccd_parsed.inlineCcdPtr() != null);
+    try applyBuiltinClassifier(&ccd_parsed.input, .ccd, null, ccd_parsed.inlineCcdPtr(), null);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.64), ccd_parsed.input.r[1], 0.001);
+
+    var protor_parsed = try readInputFile(allocator, std.testing.io, cif_path, .{
+        .classifier_type = .protor,
+        .include_hetatm = true,
+    });
+    defer protor_parsed.deinit();
+    try std.testing.expect(protor_parsed.inlineCcdPtr() == null);
+    try applyBuiltinClassifier(&protor_parsed.input, .protor, null, protor_parsed.inlineCcdPtr(), null);
+    try std.testing.expect(protor_parsed.input.r[1] != 1.64);
 }
 
 test "resolveBatchThreadCount allows explicit overcommit for IO-bound runs" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -1067,7 +1067,7 @@ fn processOneSdfMolecule(
 
     // Build CCD component dict for this molecule's bond topology
     var sdf_dict: ?ccd_parser.ComponentDict = null;
-    if (molecule.name.len > 0) {
+    if (classifierUsesCcdResources(config.classifier_type) and molecule.name.len > 0) {
         const stored = sdf_parser.toStoredComponent(arena, molecule) catch |err| blk: {
             logWarning("{s}: failed to build SDF component: {s}", .{ display_name, @errorName(err) });
             break :blk null;
@@ -3022,6 +3022,10 @@ fn classifierUsesCcdResources(effective_classifier_type: ?ClassifierType) bool {
     return classifier_type == .ccd;
 }
 
+fn batchArgsUseCcdResources(args: BatchArgs) bool {
+    return classifierUsesCcdResources(args.classifier_type);
+}
+
 fn resolveWorkflowCcdPath(args: BatchArgs, classifier_config: workflow_manifest.ClassifierConfig, effective_classifier_type: ?ClassifierType) ?[]const u8 {
     if (!classifierUsesCcdResources(effective_classifier_type)) return null;
     if (args.ccd_explicit) return args.ccd_path;
@@ -3966,40 +3970,43 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
 
     // Load external CCD dictionary if specified
     var ext_ccd: ?ccd_parser.ComponentDict = null;
-    if (args.ccd_path) |ccd_path| {
-        const ccd_data = if (compressed.isCompressed(ccd_path))
-            compressed.read(allocator, ccd_path) catch |err| {
-                std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
-                std.process.exit(1);
-            }
-        else blk: {
-            const f = std.Io.Dir.cwd().openFile(io, ccd_path, .{}) catch |err| {
-                std.debug.print("Error opening CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
-                std.process.exit(1);
+    const use_ccd_resources = batchArgsUseCcdResources(args);
+    if (use_ccd_resources) {
+        if (args.ccd_path) |ccd_path| {
+            const ccd_data = if (compressed.isCompressed(ccd_path))
+                compressed.read(allocator, ccd_path) catch |err| {
+                    std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                    std.process.exit(1);
+                }
+            else blk: {
+                const f = std.Io.Dir.cwd().openFile(io, ccd_path, .{}) catch |err| {
+                    std.debug.print("Error opening CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                    std.process.exit(1);
+                };
+                defer f.close(io);
+                var read_buf_ccd: [65536]u8 = undefined;
+                var file_r_ccd = f.reader(io, &read_buf_ccd);
+                break :blk file_r_ccd.interface.allocRemaining(allocator, .unlimited) catch |err| {
+                    std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                    std.process.exit(1);
+                };
             };
-            defer f.close(io);
-            var read_buf_ccd: [65536]u8 = undefined;
-            var file_r_ccd = f.reader(io, &read_buf_ccd);
-            break :blk file_r_ccd.interface.allocRemaining(allocator, .unlimited) catch |err| {
-                std.debug.print("Error reading CCD file '{s}': {s}\n", .{ ccd_path, @errorName(err) });
-                std.process.exit(1);
-            };
-        };
-        defer allocator.free(ccd_data);
+            defer allocator.free(ccd_data);
 
-        ext_ccd = ccd_binary.loadDict(allocator, ccd_data) catch |err| {
-            std.debug.print("Error loading CCD dictionary '{s}': {s}\n", .{ ccd_path, @errorName(err) });
-            std.process.exit(1);
-        };
-        if (!args.quiet) {
-            std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), ccd_path });
+            ext_ccd = ccd_binary.loadDict(allocator, ccd_data) catch |err| {
+                std.debug.print("Error loading CCD dictionary '{s}': {s}\n", .{ ccd_path, @errorName(err) });
+                std.process.exit(1);
+            };
+            if (!args.quiet) {
+                std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), ccd_path });
+            }
         }
     }
     defer if (ext_ccd) |*d| d.deinit();
 
     // Load SDF components from --sdf option
     var sdf_ccd: ?ccd_parser.ComponentDict = null;
-    if (args.sdf_paths.len > 0) {
+    if (use_ccd_resources and args.sdf_paths.len > 0) {
         sdf_ccd = loadSdfComponents(allocator, io, args.sdf_paths.constSlice(), args.quiet) catch |err| {
             std.debug.print("Error loading SDF components: {s}\n", .{@errorName(err)});
             std.process.exit(1);
@@ -4553,6 +4560,11 @@ test "workflow custom classifier config path resolves for batch" {
 }
 
 test "batch resource resolver only loads CCD resources for CCD classifiers" {
+    try std.testing.expect(batchArgsUseCcdResources(.{ .classifier_type = .ccd }));
+    try std.testing.expect(!batchArgsUseCcdResources(.{ .classifier_type = .protor }));
+    try std.testing.expect(!batchArgsUseCcdResources(.{ .classifier_type = .naccess }));
+    try std.testing.expect(!batchArgsUseCcdResources(.{ .classifier_type = .oons }));
+
     const classifier_config = @import("workflow_manifest.zig").ClassifierConfig{
         .ccd = "workflow.zsdc",
     };

--- a/src/bcif_parser.zig
+++ b/src/bcif_parser.zig
@@ -635,6 +635,7 @@ pub const BcifParser = struct {
     model_num: ?u32 = null,
     chain_filter: ?[]const []const u8 = null,
     use_auth_chain: bool = false,
+    parse_inline_ccd: bool = true,
     inline_ccd: ?ccd_parser.ComponentDict = null,
 
     pub fn init(allocator: Allocator) BcifParser {
@@ -665,12 +666,16 @@ pub const BcifParser = struct {
         const root = try reader.readValue();
         defer freeMsgValue(self.allocator, root);
 
-        var inline_ccd = try parseInlineCcd(self.allocator, root);
-        if (inline_ccd.count() == 0) {
-            inline_ccd.deinit();
-            self.inline_ccd = null;
+        if (self.parse_inline_ccd) {
+            var inline_ccd = try parseInlineCcd(self.allocator, root);
+            if (inline_ccd.count() == 0) {
+                inline_ccd.deinit();
+                self.inline_ccd = null;
+            } else {
+                self.inline_ccd = inline_ccd;
+            }
         } else {
-            self.inline_ccd = inline_ccd;
+            self.inline_ccd = null;
         }
         errdefer self.deinitCcd();
 
@@ -2007,6 +2012,21 @@ test "parse BinaryCIF with inline CCD data" {
     try std.testing.expectEqual(@as(u16, 0), comp.bonds[0].atom_idx_1);
     try std.testing.expectEqual(@as(u16, 1), comp.bonds[0].atom_idx_2);
     try std.testing.expectEqual(.double, comp.bonds[0].order);
+}
+
+test "parse BinaryCIF can skip inline CCD data" {
+    const source = try buildMinimalBcifWithInlineCcd();
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    parser.atom_only = false;
+    parser.parse_inline_ccd = false;
+    var input = try parser.parse(source);
+    defer input.deinit();
+    defer parser.deinitCcd();
+
+    try std.testing.expectEqual(@as(usize, 3), input.atomCount());
+    try std.testing.expect(parser.getInlineCcd() == null);
 }
 
 test "parse BinaryCIF default model selection includes all models" {

--- a/src/bcif_parser.zig
+++ b/src/bcif_parser.zig
@@ -650,6 +650,14 @@ pub const BcifParser = struct {
         return null;
     }
 
+    /// Move inline CCD data out of the parser. The caller owns the returned
+    /// dictionary and must call `.deinit()` on it.
+    pub fn takeInlineCcd(self: *BcifParser) ?ccd_parser.ComponentDict {
+        const dict = self.inline_ccd;
+        self.inline_ccd = null;
+        return dict;
+    }
+
     /// Clean up inline CCD data. Must be called before the parser goes out of
     /// scope when `parse()` has been called and `getInlineCcd()` is non-null.
     pub fn deinitCcd(self: *BcifParser) void {

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -11,7 +11,6 @@ const lee_richards = @import("lee_richards.zig");
 const types = @import("types.zig");
 const classifier = @import("classifier.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
-// classifier_protor removed — ProtOr is now an alias for CCD
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
 const analysis = @import("analysis.zig");

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -51,7 +51,7 @@ pub const ZSASA_ALGORITHM_LR: c_int = 1;
 
 /// NACCESS-compatible radii
 pub const ZSASA_CLASSIFIER_NACCESS: c_int = 0;
-/// Alias for CCD (backward compatibility)
+/// Static ProtOr-compatible radii
 pub const ZSASA_CLASSIFIER_PROTOR: c_int = 1;
 /// OONS radii (older FreeSASA default)
 pub const ZSASA_CLASSIFIER_OONS: c_int = 2;

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -994,6 +994,10 @@ fn readInputFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, arg
 
             const input_result = try sdf_parser.toAtomInput(allocator, selected, !args.include_hydrogens);
 
+            if (!calcArgsUseCcdResources(args)) {
+                break :blk .{ .input = input_result };
+            }
+
             // Build CCD component dict from selected molecule's bond topology
             var sdf_dict = ccd_parser.ComponentDict.init(allocator);
             errdefer sdf_dict.deinit();

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -18,7 +18,6 @@ const types = @import("types.zig");
 const classifier = @import("classifier.zig");
 const classifier_parser = @import("classifier_parser.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
-// classifier_protor removed — ProtOr is now an alias for CCD
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
 const ccd_parser = @import("ccd_parser.zig");
@@ -757,7 +756,7 @@ fn applyWorkflowClassifierToCalcArgs(args: *CalcArgs, classifier_config: workflo
 
 fn classifierUsesCcdResources(effective_classifier_type: ?ClassifierType) bool {
     const classifier_type = effective_classifier_type orelse return false;
-    return classifier_type == .ccd or classifier_type == .protor;
+    return classifier_type == .ccd;
 }
 
 fn calcArgsUseCcdResources(args: CalcArgs) bool {
@@ -788,7 +787,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\                       Default: sr
         \\    --classifier=TYPE  Built-in classifier: ccd, protor, naccess, oons
         \\                       Default: ccd for PDB/mmCIF, none for JSON
-        \\                       protor is an alias for ccd
+        \\                       protor uses static ProtOr-compatible radii only
         \\    --ccd=PATH         External CCD dictionary file (.zsdc or .cif[.gz|.zst])
         \\                       Extends CCD coverage for non-standard residues
         \\    --sdf=PATH         SDF file with bond topology for CCD classifier
@@ -834,7 +833,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\
         \\CLASSIFIERS:
         \\    ccd      CCD bond-topology radii (default for PDB/mmCIF)
-        \\    protor   Alias for ccd (ProtOr-compatible, Tsai et al. 1999)
+        \\    protor   Static ProtOr-compatible radii (Tsai et al. 1999)
         \\    naccess  NACCESS-compatible radii
         \\    oons     OONS radii (Ooi et al.)
         \\
@@ -926,6 +925,7 @@ fn readInputFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, arg
             parser.use_auth_chain = args.use_auth_chain;
             parser.skip_hydrogens = !args.include_hydrogens;
             parser.atom_only = !args.include_hetatm;
+            parser.parse_inline_ccd = calcArgsUseCcdResources(args);
 
             // Parse chain filter if specified
             var chain_filter_slice: ?[]const []const u8 = null;
@@ -944,6 +944,7 @@ fn readInputFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, arg
             parser.use_auth_chain = args.use_auth_chain;
             parser.skip_hydrogens = !args.include_hydrogens;
             parser.atom_only = !args.include_hetatm;
+            parser.parse_inline_ccd = calcArgsUseCcdResources(args);
 
             // Parse chain filter if specified
             var chain_filter_slice: ?[]const []const u8 = null;
@@ -1106,14 +1107,14 @@ fn applyBuiltinClassifier(
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
-    // For CCD/ProtOr: create classifier instance and feed inline/external CCD components
-    // ProtOr is an alias for CCD (same hardcoded radii, plus runtime CCD analysis)
+    // CCD and ProtOr share the static ProtOr-compatible table. Only CCD may
+    // extend it with runtime component topology.
     var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd or ct == .protor) classifier_ccd.CcdClassifier.init(input.allocator) else null;
     defer if (ccd_clf) |*c| c.deinit();
 
     // Feed CCD components for non-standard residues
     // Only load components that are actually present in the input structure
-    if (ccd_clf != null) {
+    if (ct == .ccd and ccd_clf != null) {
         // Collect unique non-hardcoded residue names from input
         var needed: std.StringHashMapUnmanaged(void) = .empty;
         defer needed.deinit(input.allocator);
@@ -1360,6 +1361,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: CalcArgs) !void {
     const input_format = format_detect.detectInputFormat(input_path);
     const effective_classifier: ?ClassifierType = effective_args.classifier_type orelse
         if (effective_args.config_path == null and input_format != .json) .ccd else null;
+    effective_args.classifier_type = if (effective_args.validate_only) null else effective_classifier;
 
     // CCD classifier implies HETATM inclusion (the whole point is classifying non-standard residues)
     if (effective_classifier) |ct| {
@@ -2252,34 +2254,44 @@ test "calc CLI explicit classifier overrides workflow classifier" {
     try std.testing.expectEqual(@as(?[]const u8, null), args.config_path);
 }
 
-test "calc workflow applies CCD resources for CCD and ProtOr classifiers" {
+test "calc workflow applies CCD resources only for CCD classifier" {
     const sdf_paths = [_][]const u8{ "workflow-ligand.sdf", "workflow-cofactor.sdf" };
 
-    inline for (.{ ClassifierType.ccd, ClassifierType.protor }) |expected_classifier| {
-        const classifier_type = switch (expected_classifier) {
-            .ccd => "ccd",
-            .protor => "protor",
-            else => unreachable,
-        };
-        const workflow = workflow_manifest.Workflow{
-            .allocator = std.testing.allocator,
-            .content = "",
-            .classifier = .{
-                .type = classifier_type,
-                .ccd = "workflow.zsdc",
-                .sdf = sdf_paths[0..],
-            },
-        };
-        var args = CalcArgs{};
+    const ccd_workflow = workflow_manifest.Workflow{
+        .allocator = std.testing.allocator,
+        .content = "",
+        .classifier = .{
+            .type = "ccd",
+            .ccd = "workflow.zsdc",
+            .sdf = sdf_paths[0..],
+        },
+    };
+    var ccd_args = CalcArgs{};
 
-        try applyWorkflowToCalcArgs(&args, workflow);
+    try applyWorkflowToCalcArgs(&ccd_args, ccd_workflow);
 
-        try std.testing.expectEqual(expected_classifier, args.classifier_type.?);
-        try std.testing.expectEqualStrings("workflow.zsdc", args.ccd_path.?);
-        try std.testing.expectEqual(@as(usize, 2), args.sdf_paths.len);
-        try std.testing.expectEqualStrings("workflow-ligand.sdf", args.sdf_paths.constSlice()[0]);
-        try std.testing.expectEqualStrings("workflow-cofactor.sdf", args.sdf_paths.constSlice()[1]);
-    }
+    try std.testing.expectEqual(ClassifierType.ccd, ccd_args.classifier_type.?);
+    try std.testing.expectEqualStrings("workflow.zsdc", ccd_args.ccd_path.?);
+    try std.testing.expectEqual(@as(usize, 2), ccd_args.sdf_paths.len);
+    try std.testing.expectEqualStrings("workflow-ligand.sdf", ccd_args.sdf_paths.constSlice()[0]);
+    try std.testing.expectEqualStrings("workflow-cofactor.sdf", ccd_args.sdf_paths.constSlice()[1]);
+
+    const protor_workflow = workflow_manifest.Workflow{
+        .allocator = std.testing.allocator,
+        .content = "",
+        .classifier = .{
+            .type = "protor",
+            .ccd = "workflow.zsdc",
+            .sdf = sdf_paths[0..],
+        },
+    };
+    var protor_args = CalcArgs{};
+
+    try applyWorkflowToCalcArgs(&protor_args, protor_workflow);
+
+    try std.testing.expectEqual(ClassifierType.protor, protor_args.classifier_type.?);
+    try std.testing.expectEqual(@as(?[]const u8, null), protor_args.ccd_path);
+    try std.testing.expectEqual(@as(usize, 0), protor_args.sdf_paths.len);
 }
 
 test "calc CLI explicit CCD resources are preserved for CCD workflow classifier" {

--- a/src/classifier.zig
+++ b/src/classifier.zig
@@ -10,9 +10,10 @@
 //!
 //! ## Available Built-in Classifiers
 //!
-//! - **CCD**: Default. Derives radii from CCD bond topology (ProtOr-compatible).
-//!   ProtOr is an alias for CCD — they use the same hardcoded radii, but CCD
-//!   additionally supports runtime analysis of non-standard residues.
+//! - **CCD**: Default. Uses ProtOr-compatible hardcoded radii and can extend
+//!   them with runtime CCD bond-topology analysis for non-standard residues.
+//! - **ProtOr**: Static ProtOr-compatible hardcoded radii only. This is useful
+//!   for protein-only inputs where runtime CCD analysis is unnecessary.
 //! - **NACCESS**: NACCESS-compatible radii (João Rodrigues)
 //! - **OONS**: Ooi, Oobatake, Nemethy, Scheraga radii (older FreeSASA default)
 //!
@@ -40,15 +41,13 @@ pub const ClassifierType = enum {
     /// Based on naccess.config from FreeSASA (João Rodrigues)
     naccess,
 
-    /// Alias for CCD — kept for backward compatibility
-    /// Uses the same CCD classifier internally
+    /// Static ProtOr-compatible hardcoded radii
     protor,
 
     /// OONS radii (older FreeSASA default)
     /// Reference: Ooi, Oobatake, Nemethy, Scheraga
     oons,
 
-    /// CCD-based radii derived from bond topology (default)
     /// Hardcoded ProtOr radii + runtime CCD analysis for non-standard residues
     ccd,
 

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -134,6 +134,14 @@ pub const MmcifParser = struct {
         return null;
     }
 
+    /// Move inline CCD data out of the parser. The caller owns the returned
+    /// dictionary and must call `.deinit()` on it.
+    pub fn takeInlineCcd(self: *MmcifParser) ?ccd_parser.ComponentDict {
+        const dict = self.inline_ccd;
+        self.inline_ccd = null;
+        return dict;
+    }
+
     /// Clean up inline CCD data. Must be called before the parser goes out of
     /// scope when `parse()` has been called and `getInlineCcd()` is non-null.
     pub fn deinitCcd(self: *MmcifParser) void {

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -118,6 +118,9 @@ pub const MmcifParser = struct {
     chain_filter: ?[]const []const u8 = null,
     /// Use auth_asym_id instead of label_asym_id for chain
     use_auth_chain: bool = false,
+    /// Parse inline CCD data from `_chem_comp_atom`/`_chem_comp_bond` loops.
+    /// Disable this when the caller will not use inline CCD resources.
+    parse_inline_ccd: bool = true,
     /// Inline CCD data parsed from `_chem_comp_atom`/`_chem_comp_bond` loops
     inline_ccd: ?ccd_parser.ComponentDict = null,
 
@@ -142,13 +145,21 @@ pub const MmcifParser = struct {
 
     /// Parse mmCIF from a string
     pub fn parse(self: *MmcifParser, source: []const u8) !AtomInput {
+        self.deinitCcd();
+
         // First pass: extract any inline CCD data (_chem_comp_atom / _chem_comp_bond)
-        var ccd_dict = try ccd_parser.parseCcdData(self.allocator, source, null);
-        if (ccd_dict.count() == 0) {
-            ccd_dict.deinit();
-            self.inline_ccd = null;
+        // only when the caller can use it. Most protein-only batch workflows do
+        // not need this full-file scan.
+        if (self.parse_inline_ccd and hasInlineCcdAtomTag(source)) {
+            var ccd_dict = try ccd_parser.parseCcdData(self.allocator, source, null);
+            if (ccd_dict.count() == 0) {
+                ccd_dict.deinit();
+                self.inline_ccd = null;
+            } else {
+                self.inline_ccd = ccd_dict;
+            }
         } else {
-            self.inline_ccd = ccd_dict;
+            self.inline_ccd = null;
         }
 
         // Second pass: parse _atom_site loop for coordinates
@@ -621,6 +632,10 @@ pub const MmcifParser = struct {
         return true;
     }
 };
+
+fn hasInlineCcdAtomTag(source: []const u8) bool {
+    return std.mem.indexOf(u8, source, "_chem_comp_atom.") != null;
+}
 
 fn freeStringItems(allocator: Allocator, items: []const []const u8) void {
     for (items) |item| allocator.free(item);
@@ -1259,4 +1274,40 @@ test "parse mmCIF with inline CCD after atom_site" {
     try std.testing.expect(comp != null);
     try std.testing.expectEqual(@as(usize, 4), comp.?.atoms.len);
     try std.testing.expectEqual(@as(usize, 3), comp.?.bonds.len);
+}
+
+test "parse mmCIF can skip inline CCD extraction" {
+    const source =
+        \\data_TEST
+        \\#
+        \\loop_
+        \\_chem_comp_atom.comp_id
+        \\_chem_comp_atom.atom_id
+        \\_chem_comp_atom.type_symbol
+        \\LIG C1 C
+        \\LIG O1 O
+        \\#
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.group_PDB
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C C1 LIG ATOM 10.0 20.0 30.0
+        \\2 O O1 LIG ATOM 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    parser.parse_inline_ccd = false;
+    defer parser.deinitCcd();
+
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expect(parser.getInlineCcd() == null);
 }

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -20,7 +20,6 @@ const pdb_parser = @import("pdb_parser.zig");
 const mmcif_parser = @import("mmcif_parser.zig");
 const classifier = @import("classifier.zig");
 const classifier_naccess = @import("classifier_naccess.zig");
-// classifier_protor removed — ProtOr is now an alias for CCD
 const classifier_oons = @import("classifier_oons.zig");
 const classifier_ccd = @import("classifier_ccd.zig");
 const ccd_parser = @import("ccd_parser.zig");
@@ -860,6 +859,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
         .mmcif => blk: {
             var parser = mmcif_parser.MmcifParser.init(allocator);
             parser.skip_hydrogens = !args.include_hydrogens;
+            parser.parse_inline_ccd = false;
             break :blk try parser.parseFile(io, topology_path);
         },
     };
@@ -871,29 +871,32 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
     }
 
     // Load external CCD dictionary if specified
+    const use_ccd_resources = args.classifier_type == .ccd;
     var ext_ccd: ?ccd_parser.ComponentDict = null;
-    if (args.ccd_path) |ccd_path| {
-        const ccd_data = if (compressed.isCompressed(ccd_path))
-            try compressed.read(allocator, ccd_path)
-        else blk: {
-            const f = try std.Io.Dir.cwd().openFile(io, ccd_path, .{});
-            defer f.close(io);
-            var read_buf_ccd: [65536]u8 = undefined;
-            var file_r_ccd = f.reader(io, &read_buf_ccd);
-            break :blk try file_r_ccd.interface.allocRemaining(allocator, .unlimited);
-        };
-        defer allocator.free(ccd_data);
+    if (use_ccd_resources) {
+        if (args.ccd_path) |ccd_path| {
+            const ccd_data = if (compressed.isCompressed(ccd_path))
+                try compressed.read(allocator, ccd_path)
+            else blk: {
+                const f = try std.Io.Dir.cwd().openFile(io, ccd_path, .{});
+                defer f.close(io);
+                var read_buf_ccd: [65536]u8 = undefined;
+                var file_r_ccd = f.reader(io, &read_buf_ccd);
+                break :blk try file_r_ccd.interface.allocRemaining(allocator, .unlimited);
+            };
+            defer allocator.free(ccd_data);
 
-        ext_ccd = try ccd_binary.loadDict(allocator, ccd_data);
-        if (!args.quiet) {
-            std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), ccd_path });
+            ext_ccd = try ccd_binary.loadDict(allocator, ccd_data);
+            if (!args.quiet) {
+                std.debug.print("External CCD: loaded {d} components from '{s}'\n", .{ ext_ccd.?.components.count(), ccd_path });
+            }
         }
     }
     defer if (ext_ccd) |*d| d.deinit();
 
     // Load SDF components from --sdf option
     var sdf_ccd: ?ccd_parser.ComponentDict = null;
-    if (args.sdf_paths.len > 0) {
+    if (use_ccd_resources and args.sdf_paths.len > 0) {
         sdf_ccd = loadSdfComponents(allocator, io, args.sdf_paths.constSlice(), args.quiet) catch |err| {
             std.debug.print("Error loading SDF components: {s}\n", .{@errorName(err)});
             std.process.exit(1);
@@ -1342,11 +1345,12 @@ fn applyBuiltinClassifier(
     const residues = input.residue orelse return error.MissingClassificationInfo;
     const atom_names = input.atom_name orelse return error.MissingClassificationInfo;
 
-    // For CCD/ProtOr: create classifier instance and feed external CCD components
+    // CCD and ProtOr share the static ProtOr-compatible table. Only CCD may
+    // extend it with runtime component topology.
     var ccd_clf: ?classifier_ccd.CcdClassifier = if (ct == .ccd or ct == .protor) classifier_ccd.CcdClassifier.init(input.allocator) else null;
     defer if (ccd_clf) |*c| c.deinit();
 
-    if (ccd_clf != null) {
+    if (ct == .ccd and ccd_clf != null) {
         // Deduplicate: collect unique non-hardcoded residues
         var needed: std.StringHashMapUnmanaged(void) = .empty;
         defer needed.deinit(input.allocator);

--- a/src/workflow_manifest.zig
+++ b/src/workflow_manifest.zig
@@ -304,7 +304,7 @@ fn validateClassifier(config: ClassifierConfig) WorkflowError!void {
 }
 
 fn classifierAllowsCcdResources(classifier_type: []const u8) bool {
-    return std.mem.eql(u8, classifier_type, "ccd") or std.mem.eql(u8, classifier_type, "protor");
+    return std.mem.eql(u8, classifier_type, "ccd");
 }
 
 fn validateAnalysis(analysis: Analysis) WorkflowError!void {
@@ -848,4 +848,24 @@ test "reject invalid classifier combinations" {
         \\sdf = "ligand.sdf"
     ;
     try std.testing.expectError(error.InvalidClassifierConfig, parse(std.testing.allocator, naccess_with_sdf));
+
+    const protor_with_ccd =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[classifier]
+        \\type = "protor"
+        \\ccd = "components.zsdc"
+    ;
+    try std.testing.expectError(error.InvalidClassifierConfig, parse(std.testing.allocator, protor_with_ccd));
+
+    const protor_with_sdf =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[classifier]
+        \\type = "protor"
+        \\sdf = "ligand.sdf"
+    ;
+    try std.testing.expectError(error.InvalidClassifierConfig, parse(std.testing.allocator, protor_with_sdf));
 }

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -8,6 +8,14 @@ All notable changes to zsasa. See [GitHub Releases](https://github.com/N283T/zsa
 
 ## Unreleased
 
+### Changed
+
+- **ProtOr classifier**: make `--classifier=protor` use static ProtOr-compatible radii without loading inline, external, or SDF-derived CCD resources. This provides a faster protein-only path for mmCIF/PDB inputs such as AFDB models.
+
+### Fixed
+
+- **mmCIF batch parsing**: skip per-file inline CCD extraction in batch mode and avoid scanning mmCIF files for inline CCD data when no `_chem_comp_atom` category is present.
+
 ## [v0.7.1](https://github.com/N283T/zsasa/releases/tag/v0.7.1) — 2026-06-29
 
 ### Fixed

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -14,7 +14,7 @@ All notable changes to zsasa. See [GitHub Releases](https://github.com/N283T/zsa
 
 ### Fixed
 
-- **mmCIF batch parsing**: skip per-file inline CCD extraction in batch mode and avoid scanning mmCIF files for inline CCD data when no `_chem_comp_atom` category is present.
+- **mmCIF batch parsing**: keep per-file inline CCD extraction for `batch --classifier=ccd` when `_chem_comp_atom` data is present, but fast-skip AFDB-like mmCIF files without inline CCD categories.
 
 ## [v0.7.1](https://github.com/N283T/zsasa/releases/tag/v0.7.1) — 2026-06-29
 

--- a/website/docs/cli/input.md
+++ b/website/docs/cli/input.md
@@ -107,7 +107,7 @@ Built-in classifiers assign atom radii based on residue and atom names. See [Cla
 |------------|-------------|
 | `naccess` | NACCESS-compatible radii (Hubbard & Thornton 1993) |
 | `ccd` | CCD bond-topology radii — **default for calc/batch PDB/mmCIF** |
-| `protor` | Alias for CCD, accepted for compatibility |
+| `protor` | Static ProtOr-compatible radii without runtime CCD resource parsing |
 | `oons` | OONS radii (Ooi et al. 1987) |
 
 ### Custom Config (`--config=FILE`)

--- a/website/docs/guide/classifiers.mdx
+++ b/website/docs/guide/classifiers.mdx
@@ -12,7 +12,7 @@ Classifiers assign van der Waals radii and polarity classes to atoms based on re
 ## Quick Recommendation
 
 - **CCD** (default for `calc`/`batch`): ProtOr-compatible hybridization-based radii (Tsai et al. 1999), extended with CCD bond topology analysis for non-standard residues. Uses united-atom radii (implicit H). Recommended for crystal structures.
-- **ProtOr**: Alias for CCD. Accepted for backward compatibility with [FreeSASA](https://freesasa.github.io/).
+- **ProtOr**: Static ProtOr-compatible radii only. Use this for protein-only structures such as AFDB models when runtime CCD bond-topology analysis is unnecessary.
 - **NACCESS** (default for `traj`): Use for MD trajectories with explicit hydrogens, or when reproducing NACCESS-based studies.
 - **OONS**: Larger aliphatic carbon radii (2.00 Å). Use when reproducing or comparing with OONS-based studies.
 
@@ -54,17 +54,17 @@ NACCESS treats S, Se, and P as **apolar**, while ProtOr, OONS, and CCD treat the
 
 ### Key Differences
 
-| Property | CCD (= ProtOr) | NACCESS | OONS |
-|----------|:---:|:---:|:---:|
-| **Basis** | Hybridization state | Atom type | Atom type |
-| **ANY fallback** | No | Yes | Yes |
-| **S, Se, P polarity** | Polar | Apolar | Polar |
-| **Carbonyl C polarity** | Apolar | Apolar | **Polar** |
-| **Non-standard residues** | CCD bond topology | Element fallback | Element fallback |
-| **Reference** | Tsai et al. 1999 + wwPDB CCD | Hubbard & Thornton 1993 | Ooi et al. 1987 |
+| Property | CCD | ProtOr | NACCESS | OONS |
+|----------|:---:|:---:|:---:|:---:|
+| **Basis** | Hybridization state + CCD topology | Hybridization state | Atom type | Atom type |
+| **ANY fallback** | No | No | Yes | Yes |
+| **S, Se, P polarity** | Polar | Polar | Apolar | Polar |
+| **Carbonyl C polarity** | Apolar | Apolar | Apolar | **Polar** |
+| **Non-standard residues** | CCD bond topology when resources are available | Element fallback | Element fallback | Element fallback |
+| **Reference** | Tsai et al. 1999 + wwPDB CCD | Tsai et al. 1999 | Hubbard & Thornton 1993 | Ooi et al. 1987 |
 
-:::info[ProtOr is an alias for CCD]
-`--classifier=protor` and `--classifier=ccd` use the same classifier internally. ProtOr is accepted for backward compatibility with FreeSASA. There is no reason to prefer ProtOr over CCD — CCD is strictly a superset.
+:::info[ProtOr skips CCD resource parsing]
+`--classifier=protor` uses the static ProtOr-compatible radii table and does not load inline, external, or SDF-derived CCD resources. Prefer it for protein-only mmCIF/PDB inputs where CCD topology analysis is unnecessary.
 :::
 
 ## Usage
@@ -191,7 +191,7 @@ type = "C_ALI"
 
 ## CCD Classifier
 
-The CCD classifier is the default classifier in zsasa (`--classifier=protor` is an alias). It derives van der Waals radii from the [wwPDB Chemical Component Dictionary](https://www.wwpdb.org/data/ccd) (CCD) bond topology, using the same hybridization-based radii as ProtOr (Tsai et al. 1999). Unlike NACCESS and OONS — which only cover standard amino acids and nucleotides — the CCD classifier can assign hybridization-aware radii to **any** chemical component: ligands, modified residues, cofactors, post-translational modifications, and more.
+The CCD classifier is the default classifier in zsasa. It derives van der Waals radii from the [wwPDB Chemical Component Dictionary](https://www.wwpdb.org/data/ccd) (CCD) bond topology, using the same hybridization-based radii as ProtOr (Tsai et al. 1999). Unlike NACCESS and OONS — which only cover standard amino acids and nucleotides — the CCD classifier can assign hybridization-aware radii to **any** chemical component: ligands, modified residues, cofactors, post-translational modifications, and more. Use `--classifier=protor` when you want the static ProtOr-compatible table without runtime CCD resource parsing.
 
 ### Why CCD?
 
@@ -219,15 +219,20 @@ The CCD classifier uses a 3-level lookup:
 
 | Input Format | Hardcoded Table | Inline CCD | External CCD (`--ccd=`) |
 |-------------|:-:|:-:|:-:|
-| **mmCIF** | ✅ | ✅ auto-extracted | ✅ |
+| **mmCIF (`calc`)** | ✅ | ✅ auto-extracted with `--classifier=ccd` | ✅ |
+| **mmCIF (`batch`)** | ✅ | skipped for throughput | ✅ |
 | **PDB** | ✅ | — (not available in PDB format) | ✅ |
 
-- **mmCIF input**: Inline CCD data (if present) is automatically parsed. No extra flags needed.
+- **mmCIF calc input**: Inline CCD data (if present) is automatically parsed with `--classifier=ccd`. Use `--classifier=protor` to skip CCD resource parsing for protein-only structures.
+- **mmCIF batch input**: Inline CCD data is skipped for throughput. Provide `--ccd=<path>` or `--sdf=<path>` when batch jobs need CCD topology for non-standard residues.
 - **PDB input**: PDB format does not include bond topology, so inline CCD is not available. For non-standard residues, provide an external CCD dictionary with `--ccd=<path>` to get the same hybridization-aware radii.
 
 ```bash
-# mmCIF — inline CCD is automatically used
+# mmCIF calc — inline CCD is automatically used with CCD
 zsasa calc --classifier=ccd structure.cif output.json
+
+# protein-only mmCIF — skip CCD resource parsing
+zsasa calc --classifier=protor structure.cif output.json
 
 # PDB — use external CCD for non-standard residues
 zsasa calc --classifier=ccd --ccd=HEM.cif structure.pdb output.json
@@ -326,8 +331,8 @@ When a classifier cannot find a matching (residue, atom name) pair:
 2. If still unmatched, the element is extracted from the atom name and a generic van der Waals radius is assigned
 
 The CCD classifier avoids this element fallback for non-standard residues by deriving hybridization-aware radii from CCD bond topology. To maximize coverage:
-- Use mmCIF input (inline CCD is auto-extracted)
-- Or provide `--ccd=<path>` for PDB input
+- Use `zsasa calc --classifier=ccd` with mmCIF input when inline CCD categories are present
+- Provide `--ccd=<path>` for PDB input or batch workloads
 
 To avoid ambiguity (e.g., "CA" = Carbon-alpha vs Calcium), include an `element` field (atomic numbers) in JSON input:
 

--- a/website/docs/guide/classifiers.mdx
+++ b/website/docs/guide/classifiers.mdx
@@ -220,11 +220,11 @@ The CCD classifier uses a 3-level lookup:
 | Input Format | Hardcoded Table | Inline CCD | External CCD (`--ccd=`) |
 |-------------|:-:|:-:|:-:|
 | **mmCIF (`calc`)** | ✅ | ✅ auto-extracted with `--classifier=ccd` | ✅ |
-| **mmCIF (`batch`)** | ✅ | skipped for throughput | ✅ |
+| **mmCIF (`batch`)** | ✅ | ✅ auto-extracted with `--classifier=ccd`; fast-skipped when absent | ✅ |
 | **PDB** | ✅ | — (not available in PDB format) | ✅ |
 
 - **mmCIF calc input**: Inline CCD data (if present) is automatically parsed with `--classifier=ccd`. Use `--classifier=protor` to skip CCD resource parsing for protein-only structures.
-- **mmCIF batch input**: Inline CCD data is skipped for throughput. Provide `--ccd=<path>` or `--sdf=<path>` when batch jobs need CCD topology for non-standard residues.
+- **mmCIF batch input**: Inline CCD data is automatically parsed with `--classifier=ccd` when present. AFDB-like files without `_chem_comp_atom` are detected quickly and do not pay the full inline CCD extraction cost. Use `--classifier=protor` for protein-only runs that should skip all CCD resources.
 - **PDB input**: PDB format does not include bond topology, so inline CCD is not available. For non-standard residues, provide an external CCD dictionary with `--ccd=<path>` to get the same hybridization-aware radii.
 
 ```bash

--- a/website/docs/python-api/classifier.md
+++ b/website/docs/python-api/classifier.md
@@ -7,7 +7,7 @@ Atom classification and RSA calculation.
 ```python
 class ClassifierType(IntEnum):
     NACCESS = 0  # NACCESS-compatible radii
-    PROTOR = 1   # Alias for CCD, kept for compatibility
+    PROTOR = 1   # Static ProtOr-compatible radii
     OONS = 2     # OONS radii
     CCD = 3      # CCD-based radii (default)
 ```

--- a/website/docs/python-api/index.md
+++ b/website/docs/python-api/index.md
@@ -16,7 +16,7 @@ The Python bindings provide:
 - **NumPy integration**: Pass coordinates and radii as NumPy arrays
 - **Two algorithms**: Shrake-Rupley (fast) and Lee-Richards (precise)
 - **Multi-threading**: Automatic parallelization across CPU cores
-- **Atom classification**: CCD (default), PROTOR alias, NACCESS, and OONS classifiers
+- **Atom classification**: CCD (default), static PROTOR, NACCESS, and OONS classifiers
 - **RSA calculation**: Relative Solvent Accessibility
 - **Per-residue aggregation**: Aggregate atom SASA to residue level
 - **Directory batch processing**: Process entire directories of structure files


### PR DESCRIPTION
## Summary

- Add parser controls to skip inline CCD extraction for mmCIF and BinaryCIF when callers do not need inline CCD resources.
- Skip per-file inline CCD extraction in batch and trajectory topology parsing.
- Make `--classifier=protor` use the static ProtOr-compatible table without loading inline, external, or SDF-derived CCD resources.
- Keep `--classifier=ccd` as the runtime CCD topology path and document the distinction.

## Root cause

Batch mmCIF parsing always performed an inline CCD extraction pass even though batch classification does not consume per-file inline CCD dictionaries. For AFDB-style protein-only CIFs this added avoidable parsing work. ProtOr was also treated as a CCD resource-using alias, so it could not serve as a lightweight protein-only classifier path.

## Validation

- `zig fmt --check src/`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `npm run build` in `website/`
- `./zig-out/bin/zsasa --help`
- `./zig-out/bin/zsasa --version`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json --quiet`
- 1-file AFDB CIF parser timing check for `parse_inline_ccd=true/false`
- 1-file batch smoke for `--classifier=protor` and `--classifier=ccd`
