### PR TITLE
feat: add altloc parsing modes

### DIFF
--- a/src/altloc.zig
+++ b/src/altloc.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub const AltLocMode = enum {
+    /// Historical behavior: blank altLoc wins, then A, then highest occupancy.
+    auto,
+    /// Assume there are no non-blank altLocs; fail fast if one is encountered.
+    none,
+    /// Keep all alternate locations.
+    all,
+    /// Keep blank altLocs and the selected altLoc ID.
+    selected,
+    /// Keep the highest-occupancy alternate for each atom site.
+    highest_occupancy,
+};
+
+pub const AltLocSetting = struct {
+    mode: AltLocMode = .auto,
+    id: u8 = 'A',
+};
+
+pub fn parseSetting(value: []const u8) ?AltLocSetting {
+    if (std.mem.eql(u8, value, "auto")) return .{ .mode = .auto };
+    if (std.mem.eql(u8, value, "none")) return .{ .mode = .none };
+    if (std.mem.eql(u8, value, "all")) return .{ .mode = .all };
+    if (std.mem.eql(u8, value, "highest-occupancy") or
+        std.mem.eql(u8, value, "highest_occupancy"))
+    {
+        return .{ .mode = .highest_occupancy };
+    }
+    if (value.len == 1 and value[0] != '.' and value[0] != '?') {
+        return .{ .mode = .selected, .id = value[0] };
+    }
+    return null;
+}

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -83,6 +83,8 @@ pub const BatchConfig = struct {
     custom_classifier_path: ?[]const u8 = null,
     chain_filter: ?[]const []const u8 = null,
     use_auth_chain: bool = false,
+    alt_loc_mode: mmcif_parser.AltLocMode = .auto,
+    alt_loc_id: u8 = 'A',
     residue_map: bool = false,
 };
 
@@ -632,6 +634,8 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
             parser.use_auth_chain = config.use_auth_chain;
+            parser.alt_loc_mode = config.alt_loc_mode;
+            parser.alt_loc_id = config.alt_loc_id;
             parser.parse_inline_ccd = classifierUsesCcdResources(config.classifier_type);
             const input = try parser.parseFile(io, path);
             break :blk .{ .input = input, .inline_ccd = parser.takeInlineCcd() };
@@ -643,6 +647,8 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
             parser.use_auth_chain = config.use_auth_chain;
+            parser.alt_loc_mode = config.alt_loc_mode;
+            parser.alt_loc_id = config.alt_loc_id;
             parser.parse_inline_ccd = classifierUsesCcdResources(config.classifier_type);
             const input = try parser.parseFile(io, path);
             break :blk .{ .input = input, .inline_ccd = parser.takeInlineCcd() };
