### PR TITLE
chore: add zsasa release tooling

### DIFF
--- a/.codex/skills/zsasa-release/SKILL.md
+++ b/.codex/skills/zsasa-release/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: zsasa-release
+description: Use when preparing, merging, tagging, or troubleshooting a zsasa project release, including requests like release, version bump, changelog, create release PR, merge release PR, tag push, or publish vX.Y.Z.
+---
+
+# zsasa Release
+
+Use this instead of the generic release flow when working in the `N283T/zsasa` repository.
+
+## Principles
+
+- Work from a non-`main` branch for release PR preparation.
+- Keep release edits mechanical and scoped.
+- Treat tag push as the publish trigger; do not tag before the release PR is merged to `main`.
+- Do not bump `packaging/aur/PKGBUILD` in the release PR. Its checksum depends on release assets generated after tag push.
+- Use concrete dates in release metadata and changelogs.
+
+## Phase 1: create the release PR
+
+1. Start from clean, up-to-date `main`.
+2. Create `release/vX.Y.Z`.
+3. Run:
+
+   ```bash
+   ./scripts/release_bump.py X.Y.Z
+   ```
+
+   This updates the fixed zsasa version surfaces and promotes `CHANGELOG.md` / `website/docs/changelog.md` Unreleased notes into the release section.
+
+4. Inspect for stale versions:
+
+   ```bash
+   rg -n --glob '!CHANGELOG.md' --glob '!website/docs/changelog.md' --glob '!*lock*' '\bOLD_VERSION\b' .
+   ```
+
+5. Run the release checks that match touched surfaces:
+
+   ```bash
+   zig fmt --check src/
+   zig build test
+   zig build -Doptimize=ReleaseFast
+   ./zig-out/bin/zsasa --version
+   mkdir -p /tmp/zsasa-check
+   ./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json
+   ```
+
+   Also run Python checks when Python/C ABI files changed, and website build when website docs changed.
+
+6. Commit as `release: vX.Y.Z`, push, and open the PR.
+
+## Phase 2: merge and tag
+
+When the user asks to proceed after CI, do not stop at “PR is open.” Verify checks and merge/tag in one flow:
+
+```bash
+./scripts/release_tag.py X.Y.Z --pr PR_NUMBER --merge
+```
+
+The script verifies CI/check state, squash-merges the release PR when open, fetches `origin/main`, verifies release files from that commit, creates an annotated `vX.Y.Z` tag on it, and pushes the tag.
+
+## Common mistakes
+
+- Forgetting `python/uv.lock` or `src/c_api.zig` version bumps.
+- Editing website changelog but not root `CHANGELOG.md`, or vice versa.
+- Treating skipped deploy checks as failures; skipped deploy is normal on PRs.
+- Tagging a release branch instead of updated `main`.
+- Updating AUR `pkgver` before the asset checksum exists.

--- a/.codex/skills/zsasa-release/agents/openai.yaml
+++ b/.codex/skills/zsasa-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "zsasa release"
+  short_description: "Release workflow for zsasa"
+  default_prompt: "Create or finish a zsasa release."