@@ -2236,6 +2242,8 @@ pub const BatchArgs = struct {
     workflow_path: ?[]const u8 = null,
     chain_filter: ?[]const u8 = null,
     use_auth_chain: bool = false,
+    alt_loc_mode: mmcif_parser.AltLocMode = .auto,
+    alt_loc_id: u8 = 'A',
     residue_map: bool = false,
     n_threads: usize = 0,
     probe_radius: f64 = 1.4,
@@ -2271,6 +2279,7 @@ pub const BatchArgs = struct {
     classifier_explicit: bool = false,
     include_hydrogens_explicit: bool = false,
     include_hetatm_explicit: bool = false,
+    alt_loc_explicit: bool = false,
     use_bitmask_explicit: bool = false,
     bitmask_correction_explicit: bool = false,
     bitmask_correction_coeff_explicit: bool = false,
@@ -2432,6 +2441,14 @@ fn parseClassifierType(value: []const u8) ClassifierType {
         std.debug.print("Valid classifiers: ccd, protor, naccess, oons\n", .{});
         std.process.exit(1);
     }
+}
+
+fn parseAltLocSetting(value: []const u8) mmcif_parser.AltLocSetting {
+    return mmcif_parser.parseAltLocSetting(value) orelse {
+        std.debug.print("Error: Invalid altloc mode: {s}\n", .{value});
+        std.debug.print("Valid altloc modes: auto, none, all, highest-occupancy, or a single altLoc ID like A\n", .{});
+        std.process.exit(1);
+    };
 }
 
 /// Parse and validate precision value
@@ -2623,6 +2640,23 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         // --auth-chain
         else if (std.mem.eql(u8, arg, "--auth-chain")) {
             result.use_auth_chain = true;
+        }
+        // --altloc=MODE or --altloc MODE
+        else if (std.mem.startsWith(u8, arg, "--altloc=")) {
+            const setting = parseAltLocSetting(arg["--altloc=".len..]);
+            result.alt_loc_mode = setting.mode;
+            result.alt_loc_id = setting.id;
+            result.alt_loc_explicit = true;
+        } else if (std.mem.eql(u8, arg, "--altloc")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --altloc\n", .{});
+                std.process.exit(1);
+            }
+            const setting = parseAltLocSetting(args[i]);
+            result.alt_loc_mode = setting.mode;
+            result.alt_loc_id = setting.id;
+            result.alt_loc_explicit = true;
         }
         // --residue-map
         else if (std.mem.eql(u8, arg, "--residue-map")) {
@@ -2850,6 +2884,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --manifest=PATH     Compatibility alias for --workflow
         \\    --chain=ID          Filter by chain ID for non-workflow batch (e.g. A or A,B)
         \\    --auth-chain        Use auth_asym_id instead of label_asym_id for mmCIF chain matching
+        \\    --altloc=MODE       mmCIF/BCIF alternate-location handling: auto, none, all,
+        \\                        highest-occupancy, or a single ID like A (default: auto)
         \\    --residue-map       Include compact residue map arrays in JSONL output
         \\    --probe-radius=R    Probe radius in Angstroms (default: 1.4)
         \\    --n-points=N        Test points per atom (default: 100, for sr)
@@ -4093,6 +4129,8 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         .sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null,
         .chain_filter = chain_filter_slice,
         .use_auth_chain = args.use_auth_chain,
+        .alt_loc_mode = args.alt_loc_mode,
+        .alt_loc_id = args.alt_loc_id,
         .residue_map = args.residue_map,
     };
 
@@ -4436,6 +4474,26 @@ test "BatchArgs --auth-chain" {
     const args = [_][]const u8{ "zsasa", "batch", "--auth-chain", "input_dir/" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.use_auth_chain);
+}
+
+test "BatchArgs --altloc modes" {
+    const none_args = [_][]const u8{ "zsasa", "batch", "--altloc=none", "input_dir/" };
+    const all_args = [_][]const u8{ "zsasa", "batch", "--altloc", "all", "input_dir/" };
+    const selected_args = [_][]const u8{ "zsasa", "batch", "--altloc=C", "input_dir/" };
+    const occupancy_args = [_][]const u8{ "zsasa", "batch", "--altloc=highest-occupancy", "input_dir/" };
+
+    const none = parseArgs(&none_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.none, none.alt_loc_mode);
+
+    const all = parseArgs(&all_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.all, all.alt_loc_mode);
+
+    const selected = parseArgs(&selected_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.selected, selected.alt_loc_mode);
+    try std.testing.expectEqual(@as(u8, 'C'), selected.alt_loc_id);
+
+    const occupancy = parseArgs(&occupancy_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.highest_occupancy, occupancy.alt_loc_mode);
 }
 
 test "BatchArgs --residue-map" {

--- a/src/bcif_parser.zig
+++ b/src/bcif_parser.zig
@@ -6,6 +6,7 @@ const compressed = @import("compressed.zig");
 const types = @import("types.zig");
 const ccd_parser = @import("ccd_parser.zig");
 const hyb = @import("hybridization.zig");
+const altloc = @import("altloc.zig");
 const AtomInput = types.AtomInput;
 pub const ParseError = error{
     InvalidMessagePack,
@@ -17,6 +18,7 @@ pub const ParseError = error{
     UnsupportedEncoding,
     InvalidColumnData,
     InvalidCoordinate,
+    UnexpectedAltLoc,
     ColumnLengthMismatch,
 };
 
@@ -632,6 +634,8 @@ pub const BcifParser = struct {
     atom_only: bool = true,
     skip_hydrogens: bool = true,
     first_alt_loc_only: bool = true,
+    alt_loc_mode: altloc.AltLocMode = .auto,
+    alt_loc_id: u8 = 'A',
     model_num: ?u32 = null,
     chain_filter: ?[]const []const u8 = null,
     use_auth_chain: bool = false,
@@ -703,10 +707,11 @@ pub const BcifParser = struct {
 
         var decoded = try self.allocator.alloc(DecodedColumn, raw_columns.len);
         var decoded_count: usize = 0;
-        errdefer {
+        var decoded_errdefer_active = true;
+        errdefer if (decoded_errdefer_active) {
             for (decoded[0..decoded_count]) |*column| column.deinit(self.allocator);
             self.allocator.free(decoded);
-        }
+        };
         for (raw_columns) |column| {
             decoded[decoded_count] = decodeBcifColumn(self.allocator, column) catch |err| {
                 self.deinitCcd();
@@ -718,6 +723,7 @@ pub const BcifParser = struct {
                 return ParseError.ColumnLengthMismatch;
             }
         }
+        decoded_errdefer_active = false;
         defer {
             for (decoded[0..decoded_count]) |*column| column.deinit(self.allocator);
             self.allocator.free(decoded);
@@ -753,7 +759,11 @@ pub const BcifParser = struct {
         var row: usize = 0;
         while (row < row_count) : (row += 1) {
             if (!self.shouldIncludeAtom(decoded, columns, row)) continue;
-            try atom_records.append(self.allocator, try self.atomRecordFromRow(decoded, columns, row));
+            const atom = try self.atomRecordFromRow(decoded, columns, row);
+            if (self.alt_loc_mode == .none and atom.alt_loc != ' ') {
+                return ParseError.UnexpectedAltLoc;
+            }
+            try atom_records.append(self.allocator, atom);
         }
 
         for (atom_records.items, 0..) |atom, i| {
@@ -906,6 +916,18 @@ pub const BcifParser = struct {
     fn shouldKeepAltLoc(self: *BcifParser, atoms: []const AtomRecord, index: usize) bool {
         if (!self.first_alt_loc_only) return true;
 
+        return switch (self.alt_loc_mode) {
+            .all, .none => true,
+            .selected => blk: {
+                const atom = atoms[index];
+                break :blk atom.alt_loc == ' ' or atom.alt_loc == self.alt_loc_id;
+            },
+            .highest_occupancy => shouldKeepHighestOccupancyAltLoc(atoms, index),
+            .auto => shouldKeepAutoAltLoc(atoms, index),
+        };
+    }
+
+    fn shouldKeepAutoAltLoc(atoms: []const AtomRecord, index: usize) bool {
         const atom = atoms[index];
         if (atom.alt_loc == ' ') return true;
 
@@ -923,6 +945,18 @@ pub const BcifParser = struct {
             }
         }
         return best_non_preferred == index;
+    }
+
+    fn shouldKeepHighestOccupancyAltLoc(atoms: []const AtomRecord, index: usize) bool {
+        const atom = atoms[index];
+        var best_index = index;
+        for (atoms, 0..) |other, other_index| {
+            if (!sameAltLocSite(atom, other)) continue;
+            if (other.occupancy > atoms[best_index].occupancy) {
+                best_index = other_index;
+            }
+        }
+        return best_index == index;
     }
 
     fn shouldIncludeAtom(self: *BcifParser, decoded: []const DecodedColumn, columns: AtomSiteColumns, row: usize) bool {
@@ -2074,6 +2108,46 @@ test "parse BinaryCIF altLoc selection is per atom site and keeps later B-only s
     try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
     try std.testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
     try std.testing.expectEqual(@as(i32, 2), input.residue_num.?[1]);
+}
+
+test "parse BinaryCIF altLoc all mode keeps every alternate" {
+    const source = try buildMinimalBcif(.{ .include_alt_later_b_only = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .all;
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 12.0), input.x[1], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 14.0), input.x[2], 0.001);
+}
+
+test "parse BinaryCIF altLoc none mode rejects non-blank alternate" {
+    const source = try buildMinimalBcif(.{ .include_alt_later_b_only = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .none;
+    const result = parser.parse(source);
+    try std.testing.expectError(ParseError.UnexpectedAltLoc, result);
+}
+
+test "parse BinaryCIF altLoc selected ID keeps requested alternate" {
+    const source = try buildMinimalBcif(.{ .include_alt_later_b_only = true });
+    defer std.testing.allocator.free(source);
+
+    var parser = BcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .selected;
+    parser.alt_loc_id = 'B';
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 12.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 14.0), input.x[1], 0.001);
 }
 
 test "parse BinaryCIF altLoc selection is scoped by model" {

--- a/src/calc.zig
+++ b/src/calc.zig
@@ -60,6 +60,8 @@ pub const CalcArgs = struct {
     chain_filter: ?[]const u8 = null, // Chain filter (e.g., "A" or "A,B,C")
     model_num: ?u32 = null, // Model number for NMR structures
     use_auth_chain: bool = false, // Use auth_asym_id instead of label_asym_id
+    alt_loc_mode: mmcif_parser.AltLocMode = .auto, // Alternate-location handling for mmCIF
+    alt_loc_id: u8 = 'A', // Selected altLoc ID for --altloc=<ID>
     include_hydrogens: bool = false, // Include hydrogen atoms (default: exclude)
     include_hetatm: bool = false, // Include HETATM records (default: exclude)
     per_residue: bool = false, // Show per-residue SASA
@@ -87,6 +89,7 @@ pub const CalcArgs = struct {
     chain_explicit: bool = false,
     model_explicit: bool = false,
     auth_chain_explicit: bool = false,
+    alt_loc_explicit: bool = false,
     include_hydrogens_explicit: bool = false,
     include_hetatm_explicit: bool = false,
     per_residue_explicit: bool = false,
@@ -218,6 +221,14 @@ fn parseClassifierType(value: []const u8) ClassifierType {
         std.debug.print("Valid classifiers: ccd, protor, naccess, oons\n", .{});
         std.process.exit(1);
     }
+}
+
+fn parseAltLocSetting(value: []const u8) mmcif_parser.AltLocSetting {
+    return mmcif_parser.parseAltLocSetting(value) orelse {
+        std.debug.print("Error: Invalid altloc mode: {s}\n", .{value});
+        std.debug.print("Valid altloc modes: auto, none, all, highest-occupancy, or a single altLoc ID like A\n", .{});
+        std.process.exit(1);
+    };
 }
 
 /// Parse and validate precision value
@@ -450,6 +461,23 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) CalcArgs {
         else if (std.mem.eql(u8, arg, "--auth-chain")) {
             result.use_auth_chain = true;
             result.auth_chain_explicit = true;
+        }
+        // --altloc=MODE or --altloc MODE
+        else if (std.mem.startsWith(u8, arg, "--altloc=")) {
+            const setting = parseAltLocSetting(arg["--altloc=".len..]);
+            result.alt_loc_mode = setting.mode;
+            result.alt_loc_id = setting.id;
+            result.alt_loc_explicit = true;
+        } else if (std.mem.eql(u8, arg, "--altloc")) {
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --altloc\n", .{});
+                std.process.exit(1);
+            }
+            const setting = parseAltLocSetting(args[i]);
+            result.alt_loc_mode = setting.mode;
+            result.alt_loc_id = setting.id;
+            result.alt_loc_explicit = true;
         }
         // --include-hydrogens (include hydrogen atoms, default: exclude)
         else if (std.mem.eql(u8, arg, "--include-hydrogens")) {
@@ -799,6 +827,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --chain=ID         Filter by chain ID (e.g., --chain=A or --chain=A,B,C)
         \\                       Default: label_asym_id (mmCIF standard)
         \\    --auth-chain       Use auth_asym_id instead of label_asym_id
+        \\    --altloc=MODE      mmCIF/BCIF alternate-location handling: auto, none, all,
+        \\                       highest-occupancy, or a single ID like A (default: auto)
         \\    --include-hydrogens Include hydrogen atoms (default: excluded)
         \\    --include-hetatm   Include HETATM records (default: excluded)
         \\    --model=N          Model number for NMR structures (default: all)
@@ -925,6 +955,8 @@ fn readInputFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, arg
             parser.use_auth_chain = args.use_auth_chain;
             parser.skip_hydrogens = !args.include_hydrogens;
             parser.atom_only = !args.include_hetatm;
+            parser.alt_loc_mode = args.alt_loc_mode;
+            parser.alt_loc_id = args.alt_loc_id;
             parser.parse_inline_ccd = calcArgsUseCcdResources(args);
 
             // Parse chain filter if specified
@@ -944,6 +976,8 @@ fn readInputFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, arg
             parser.use_auth_chain = args.use_auth_chain;
             parser.skip_hydrogens = !args.include_hydrogens;
             parser.atom_only = !args.include_hetatm;
+            parser.alt_loc_mode = args.alt_loc_mode;
+            parser.alt_loc_id = args.alt_loc_id;
             parser.parse_inline_ccd = calcArgsUseCcdResources(args);
 
             // Parse chain filter if specified
@@ -2064,6 +2098,26 @@ test "CalcArgs --auth-chain" {
     const args = [_][]const u8{ "zsasa", "calc", "--auth-chain", "input.json" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.use_auth_chain);
+}
+
+test "CalcArgs --altloc modes" {
+    const none_args = [_][]const u8{ "zsasa", "calc", "--altloc=none", "input.cif" };
+    const all_args = [_][]const u8{ "zsasa", "calc", "--altloc", "all", "input.cif" };
+    const selected_args = [_][]const u8{ "zsasa", "calc", "--altloc=B", "input.cif" };
+    const occupancy_args = [_][]const u8{ "zsasa", "calc", "--altloc=highest-occupancy", "input.cif" };
+
+    const none = parseArgs(&none_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.none, none.alt_loc_mode);
+
+    const all = parseArgs(&all_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.all, all.alt_loc_mode);
+
+    const selected = parseArgs(&selected_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.selected, selected.alt_loc_mode);
+    try std.testing.expectEqual(@as(u8, 'B'), selected.alt_loc_id);
+
+    const occupancy = parseArgs(&occupancy_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.highest_occupancy, occupancy.alt_loc_mode);
 }
 
 test "CalcArgs --output FILE (space-separated)" {

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -36,6 +36,7 @@ const compressed = @import("compressed.zig");
 const types = @import("types.zig");
 const AtomInput = types.AtomInput;
 const ccd_parser = @import("ccd_parser.zig");
+const altloc = @import("altloc.zig");
 
 /// Error types for mmCIF parsing
 pub const ParseError = error{
@@ -45,7 +46,13 @@ pub const ParseError = error{
     MissingCoordinateField,
     /// Invalid coordinate value (not a valid number)
     InvalidCoordinate,
+    /// A non-blank altLoc was encountered while altLoc mode is `none`
+    UnexpectedAltLoc,
 };
+
+pub const AltLocMode = altloc.AltLocMode;
+pub const AltLocSetting = altloc.AltLocSetting;
+pub const parseAltLocSetting = altloc.parseSetting;
 
 /// Column indices for atom_site fields
 const AtomSiteColumns = struct {
@@ -112,6 +119,10 @@ pub const MmcifParser = struct {
     skip_hydrogens: bool = true,
     /// Filter to include only first alternate location
     first_alt_loc_only: bool = true,
+    /// Alternate-location handling policy for mmCIF atom_site rows.
+    alt_loc_mode: AltLocMode = .auto,
+    /// Selected altLoc ID when `alt_loc_mode == .selected`.
+    alt_loc_id: u8 = 'A',
     /// Model number to extract (null = first model or all)
     model_num: ?u32 = null,
     /// Chain IDs to include (null = all chains)
@@ -377,6 +388,9 @@ pub const MmcifParser = struct {
 
                         if (should_include) {
                             const atom = try self.atomRecordFromRow(row_values, columns);
+                            if (self.alt_loc_mode == .none and atom.alt_loc != ' ') {
+                                return ParseError.UnexpectedAltLoc;
+                            }
                             has_non_blank_alt_loc = has_non_blank_alt_loc or atom.alt_loc != ' ';
                             try atom_records.append(self.allocator, atom);
                         }
@@ -581,6 +595,18 @@ pub const MmcifParser = struct {
     fn shouldKeepAltLoc(self: *MmcifParser, atoms: []const AtomRecord, index: usize) bool {
         if (!self.first_alt_loc_only) return true;
 
+        return switch (self.alt_loc_mode) {
+            .all, .none => true,
+            .selected => blk: {
+                const atom = atoms[index];
+                break :blk atom.alt_loc == ' ' or atom.alt_loc == self.alt_loc_id;
+            },
+            .highest_occupancy => shouldKeepHighestOccupancyAltLoc(atoms, index),
+            .auto => shouldKeepAutoAltLoc(atoms, index),
+        };
+    }
+
+    fn shouldKeepAutoAltLoc(atoms: []const AtomRecord, index: usize) bool {
         const atom = atoms[index];
         if (atom.alt_loc == ' ') return true;
 
@@ -598,6 +624,18 @@ pub const MmcifParser = struct {
             }
         }
         return best_non_preferred == index;
+    }
+
+    fn shouldKeepHighestOccupancyAltLoc(atoms: []const AtomRecord, index: usize) bool {
+        const atom = atoms[index];
+        var best_index = index;
+        for (atoms, 0..) |other, other_index| {
+            if (!sameAltLocSite(atom, other)) continue;
+            if (other.occupancy > atoms[best_index].occupancy) {
+                best_index = other_index;
+            }
+        }
+        return best_index == index;
     }
 
     /// Check if an atom should be included based on filters
@@ -1242,6 +1280,150 @@ test "parse mmCIF null altLoc is treated as blank" {
 
     try std.testing.expectEqual(@as(usize, 1), input.atomCount());
     try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+}
+
+test "parse mmCIF altLoc all mode keeps every alternate" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.occupancy
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CB ALA A 1 A 0.60 10.0 20.0 30.0
+        \\2 C CB ALA A 1 B 0.40 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .all;
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 10.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 11.0), input.x[1], 0.001);
+}
+
+test "parse mmCIF altLoc none mode rejects non-blank alternate" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.occupancy
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CB ALA A 1 A 0.60 10.0 20.0 30.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .none;
+    const result = parser.parse(source);
+    try std.testing.expectError(ParseError.UnexpectedAltLoc, result);
+}
+
+test "parse mmCIF altLoc none mode accepts blank alternates" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.occupancy
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CB ALA A 1 . 1.00 10.0 20.0 30.0
+        \\2 C CG ALA A 1 ? 1.00 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .none;
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+}
+
+test "parse mmCIF altLoc selected ID keeps blank and requested alternate" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.occupancy
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CA ALA A 1 . 1.00 9.0 19.0 29.0
+        \\2 C CB ALA A 1 A 0.60 10.0 20.0 30.0
+        \\3 C CB ALA A 1 B 0.40 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .selected;
+    parser.alt_loc_id = 'B';
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 9.0), input.x[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 11.0), input.x[1], 0.001);
+}
+
+test "parse mmCIF altLoc highest occupancy mode ignores A preference" {
+    const source =
+        \\data_TEST
+        \\loop_
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.occupancy
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\1 C CB ALA A 1 A 0.40 10.0 20.0 30.0
+        \\2 C CB ALA A 1 B 0.70 11.0 21.0 31.0
+        \\#
+    ;
+
+    var parser = MmcifParser.init(std.testing.allocator);
+    parser.alt_loc_mode = .highest_occupancy;
+    var input = try parser.parse(source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 11.0), input.x[0], 0.001);
 }
 
 test "parse mmCIF altLoc selection is per atom site and keeps later B-only sites" {

--- a/src/traj.zig
+++ b/src/traj.zig
@@ -148,6 +148,8 @@ pub const TrajArgs = struct {
     start_frame: u32 = 0, // Start frame
     end_frame: ?u32 = null, // End frame (null = all)
     include_hydrogens: bool = true, // Include hydrogen atoms (default: include for MD trajectories)
+    alt_loc_mode: mmcif_parser.AltLocMode = .auto, // Alternate-location handling for mmCIF topology
+    alt_loc_id: u8 = 'A',
     batch_size: u32 = 0, // Frames per batch for parallel processing (0 = auto)
     use_bitmask: bool = false, // Use bitmask LUT optimization for SR (n_points must be 1..1024)
     bitmask_lut_mode: BitmaskLutMode = .single,
@@ -298,6 +300,19 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) TrajArgs {
                 result.include_hydrogens = true;
             } else if (std.mem.eql(u8, arg, "--no-hydrogens") or std.mem.eql(u8, arg, "--exclude-hydrogens")) {
                 result.include_hydrogens = false;
+            } else if (std.mem.startsWith(u8, arg, "--altloc=")) {
+                const setting = parseAltLocSetting(arg["--altloc=".len..]);
+                result.alt_loc_mode = setting.mode;
+                result.alt_loc_id = setting.id;
+            } else if (std.mem.eql(u8, arg, "--altloc")) {
+                i += 1;
+                if (i >= args.len) {
+                    std.debug.print("Error: Missing value for --altloc\n", .{});
+                    std.process.exit(1);
+                }
+                const setting = parseAltLocSetting(args[i]);
+                result.alt_loc_mode = setting.mode;
+                result.alt_loc_id = setting.id;
             } else if (std.mem.eql(u8, arg, "--use-bitmask")) {
                 result.use_bitmask = true;
             } else if (std.mem.startsWith(u8, arg, "--bitmask-lut-mode=")) {
@@ -385,6 +400,14 @@ fn parsePrecision(value: []const u8) Precision {
     }
 }
 
+fn parseAltLocSetting(value: []const u8) mmcif_parser.AltLocSetting {
+    return mmcif_parser.parseAltLocSetting(value) orelse {
+        std.debug.print("Error: Invalid altloc mode: {s}\n", .{value});
+        std.debug.print("Valid altloc modes: auto, none, all, highest-occupancy, or a single altLoc ID like A\n", .{});
+        std.process.exit(1);
+    };
+}
+
 fn parseClassifierType(value: []const u8) ClassifierType {
     if (ClassifierType.fromString(value)) |ct| {
         return ct;
@@ -425,6 +448,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --no-hydrogens     Exclude hydrogen atoms (default: included)
         \\    --include-hydrogens
         \\                       Include hydrogen atoms (default, for backward compat)
+        \\    --altloc=MODE      mmCIF topology alternate-location handling: auto, none,
+        \\                       all, highest-occupancy, or a single ID like A (default: auto)
         \\    --use-bitmask      Use bitmask LUT optimization for SR algorithm
         \\                       (n-points must be 1..1024)
         \\    --bitmask-lut-mode=MODE
@@ -859,6 +884,8 @@ pub fn run(allocator: Allocator, io: std.Io, args: TrajArgs) !void {
         .mmcif => blk: {
             var parser = mmcif_parser.MmcifParser.init(allocator);
             parser.skip_hydrogens = !args.include_hydrogens;
+            parser.alt_loc_mode = args.alt_loc_mode;
+            parser.alt_loc_id = args.alt_loc_id;
             parser.parse_inline_ccd = false;
             break :blk try parser.parseFile(io, topology_path);
         },
@@ -1430,6 +1457,18 @@ test "TrajArgs quiet disables progress" {
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(true, parsed.quiet);
     try std.testing.expectEqual(false, parsed.show_progress);
+}
+
+test "TrajArgs --altloc modes" {
+    const none_args = [_][]const u8{ "zsasa", "traj", "--altloc=none", "traj.xtc", "topology.cif" };
+    const selected_args = [_][]const u8{ "zsasa", "traj", "--altloc", "D", "traj.xtc", "topology.cif" };
+
+    const none = parseArgs(&none_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.none, none.alt_loc_mode);
+
+    const selected = parseArgs(&selected_args, 2);
+    try std.testing.expectEqual(mmcif_parser.AltLocMode.selected, selected.alt_loc_mode);
+    try std.testing.expectEqual(@as(u8, 'D'), selected.alt_loc_id);
 }
 
 test "TrajArgs --bitmask-correction-coeff" {

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -144,6 +144,7 @@ See [Classifiers](../guide/classifiers.mdx) for detailed classifier documentatio
 | `--chain=ID` | Filter by chain ID (e.g., `A` or `A,B,C`) | all chains |
 | `--model=N` | Model number for NMR structures (≥1) | all models |
 | `--auth-chain` | Use auth_asym_id instead of label_asym_id | label_asym_id |
+| `--altloc=MODE` | mmCIF/BinaryCIF alternate-location handling: `auto`, `none`, `all`, `highest-occupancy`, or one ID such as `A` | `auto` |
 | `--include-hydrogens` | Include hydrogen atoms (calc/batch default: excluded) | excluded |
 | `--no-hydrogens` | Exclude hydrogen atoms (traj default: included) | — |
 | `--include-hetatm` | Include HETATM records | excluded |
@@ -202,6 +203,7 @@ Most [common options](#common-options) apply, plus the trajectory-specific optio
 | `--precision=P` | Floating-point precision: `f32` or `f64` | `f32` (note: different from calc/batch) |
 | `--no-hydrogens` | Exclude hydrogen atoms | included |
 | `--include-hydrogens` | Include hydrogen atoms (default, for backward compat) | included |
+| `--altloc=MODE` | mmCIF topology alternate-location handling: `auto`, `none`, `all`, `highest-occupancy`, or one ID such as `A` | `auto` |
 | `--stride=N` | Process every Nth frame | `1` |
 | `--start=N` | Start from frame N | `0` |
 | `--end=N` | End at frame N | all |

--- a/website/docs/cli/input.md
+++ b/website/docs/cli/input.md
@@ -70,11 +70,13 @@ Standard mmCIF files are supported. The parser extracts:
 - `_atom_site.label_seq_id` / `auth_seq_id` - Residue number
 - `_atom_site.pdbx_PDB_ins_code` - Insertion code
 - `_atom_site.pdbx_PDB_model_num` - Model number
-- `_atom_site.label_alt_id` - Alternate location (first kept by default)
+- `_atom_site.label_alt_id` - Alternate location (`--altloc=auto` by default)
+
+Alternate-location handling can be controlled with `--altloc=MODE` for mmCIF and BinaryCIF input. `auto` preserves the historical behavior (blank alternate location first, then `A`, then highest occupancy), `none` assumes no non-blank alternate locations and errors if one is found, `all` keeps every alternate, `highest-occupancy` keeps the highest-occupancy atom for each site, and a single ID such as `--altloc=A` keeps blank atoms plus that alternate ID.
 
 ## BinaryCIF Format
 
-BinaryCIF input decodes `_atom_site` for SASA calculation and uses embedded `_chem_comp_atom` / `_chem_comp_bond` inline CCD data when `--classifier=ccd` (or the `ccd` default) needs bond topology for non-standard compounds. You can still provide external CCD or SDF topology when the BinaryCIF file does not include component topology.
+BinaryCIF input decodes `_atom_site` for SASA calculation, supports the same `--altloc` policy as mmCIF, and uses embedded `_chem_comp_atom` / `_chem_comp_bond` inline CCD data when `--classifier=ccd` (or the `ccd` default) needs bond topology for non-standard compounds. You can still provide external CCD or SDF topology when the BinaryCIF file does not include component topology.
 
 ## PDB Format
 


### PR DESCRIPTION
## Summary
- add shared altLoc policy parsing for `auto`, `none`, `all`, `highest-occupancy`, and single-ID selection such as `A`
- apply `--altloc` to calc, batch, and traj mmCIF topology paths
- apply the same policy to both mmCIF and BinaryCIF atom_site parsing
- add parser and CLI tests for altLoc modes, including BCIF behavior
- document the new option and mode semantics

## Verification
- `zig build test`
- `zig fmt --check src/`
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa calc --altloc=none examples/1ubq.cif /tmp/zsasa-check/altloc-none.json`
- `./zig-out/bin/zsasa batch --help`
- `./zig-out/bin/zsasa traj --help`
- `cd website && npm run build`

## Notes
- Default remains `auto`, preserving existing altLoc selection behavior.
- `none` is an assertion mode: non-blank altLocs return an error instead of silently duplicating atoms.