--- a/scripts/release_bump.py
+++ b/scripts/release_bump.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Bump zsasa release metadata and promote changelog notes."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+REPO = "https://github.com/N283T/zsasa"
+VERSION_RE = re.compile(r"^v?(\d+\.\d+\.\d+)$")
+
+
+class BumpResult(NamedTuple):
+    version: str
+    tag: str
+    previous_version: str
+    changed_files: tuple[str, ...]
+    stale_refs: tuple[str, ...]
+
+
+def normalize_version(raw: str) -> tuple[str, str]:
+    match = VERSION_RE.match(raw.strip())
+    if not match:
+        raise ValueError(f"version must be X.Y.Z or vX.Y.Z, got {raw!r}")
+    version = match.group(1)
+    return version, f"v{version}"
+
+
+def run_cmd(args: list[str], cwd: Path, *, capture: bool = False) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+    return result.stdout if capture else ""
+
+
+def require_clean_tree(root: Path) -> None:
+    status = run_cmd(["git", "status", "--porcelain"], root, capture=True)
+    if status.strip():
+        raise RuntimeError("working tree is not clean; commit/stash changes before bumping a release")
+
+
+def read_current_version(root: Path) -> str:
+    text = root.joinpath("build.zig").read_text()
+    match = re.search(r'const version = "(\d+\.\d+\.\d+)";', text)
+    if not match:
+        raise RuntimeError("could not determine current version from build.zig")
+    return match.group(1)
+
+
+def replace_once(path: Path, old: str, new: str) -> bool:
+    text = path.read_text()
+    if old not in text:
+        raise RuntimeError(f"{path}: expected text not found: {old!r}")
+    path.write_text(text.replace(old, new, 1))
+    return old != new
+
+
+def bump_fixed_version_files(root: Path, old: str, new: str, release_date: str) -> list[str]:
+    replacements = {
+        "build.zig": [(f'const version = "{old}";', f'const version = "{new}";')],
+        "build.zig.zon": [(f'.version = "{old}",', f'.version = "{new}",')],
+        "flake.nix": [(f'version = "{old}";', f'version = "{new}";')],
+        "python/pyproject.toml": [(f'version = "{old}"', f'version = "{new}"')],
+        "python/uv.lock": [(f'name = "zsasa"\nversion = "{old}"', f'name = "zsasa"\nversion = "{new}"')],
+        "packaging/conda-forge/meta.yaml": [(f'{{% set version = "{old}" %}}', f'{{% set version = "{new}" %}}')],
+        "src/c_api.zig": [(f'const VERSION = "{old}";', f'const VERSION = "{new}";')],
+        "CITATION.cff": [(f'version: "{old}"', f'version: "{new}"'), (r'date-released: "', r'date-released: "')],
+    }
+    changed: list[str] = []
+    for rel, pairs in replacements.items():
+        path = root.joinpath(rel)
+        text = path.read_text()
+        original = text
+        if rel == "CITATION.cff":
+            text = text.replace(f'version: "{old}"', f'version: "{new}"', 1)
+            text = re.sub(r'date-released: "\d{4}-\d{2}-\d{2}"', f'date-released: "{release_date}"', text, count=1)
+            if text == original:
+                raise RuntimeError(f"{path}: citation version/date replacement did not change file")
+            path.write_text(text)
+        else:
+            for old_text, new_text in pairs:
+                if old_text not in text:
+                    raise RuntimeError(f"{path}: expected text not found: {old_text!r}")
+                text = text.replace(old_text, new_text, 1)
+            path.write_text(text)
+        if path.read_text() != original:
+            changed.append(rel)
+    return changed
+
+
+def find_next_heading(lines: list[str], start: int, prefix: str) -> int:
+    for idx in range(start + 1, len(lines)):
+        if lines[idx].startswith(prefix):
+            return idx
+    return len(lines)
+
+
+def promote_changelog(root: Path, version: str, tag: str, old: str, release_date: str, *, allow_empty_notes: bool) -> list[str]:
+    changed: list[str] = []
+    path = root.joinpath("CHANGELOG.md")
+    text = path.read_text()
+    if f"## [{version}]" in text:
+        raise RuntimeError(f"CHANGELOG.md already contains section for {version}")
+    lines = text.splitlines(keepends=True)
+    try:
+        start = next(i for i, line in enumerate(lines) if line.rstrip() == "## [Unreleased]")
+    except StopIteration as exc:
+        raise RuntimeError("CHANGELOG.md missing ## [Unreleased] section") from exc
+    end = find_next_heading(lines, start, "## [")
+    notes = "".join(lines[start + 1 : end]).strip()
+    if not notes and not allow_empty_notes:
+        raise RuntimeError("CHANGELOG.md Unreleased section is empty; add release notes or pass --allow-empty-notes")
+    new_section = f"## [Unreleased]\n\n## [{version}] - {release_date}\n\n{notes}\n\n"
+    updated = "".join(lines[:start]) + new_section + "".join(lines[end:])
+    unreleased_old = f"[Unreleased]: {REPO}/compare/v{old}...HEAD"
+    unreleased_new = f"[Unreleased]: {REPO}/compare/{tag}...HEAD"
+    version_link = f"[{version}]: {REPO}/compare/v{old}...{tag}"
+    if unreleased_old in updated:
+        updated = updated.replace(unreleased_old, f"{unreleased_new}\n{version_link}", 1)
+    elif "[Unreleased]:" in updated:
+        updated = re.sub(r"^\[Unreleased\]: .*$", f"{unreleased_new}\n{version_link}", updated, count=1, flags=re.MULTILINE)
+    else:
+        updated = updated.rstrip() + f"\n\n{unreleased_new}\n{version_link}\n"
+    path.write_text(updated)
+    changed.append("CHANGELOG.md")
+
+    website_path = root.joinpath("website", "docs", "changelog.md")
+    website = website_path.read_text()
+    if f"## [v{version}]" in website:
+        raise RuntimeError(f"website/docs/changelog.md already contains section for v{version}")
+    website_lines = website.splitlines(keepends=True)
+    try:
+        w_start = next(i for i, line in enumerate(website_lines) if line.rstrip() == "## Unreleased")
+    except StopIteration as exc:
+        raise RuntimeError("website/docs/changelog.md missing ## Unreleased section") from exc
+    w_end = find_next_heading(website_lines, w_start, "## [")
+    website_notes = "".join(website_lines[w_start + 1 : w_end]).strip() or notes
+    if not website_notes and not allow_empty_notes:
+        raise RuntimeError("website changelog Unreleased section is empty; add release notes or pass --allow-empty-notes")
+    website_section = f"## Unreleased\n\n## [v{version}]({REPO}/releases/tag/{tag}) — {release_date}\n\n{website_notes}\n\n"
+    website_path.write_text("".join(website_lines[:w_start]) + website_section + "".join(website_lines[w_end:]))
+    changed.append("website/docs/changelog.md")
+    return changed
+
+
+def collect_stale_refs(root: Path, old: str) -> tuple[str, ...]:
+    active_paths = [
+        "build.zig",
+        "build.zig.zon",
+        "flake.nix",
+        "python/pyproject.toml",
+        "python/uv.lock",
+        "packaging/conda-forge/meta.yaml",
+        "src/c_api.zig",
+        "CITATION.cff",
+    ]
+    stale: list[str] = []
+    pattern = re.compile(rf"\b{re.escape(old)}\b")
+    for rel in active_paths:
+        path = root.joinpath(rel)
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            if pattern.search(line):
+                stale.append(f"{rel}:{number}:{line}")
+    return tuple(stale)
+
+
+def run(
+    root: Path,
+    version_arg: str,
+    *,
+    release_date: str | None = None,
+    check_clean: bool = True,
+    allow_empty_notes: bool = False,
+) -> BumpResult:
+    root = root.resolve()
+    version, tag = normalize_version(version_arg)
+    release_date = release_date or dt.date.today().isoformat()
+    if check_clean:
+        require_clean_tree(root)
+    old = read_current_version(root)
+    if old == version:
+        raise RuntimeError(f"release version is already {version}")
+    changed = bump_fixed_version_files(root, old, version, release_date)
+    changed.extend(promote_changelog(root, version, tag, old, release_date, allow_empty_notes=allow_empty_notes))
+    stale = collect_stale_refs(root, old)
+    if stale:
+        raise RuntimeError("stale active version references remain:\n" + "\n".join(stale))
+    return BumpResult(version=version, tag=tag, previous_version=old, changed_files=tuple(changed), stale_refs=stale)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Release version, X.Y.Z or vX.Y.Z")
+    parser.add_argument("--date", dest="release_date", help="Release date, YYYY-MM-DD (default: today)")
+    parser.add_argument("--allow-dirty", action="store_true", help="Allow running with a dirty git tree")
+    parser.add_argument("--allow-empty-notes", action="store_true", help="Allow empty Unreleased changelog notes")
+    args = parser.parse_args(argv)
+    try:
+        result = run(
+            Path.cwd(),
+            args.version,
+            release_date=args.release_date,
+            check_clean=not args.allow_dirty,
+            allow_empty_notes=args.allow_empty_notes,
+        )
+    except Exception as exc:  # noqa: BLE001 - CLI should print concise errors.
+        print(f"release-bump: {exc}", file=sys.stderr)
+        return 1
+    print(f"Bumped zsasa {result.previous_version} -> {result.version} ({result.tag})")
+    print("Changed files:")
+    for rel in result.changed_files:
+        print(f"  {rel}")
+    print("Note: packaging/aur/PKGBUILD is intentionally not bumped before release asset checksums exist.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_tag.py
+++ b/scripts/release_tag.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Merge a zsasa release PR when requested, then create and push the release tag."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^v?(\d+\.\d+\.\d+)$")
+PASSING_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+
+
+def normalize_version(raw: str) -> tuple[str, str]:
+    match = VERSION_RE.match(raw.strip())
+    if not match:
+        raise ValueError(f"version must be X.Y.Z or vX.Y.Z, got {raw!r}")
+    version = match.group(1)
+    return version, f"v{version}"
+
+
+def run_cmd(args: list[str], cwd: Path, *, capture: bool = False) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+    return result.stdout if capture else ""
+
+
+def require_clean_tree(root: Path) -> None:
+    status = run_cmd(["git", "status", "--porcelain"], root, capture=True)
+    if status.strip():
+        raise RuntimeError("working tree is not clean; commit/stash changes before tagging")
+
+
+def load_pr(root: Path, pr: str) -> dict:
+    raw = run_cmd(
+        [
+            "gh",
+            "pr",
+            "view",
+            pr,
+            "--json",
+            "state,mergeable,isDraft,reviewDecision,statusCheckRollup,headRefName,baseRefName,url,mergedAt",
+        ],
+        root,
+        capture=True,
+    )
+    return json.loads(raw)
+
+
+def require_pr_checks_pass(pr_data: dict) -> None:
+    if pr_data.get("isDraft"):
+        raise RuntimeError("release PR is still draft")
+    if pr_data.get("reviewDecision") == "CHANGES_REQUESTED":
+        raise RuntimeError("release PR has requested changes")
+    checks = pr_data.get("statusCheckRollup") or []
+    bad: list[str] = []
+    pending: list[str] = []
+    for check in checks:
+        name = check.get("name", "<unnamed>")
+        status = check.get("status")
+        conclusion = check.get("conclusion")
+        if status != "COMPLETED":
+            pending.append(f"{name}: {status}")
+        elif conclusion not in PASSING_CONCLUSIONS:
+            bad.append(f"{name}: {conclusion}")
+    if pending:
+        raise RuntimeError("release PR checks are still pending:\n" + "\n".join(pending))
+    if bad:
+        raise RuntimeError("release PR checks are not passing:\n" + "\n".join(bad))
+
+
+def merge_release_pr(root: Path, pr: str, tag: str) -> None:
+    pr_data = load_pr(root, pr)
+    if pr_data.get("state") == "MERGED":
+        return
+    if pr_data.get("state") != "OPEN":
+        raise RuntimeError(f"release PR #{pr} is not open or merged: {pr_data.get('state')}")
+    if pr_data.get("mergeable") != "MERGEABLE":
+        raise RuntimeError(f"release PR #{pr} is not mergeable: {pr_data.get('mergeable')}")
+    require_pr_checks_pass(pr_data)
+    run_cmd(["gh", "pr", "merge", pr, "--squash", "--delete-branch", "--subject", f"release: {tag}", "--body", ""], root)
+
+
+def read_file_from_ref(root: Path, ref: str, rel: str) -> str:
+    return run_cmd(["git", "show", f"{ref}:{rel}"], root, capture=True)
+
+
+def verify_release_files(root: Path, ref: str, version: str, tag: str) -> None:
+    required = {
+        "build.zig": f'const version = "{version}";',
+        "build.zig.zon": f'.version = "{version}",',
+        "src/c_api.zig": f'const VERSION = "{version}";',
+        "python/pyproject.toml": f'version = "{version}"',
+        "CHANGELOG.md": f"## [{version}]",
+        "website/docs/changelog.md": f"## [{tag}]",
+    }
+    missing: list[str] = []
+    for rel, needle in required.items():
+        if needle not in read_file_from_ref(root, ref, rel):
+            missing.append(f"{rel}: missing {needle!r}")
+    if missing:
+        raise RuntimeError("release files do not match requested version:\n" + "\n".join(missing))
+
+
+def tag_exists(root: Path, tag: str, remote: str) -> bool:
+    local = subprocess.run(["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if local.returncode == 0:
+        return True
+    remote_result = subprocess.run(["git", "ls-remote", "--exit-code", "--tags", remote, f"refs/tags/{tag}"], cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return remote_result.returncode == 0
+
+
+def run(root: Path, version_arg: str, *, pr: str | None = None, merge: bool = False, remote: str = "origin") -> str:
+    root = root.resolve()
+    version, tag = normalize_version(version_arg)
+    require_clean_tree(root)
+    if pr is not None:
+        pr_data = load_pr(root, pr)
+        if pr_data.get("state") == "OPEN":
+            if not merge:
+                raise RuntimeError(f"release PR #{pr} is open; pass --merge to merge before tagging")
+            merge_release_pr(root, pr, tag)
+        elif pr_data.get("state") != "MERGED":
+            raise RuntimeError(f"release PR #{pr} is not merged: {pr_data.get('state')}")
+    run_cmd(["git", "fetch", "--prune", "--tags", remote, "main"], root)
+    target_ref = "FETCH_HEAD"
+    verify_release_files(root, target_ref, version, tag)
+    if tag_exists(root, tag, remote):
+        raise RuntimeError(f"tag {tag} already exists locally or on {remote}")
+    run_cmd(["git", "tag", "-a", tag, target_ref, "-m", f"Release {tag}"], root)
+    run_cmd(["git", "push", remote, tag], root)
+    return tag
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Release version, X.Y.Z or vX.Y.Z")
+    parser.add_argument("--pr", help="Release PR number to verify or merge before tagging")
+    parser.add_argument("--merge", action="store_true", help="Squash-merge the release PR if it is still open and checks pass")
+    parser.add_argument("--remote", default="origin", help="Git remote for tag push (default: origin)")
+    args = parser.parse_args(argv)
+    try:
+        tag = run(Path.cwd(), args.version, pr=args.pr, merge=args.merge, remote=args.remote)
+    except Exception as exc:  # noqa: BLE001 - CLI should print concise errors.
+        print(f"release-tag: {exc}", file=sys.stderr)
+        return 1
+    print(f"Pushed {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+import importlib.util
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str):
+    path = ROOT.joinpath("scripts", name)
+    spec = importlib.util.spec_from_file_location(name.replace(".py", ""), path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseBumpTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="zsasa-release-test-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+        self.write_minimal_repo(self.tmp)
+        subprocess.run(["git", "init"], cwd=self.tmp, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=self.tmp, check=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=self.tmp, check=True)
+        subprocess.run(["git", "add", "."], cwd=self.tmp, check=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=self.tmp, check=True, stdout=subprocess.DEVNULL)
+
+    def write_minimal_repo(self, root: Path):
+        root.joinpath("src").mkdir()
+        root.joinpath("python").mkdir()
+        root.joinpath("packaging", "conda-forge").mkdir(parents=True)
+        root.joinpath("website", "docs").mkdir(parents=True)
+        root.joinpath("build.zig").write_text('const version = "0.7.1";\n')
+        root.joinpath("build.zig.zon").write_text('    .version = "0.7.1",\n')
+        root.joinpath("flake.nix").write_text('version = "0.7.1";\n')
+        root.joinpath("python", "pyproject.toml").write_text('[project]\nname = "zsasa"\nversion = "0.7.1"\n')
+        root.joinpath("python", "uv.lock").write_text('[[package]]\nname = "zsasa"\nversion = "0.7.1"\n')
+        root.joinpath("packaging", "conda-forge", "meta.yaml").write_text('{% set version = "0.7.1" %}\n')
+        root.joinpath("src", "c_api.zig").write_text('const VERSION = "0.7.1";\n')
+        root.joinpath("CITATION.cff").write_text('version: "0.7.1"\ndate-released: "2026-06-29"\n')
+        root.joinpath("CHANGELOG.md").write_text(textwrap.dedent("""\
+            # Changelog
+
+            ## [Unreleased]
+
+            ### Changed
+
+            - Something changed. (#1)
+
+            ## [0.7.1] - 2026-06-29
+
+            ### Fixed
+
+            - Previous fix.
+
+            [Unreleased]: https://github.com/N283T/zsasa/compare/v0.7.1...HEAD
+            [0.7.1]: https://github.com/N283T/zsasa/compare/v0.7.0...v0.7.1
+            """))
+        root.joinpath("website", "docs", "changelog.md").write_text(textwrap.dedent("""\
+            ---
+            sidebar_position: 10
+            ---
+
+            # Changelog
+
+            ## Unreleased
+
+            ### Changed
+
+            - Something changed. (#1)
+
+            ## [v0.7.1](https://github.com/N283T/zsasa/releases/tag/v0.7.1) — 2026-06-29
+
+            ### Fixed
+
+            - Previous fix.
+            """))
+
+    def test_bump_updates_known_version_files_and_promotes_unreleased_notes(self):
+        bump = load_script("release_bump.py")
+        result = bump.run(self.tmp, "0.8.0", release_date="2026-07-01", check_clean=True)
+
+        self.assertEqual(result.version, "0.8.0")
+        self.assertEqual(result.tag, "v0.8.0")
+        for rel in [
+            "build.zig",
+            "build.zig.zon",
+            "flake.nix",
+            "python/pyproject.toml",
+            "python/uv.lock",
+            "packaging/conda-forge/meta.yaml",
+            "src/c_api.zig",
+            "CITATION.cff",
+        ]:
+            self.assertIn("0.8.0", self.tmp.joinpath(rel).read_text(), rel)
+            self.assertNotIn("0.7.1", self.tmp.joinpath(rel).read_text(), rel)
+
+        changelog = self.tmp.joinpath("CHANGELOG.md").read_text()
+        self.assertIn("## [Unreleased]\n\n## [0.8.0] - 2026-07-01", changelog)
+        self.assertIn("- Something changed. (#1)", changelog)
+        self.assertIn("[Unreleased]: https://github.com/N283T/zsasa/compare/v0.8.0...HEAD", changelog)
+        self.assertIn("[0.8.0]: https://github.com/N283T/zsasa/compare/v0.7.1...v0.8.0", changelog)
+
+        website = self.tmp.joinpath("website/docs/changelog.md").read_text()
+        self.assertIn("## Unreleased\n\n## [v0.8.0](https://github.com/N283T/zsasa/releases/tag/v0.8.0) — 2026-07-01", website)
+        self.assertIn("- Something changed. (#1)", website)
+
+    def test_bump_rejects_dirty_tree_when_requested(self):
+        bump = load_script("release_bump.py")
+        self.tmp.joinpath("README.md").write_text("dirty\n")
+        with self.assertRaisesRegex(RuntimeError, "working tree is not clean"):
+            bump.run(self.tmp, "0.8.0", release_date="2026-07-01", check_clean=True)
+
+
+class ReleaseTagTests(unittest.TestCase):
+    def test_normalize_version_accepts_prefixed_and_unprefixed(self):
+        tag = load_script("release_tag.py")
+        self.assertEqual(tag.normalize_version("0.8.0"), ("0.8.0", "v0.8.0"))
+        self.assertEqual(tag.normalize_version("v0.8.0"), ("0.8.0", "v0.8.0"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add repo-local `zsasa-release` Codex skill for project-specific release flow.
- Add `scripts/release_bump.py` to bump fixed zsasa version surfaces and promote root/website changelog notes.
- Add `scripts/release_tag.py` to merge a checked release PR when requested, fetch `origin/main`, verify release files, and push an annotated tag.
- Add stdlib tests for the release helper scripts.

## Verification

- `python3 scripts/test_release_tools.py`
- `python3 -m py_compile scripts/release_bump.py scripts/release_tag.py scripts/test_release_tools.py`
- `uv run --with pyyaml /Users/nagaet/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/zsasa-release`
- `git diff --check`
