### PR TITLE
feat: add safe AlphaFold batch fast path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Batch AF model fast parser**: add experimental `zsasa batch --af-model-fast` for AlphaFold-like mmCIF batches, with fallback to the generic parser when the input does not match the expected standard amino-acid layout.
+
 ## [0.8.0] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Batch AF model fast parser**: add experimental `zsasa batch --af-model-fast` for AlphaFold-like mmCIF batches, with fallback to the generic parser when the input does not match the expected standard amino-acid layout.
+- **Batch AF model fast parser**: add experimental `zsasa batch --af-model-fast` for AlphaFold-like mmCIF batches. The fast path preserves multiple chains and atom metadata, and falls back to the generic parser for unsupported layouts.
+- **Batch input I/O selection**: add `--input-io=auto|mmap|read` to compare or select file input strategies where supported.
+- **Batch stage profiling**: add `--profile-stages` with `--timing` to report aggregate read/parse, classifier, and JSONL write times.
+
+### Changed
+
+- **Batch JSONL streaming**: buffer normal-sized JSONL records while streaming large records directly to avoid regressions for PDB batches with large atom-area payloads.
 
 ## [0.8.0] - 2026-07-01
 

--- a/src/af_model_parser.zig
+++ b/src/af_model_parser.zig
@@ -1,0 +1,338 @@
+const std = @import("std");
+const compressed = @import("compressed.zig");
+const elem = @import("element.zig");
+const mmap_reader = @import("mmap_reader.zig");
+const types = @import("types.zig");
+
+const Allocator = std.mem.Allocator;
+const AtomInput = types.AtomInput;
+
+pub const ParseError = error{
+    MissingSequence,
+    NonStandardResidue,
+    NoAtomRecord,
+    MissingCoordinateMarker,
+    InvalidCoordinate,
+    AtomCountMismatch,
+};
+
+const ResidueSpec = struct {
+    one_letter: u8,
+    name: []const u8,
+    atoms: []const []const u8,
+};
+
+const gly_atoms = [_][]const u8{ "N", "CA", "C", "O" };
+const ala_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O" };
+const val_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG1", "CG2" };
+const leu_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2" };
+const ile_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG1", "CG2", "CD1" };
+const ser_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "OG" };
+const thr_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG2", "OG1" };
+const cys_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "SG" };
+const met_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "SD", "CE" };
+const pro_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD" };
+const phe_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2", "CE1", "CE2", "CZ" };
+const tyr_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2", "CE1", "CE2", "OH", "CZ" };
+const trp_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2", "CE2", "CE3", "NE1", "CH2", "CZ2", "CZ3" };
+const his_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD2", "ND1", "CE1", "NE2" };
+const glu_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "OE1", "OE2" };
+const asp_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "OD1", "OD2" };
+const asn_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "ND2", "OD1" };
+const gln_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "NE2", "OE1" };
+const lys_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "CE", "NZ" };
+const arg_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "NE", "NH1", "NH2", "CZ" };
+
+fn residueSpec(one_letter: u8) ?ResidueSpec {
+    return switch (one_letter) {
+        'A' => .{ .one_letter = 'A', .name = "ALA", .atoms = &ala_atoms },
+        'C' => .{ .one_letter = 'C', .name = "CYS", .atoms = &cys_atoms },
+        'D' => .{ .one_letter = 'D', .name = "ASP", .atoms = &asp_atoms },
+        'E' => .{ .one_letter = 'E', .name = "GLU", .atoms = &glu_atoms },
+        'F' => .{ .one_letter = 'F', .name = "PHE", .atoms = &phe_atoms },
+        'G' => .{ .one_letter = 'G', .name = "GLY", .atoms = &gly_atoms },
+        'H' => .{ .one_letter = 'H', .name = "HIS", .atoms = &his_atoms },
+        'I' => .{ .one_letter = 'I', .name = "ILE", .atoms = &ile_atoms },
+        'K' => .{ .one_letter = 'K', .name = "LYS", .atoms = &lys_atoms },
+        'L' => .{ .one_letter = 'L', .name = "LEU", .atoms = &leu_atoms },
+        'M' => .{ .one_letter = 'M', .name = "MET", .atoms = &met_atoms },
+        'N' => .{ .one_letter = 'N', .name = "ASN", .atoms = &asn_atoms },
+        'P' => .{ .one_letter = 'P', .name = "PRO", .atoms = &pro_atoms },
+        'Q' => .{ .one_letter = 'Q', .name = "GLN", .atoms = &gln_atoms },
+        'R' => .{ .one_letter = 'R', .name = "ARG", .atoms = &arg_atoms },
+        'S' => .{ .one_letter = 'S', .name = "SER", .atoms = &ser_atoms },
+        'T' => .{ .one_letter = 'T', .name = "THR", .atoms = &thr_atoms },
+        'V' => .{ .one_letter = 'V', .name = "VAL", .atoms = &val_atoms },
+        'W' => .{ .one_letter = 'W', .name = "TRP", .atoms = &trp_atoms },
+        'Y' => .{ .one_letter = 'Y', .name = "TYR", .atoms = &tyr_atoms },
+        else => null,
+    };
+}
+
+pub fn parseFile(allocator: Allocator, io: std.Io, path: []const u8) !AtomInput {
+    if (compressed.isCompressed(path)) {
+        const data = try compressed.read(allocator, path);
+        defer allocator.free(data);
+        return parse(allocator, data);
+    }
+
+    const mapped = try mmap_reader.mmapFile(allocator, io, path);
+    defer mapped.deinit();
+    return parse(allocator, mapped.data);
+}
+
+pub fn parse(allocator: Allocator, source: []const u8) !AtomInput {
+    const sequence = try extractSequence(allocator, source);
+    defer allocator.free(sequence);
+    if (sequence.len == 0) return ParseError.MissingSequence;
+
+    const expected_atoms = try expectedAtomCount(sequence);
+    var x = try allocator.alloc(f64, expected_atoms);
+    errdefer allocator.free(x);
+    var y = try allocator.alloc(f64, expected_atoms);
+    errdefer allocator.free(y);
+    var z = try allocator.alloc(f64, expected_atoms);
+    errdefer allocator.free(z);
+    var r = try allocator.alloc(f64, expected_atoms);
+    errdefer allocator.free(r);
+    var residue = try allocator.alloc(types.FixedString5, expected_atoms);
+    errdefer allocator.free(residue);
+    var atom_name = try allocator.alloc(types.FixedString4, expected_atoms);
+    errdefer allocator.free(atom_name);
+    var element = try allocator.alloc(u8, expected_atoms);
+    errdefer allocator.free(element);
+    var chain_id = try allocator.alloc(types.FixedString4, expected_atoms);
+    errdefer allocator.free(chain_id);
+    var residue_num = try allocator.alloc(i32, expected_atoms);
+    errdefer allocator.free(residue_num);
+    var insertion_code = try allocator.alloc(types.FixedString4, expected_atoms);
+    errdefer allocator.free(insertion_code);
+
+    var line_it = std.mem.splitScalar(u8, source, '\n');
+    var atom_index: usize = 0;
+    var cursor = AtomDescriptionCursor{ .sequence = sequence };
+    while (line_it.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, "\r");
+        if (!std.mem.startsWith(u8, line, "ATOM ")) continue;
+        if (atom_index >= expected_atoms) return ParseError.AtomCountMismatch;
+
+        const xyz = try parseAtomLineCoordinates(line);
+        x[atom_index] = xyz[0];
+        y[atom_index] = xyz[1];
+        z[atom_index] = xyz[2];
+
+        const desc = try cursor.next();
+        residue[atom_index] = types.FixedString5.fromSlice(desc.residue_name);
+        atom_name[atom_index] = types.FixedString4.fromSlice(desc.atom_name);
+        const e = elementFromAtomName(desc.atom_name);
+        element[atom_index] = e.atomicNumber();
+        r[atom_index] = e.vdwRadius();
+        chain_id[atom_index] = types.FixedString4.fromSlice("A");
+        residue_num[atom_index] = @intCast(desc.residue_index + 1);
+        insertion_code[atom_index] = types.FixedString4.fromSlice("");
+
+        atom_index += 1;
+    }
+
+    if (atom_index == 0) return ParseError.NoAtomRecord;
+    if (atom_index != expected_atoms) return ParseError.AtomCountMismatch;
+
+    return .{
+        .x = x,
+        .y = y,
+        .z = z,
+        .r = r,
+        .residue = residue,
+        .atom_name = atom_name,
+        .element = element,
+        .chain_id = chain_id,
+        .residue_num = residue_num,
+        .insertion_code = insertion_code,
+        .allocator = allocator,
+    };
+}
+
+fn extractSequence(allocator: Allocator, source: []const u8) ![]u8 {
+    const marker = "_struct_ref.pdbx_seq_one_letter_code";
+    const marker_pos = std.mem.indexOf(u8, source, marker) orelse return ParseError.MissingSequence;
+    var p: usize = marker_pos + marker.len;
+    while (p < source.len and (source[p] == ' ' or source[p] == '\t')) p += 1;
+
+    var raw: []const u8 = "";
+    if (p < source.len and source[p] != '\n' and source[p] != '\r') {
+        const line_end = std.mem.indexOfScalarPos(u8, source, p, '\n') orelse source.len;
+        raw = source[p..line_end];
+    } else {
+        const newline = std.mem.indexOfScalarPos(u8, source, p, '\n') orelse return ParseError.MissingSequence;
+        p = newline + 1;
+        if (p >= source.len or source[p] != ';') return ParseError.MissingSequence;
+        const content_start = p + 1;
+        const content_end = std.mem.indexOf(u8, source[content_start..], "\n;") orelse return ParseError.MissingSequence;
+        raw = source[content_start .. content_start + content_end];
+    }
+
+    var sequence = std.ArrayListUnmanaged(u8).empty;
+    errdefer sequence.deinit(allocator);
+    for (raw) |c| {
+        if (std.ascii.isWhitespace(c) or c == ';' or c == '\'' or c == '"') continue;
+        const aa = std.ascii.toUpper(c);
+        if (residueSpec(aa) == null) return ParseError.NonStandardResidue;
+        try sequence.append(allocator, aa);
+    }
+    return sequence.toOwnedSlice(allocator);
+}
+
+fn expectedAtomCount(sequence: []const u8) !usize {
+    var count: usize = 1; // terminal OXT
+    for (sequence) |aa| {
+        const spec = residueSpec(aa) orelse return ParseError.NonStandardResidue;
+        count += spec.atoms.len;
+    }
+    return count;
+}
+
+fn parseAtomLineCoordinates(line: []const u8) ![3]f64 {
+    const q_index = std.mem.indexOfScalar(u8, line, '?') orelse return ParseError.MissingCoordinateMarker;
+    var token_it = std.mem.tokenizeAny(u8, line[q_index + 1 ..], " \t\r");
+    const x_token = token_it.next() orelse return ParseError.InvalidCoordinate;
+    const y_token = token_it.next() orelse return ParseError.InvalidCoordinate;
+    const z_token = token_it.next() orelse return ParseError.InvalidCoordinate;
+    return .{
+        std.fmt.parseFloat(f64, x_token) catch return ParseError.InvalidCoordinate,
+        std.fmt.parseFloat(f64, y_token) catch return ParseError.InvalidCoordinate,
+        std.fmt.parseFloat(f64, z_token) catch return ParseError.InvalidCoordinate,
+    };
+}
+
+const AtomDescription = struct {
+    residue_index: usize,
+    residue_name: []const u8,
+    atom_name: []const u8,
+};
+
+const AtomDescriptionCursor = struct {
+    sequence: []const u8,
+    residue_index: usize = 0,
+    atom_index_in_residue: usize = 0,
+    emitted_terminal_oxt: bool = false,
+
+    fn next(self: *AtomDescriptionCursor) !AtomDescription {
+        while (self.residue_index < self.sequence.len) {
+            const spec = residueSpec(self.sequence[self.residue_index]) orelse return ParseError.NonStandardResidue;
+            if (self.atom_index_in_residue < spec.atoms.len) {
+                const desc = AtomDescription{
+                    .residue_index = self.residue_index,
+                    .residue_name = spec.name,
+                    .atom_name = spec.atoms[self.atom_index_in_residue],
+                };
+                self.atom_index_in_residue += 1;
+                return desc;
+            }
+            self.residue_index += 1;
+            self.atom_index_in_residue = 0;
+        }
+
+        if (!self.emitted_terminal_oxt and self.sequence.len > 0) {
+            self.emitted_terminal_oxt = true;
+            const last = residueSpec(self.sequence[self.sequence.len - 1]) orelse return ParseError.NonStandardResidue;
+            return .{
+                .residue_index = self.sequence.len - 1,
+                .residue_name = last.name,
+                .atom_name = "OXT",
+            };
+        }
+
+        return ParseError.AtomCountMismatch;
+    }
+};
+
+fn elementFromAtomName(atom_name: []const u8) elem.Element {
+    for (atom_name) |c| {
+        const upper = std.ascii.toUpper(c);
+        return switch (upper) {
+            'H' => .H,
+            'C' => .C,
+            'N' => .N,
+            'O' => .O,
+            'P' => .P,
+            'S' => .S,
+            else => .X,
+        };
+    }
+    return .X;
+}
+
+test "parse AlphaFold-like mmCIF atom records from sequence and ATOM rows" {
+    const source =
+        \\data_AF_TEST
+        \\_struct_ref.pdbx_seq_one_letter_code
+        \\;AG
+        \\;
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_entity_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.pdbx_PDB_ins_code
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\_atom_site.occupancy
+        \\_atom_site.B_iso_or_equiv
+        \\ATOM 1 N N . ALA A 1 1 ? 1.000 2.000 3.000 1.00 90.00
+        \\ATOM 2 C CA . ALA A 1 1 ? 2.000 3.000 4.000 1.00 90.00
+        \\ATOM 3 C C . ALA A 1 1 ? 3.000 4.000 5.000 1.00 90.00
+        \\ATOM 4 C CB . ALA A 1 1 ? 4.000 5.000 6.000 1.00 90.00
+        \\ATOM 5 O O . ALA A 1 1 ? 5.000 6.000 7.000 1.00 90.00
+        \\ATOM 6 N N . GLY A 1 2 ? 6.000 7.000 8.000 1.00 80.00
+        \\ATOM 7 C CA . GLY A 1 2 ? 7.000 8.000 9.000 1.00 80.00
+        \\ATOM 8 C C . GLY A 1 2 ? 8.000 9.000 10.000 1.00 80.00
+        \\ATOM 9 O O . GLY A 1 2 ? 9.000 10.000 11.000 1.00 80.00
+        \\ATOM 10 O OXT . GLY A 1 2 ? 10.000 11.000 12.000 1.00 80.00
+        \\#
+        \\
+    ;
+
+    var input = try parse(std.testing.allocator, source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 10), input.atomCount());
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), input.x[0], 0.0001);
+    try std.testing.expectApproxEqAbs(@as(f64, 12.0), input.z[9], 0.0001);
+    try std.testing.expectEqualStrings("ALA", input.residue.?[0].slice());
+    try std.testing.expectEqualStrings("CB", input.atom_name.?[3].slice());
+    try std.testing.expectEqualStrings("GLY", input.residue.?[9].slice());
+    try std.testing.expectEqualStrings("OXT", input.atom_name.?[9].slice());
+    try std.testing.expectEqual(@as(i32, 2), input.residue_num.?[9]);
+    try std.testing.expectEqual(@as(u8, 8), input.element.?[9]);
+}
+
+test "rejects AlphaFold-like mmCIF when ATOM row count does not match sequence" {
+    const source =
+        \\data_AF_BAD
+        \\_struct_ref.pdbx_seq_one_letter_code AG
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_entity_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.pdbx_PDB_ins_code
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM 1 N N . ALA A 1 1 ? 1.000 2.000 3.000
+        \\
+    ;
+
+    try std.testing.expectError(error.AtomCountMismatch, parse(std.testing.allocator, source));
+}

--- a/src/af_model_parser.zig
+++ b/src/af_model_parser.zig
@@ -108,15 +108,24 @@ pub fn parse(allocator: Allocator, source: []const u8) !AtomInput {
     var insertion_code = try allocator.alloc(types.FixedString4, expected_atoms);
     errdefer allocator.free(insertion_code);
 
-    var line_it = std.mem.splitScalar(u8, source, '\n');
+    const first_atom = findFirstAtomLine(source) orelse return ParseError.NoAtomRecord;
+    const first_line_end = lineEndTrimmed(source, first_atom);
+    const q_abs = std.mem.indexOfScalarPos(u8, source, first_atom, '?') orelse return ParseError.MissingCoordinateMarker;
+    if (q_abs >= first_line_end) return ParseError.MissingCoordinateMarker;
+    const coord_section_offset = q_abs + 1 - first_atom;
+
+    var atom_start = first_atom;
     var atom_index: usize = 0;
     var cursor = AtomDescriptionCursor{ .sequence = sequence };
-    while (line_it.next()) |raw_line| {
-        const line = std.mem.trim(u8, raw_line, "\r");
-        if (!std.mem.startsWith(u8, line, "ATOM ")) continue;
-        if (atom_index >= expected_atoms) return ParseError.AtomCountMismatch;
+    while (atom_index < expected_atoms) {
+        if (atom_start + 5 > source.len or !std.mem.startsWith(u8, source[atom_start..], "ATOM ")) break;
 
-        const xyz = try parseAtomLineCoordinates(line);
+        const raw_line_end = lineEnd(source, atom_start);
+        const trimmed_line_end = trimCarriageReturn(source, raw_line_end);
+        if (atom_start + coord_section_offset >= trimmed_line_end) return ParseError.InvalidCoordinate;
+
+        const line = source[atom_start..trimmed_line_end];
+        const xyz = try parseAtomLineCoordinatesAtOffset(line, coord_section_offset);
         x[atom_index] = xyz[0];
         y[atom_index] = xyz[1];
         z[atom_index] = xyz[2];
@@ -132,6 +141,8 @@ pub fn parse(allocator: Allocator, source: []const u8) !AtomInput {
         insertion_code[atom_index] = types.FixedString4.fromSlice("");
 
         atom_index += 1;
+        if (raw_line_end >= source.len) break;
+        atom_start = raw_line_end + 1;
     }
 
     if (atom_index == 0) return ParseError.NoAtomRecord;
@@ -191,17 +202,81 @@ fn expectedAtomCount(sequence: []const u8) !usize {
     return count;
 }
 
-fn parseAtomLineCoordinates(line: []const u8) ![3]f64 {
-    const q_index = std.mem.indexOfScalar(u8, line, '?') orelse return ParseError.MissingCoordinateMarker;
-    var token_it = std.mem.tokenizeAny(u8, line[q_index + 1 ..], " \t\r");
-    const x_token = token_it.next() orelse return ParseError.InvalidCoordinate;
-    const y_token = token_it.next() orelse return ParseError.InvalidCoordinate;
-    const z_token = token_it.next() orelse return ParseError.InvalidCoordinate;
-    return .{
-        std.fmt.parseFloat(f64, x_token) catch return ParseError.InvalidCoordinate,
-        std.fmt.parseFloat(f64, y_token) catch return ParseError.InvalidCoordinate,
-        std.fmt.parseFloat(f64, z_token) catch return ParseError.InvalidCoordinate,
-    };
+fn findFirstAtomLine(source: []const u8) ?usize {
+    var line_start: usize = 0;
+    while (line_start < source.len) {
+        const raw_line_end = lineEnd(source, line_start);
+        const trimmed_line_end = trimCarriageReturn(source, raw_line_end);
+        if (std.mem.startsWith(u8, source[line_start..trimmed_line_end], "ATOM ")) return line_start;
+        if (raw_line_end >= source.len) break;
+        line_start = raw_line_end + 1;
+    }
+    return null;
+}
+
+fn lineEnd(source: []const u8, line_start: usize) usize {
+    return std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
+}
+
+fn lineEndTrimmed(source: []const u8, line_start: usize) usize {
+    return trimCarriageReturn(source, lineEnd(source, line_start));
+}
+
+fn trimCarriageReturn(source: []const u8, raw_line_end: usize) usize {
+    if (raw_line_end > 0 and source[raw_line_end - 1] == '\r') return raw_line_end - 1;
+    return raw_line_end;
+}
+
+fn parseAtomLineCoordinatesAtOffset(line: []const u8, coord_section_offset: usize) ![3]f64 {
+    var cursor = coord_section_offset;
+    const x = try parseNextFixedFloat(line, &cursor);
+    const y = try parseNextFixedFloat(line, &cursor);
+    const z = try parseNextFixedFloat(line, &cursor);
+    return .{ x, y, z };
+}
+
+fn parseNextFixedFloat(line: []const u8, cursor: *usize) !f64 {
+    while (cursor.* < line.len and (line[cursor.*] == ' ' or line[cursor.*] == '\t')) cursor.* += 1;
+    const start = cursor.*;
+    while (cursor.* < line.len and isFixedFloatChar(line[cursor.*])) cursor.* += 1;
+    if (cursor.* == start) return ParseError.InvalidCoordinate;
+    return parseFixedFloat(line[start..cursor.*]) orelse ParseError.InvalidCoordinate;
+}
+
+fn isFixedFloatChar(c: u8) bool {
+    return (c >= '0' and c <= '9') or c == '.' or c == '-' or c == '+';
+}
+
+fn parseFixedFloat(field: []const u8) ?f64 {
+    if (field.len == 0) return null;
+    var i: usize = 0;
+    var negative = false;
+    if (field[i] == '-') {
+        negative = true;
+        i += 1;
+    } else if (field[i] == '+') {
+        i += 1;
+    }
+
+    var value: f64 = 0.0;
+    var has_digits = false;
+    while (i < field.len and field[i] >= '0' and field[i] <= '9') : (i += 1) {
+        has_digits = true;
+        value = value * 10.0 + @as(f64, @floatFromInt(field[i] - '0'));
+    }
+
+    if (i < field.len and field[i] == '.') {
+        i += 1;
+        var factor: f64 = 0.1;
+        while (i < field.len and field[i] >= '0' and field[i] <= '9') : (i += 1) {
+            has_digits = true;
+            value += @as(f64, @floatFromInt(field[i] - '0')) * factor;
+            factor *= 0.1;
+        }
+    }
+
+    if (!has_digits or i != field.len) return null;
+    return if (negative) -value else value;
 }
 
 const AtomDescription = struct {
@@ -284,16 +359,16 @@ test "parse AlphaFold-like mmCIF atom records from sequence and ATOM rows" {
         \\_atom_site.Cartn_z
         \\_atom_site.occupancy
         \\_atom_site.B_iso_or_equiv
-        \\ATOM 1 N N . ALA A 1 1 ? 1.000 2.000 3.000 1.00 90.00
-        \\ATOM 2 C CA . ALA A 1 1 ? 2.000 3.000 4.000 1.00 90.00
-        \\ATOM 3 C C . ALA A 1 1 ? 3.000 4.000 5.000 1.00 90.00
-        \\ATOM 4 C CB . ALA A 1 1 ? 4.000 5.000 6.000 1.00 90.00
-        \\ATOM 5 O O . ALA A 1 1 ? 5.000 6.000 7.000 1.00 90.00
-        \\ATOM 6 N N . GLY A 1 2 ? 6.000 7.000 8.000 1.00 80.00
-        \\ATOM 7 C CA . GLY A 1 2 ? 7.000 8.000 9.000 1.00 80.00
-        \\ATOM 8 C C . GLY A 1 2 ? 8.000 9.000 10.000 1.00 80.00
-        \\ATOM 9 O O . GLY A 1 2 ? 9.000 10.000 11.000 1.00 80.00
-        \\ATOM 10 O OXT . GLY A 1 2 ? 10.000 11.000 12.000 1.00 80.00
+        \\ATOM 1    N N   . ALA A 1 1   ? 1.000  2.000  3.000  1.00 90.00
+        \\ATOM 2    C CA  . ALA A 1 1   ? 2.000  3.000  4.000  1.00 90.00
+        \\ATOM 3    C C   . ALA A 1 1   ? 3.000  4.000  5.000  1.00 90.00
+        \\ATOM 4    C CB  . ALA A 1 1   ? 4.000  5.000  6.000  1.00 90.00
+        \\ATOM 5    O O   . ALA A 1 1   ? 5.000  6.000  7.000  1.00 90.00
+        \\ATOM 6    N N   . GLY A 1 2   ? 6.000  7.000  8.000  1.00 80.00
+        \\ATOM 7    C CA  . GLY A 1 2   ? 7.000  8.000  9.000  1.00 80.00
+        \\ATOM 8    C C   . GLY A 1 2   ? 8.000  9.000  10.000 1.00 80.00
+        \\ATOM 9    O O   . GLY A 1 2   ? 9.000  10.000 11.000 1.00 80.00
+        \\ATOM 10   O OXT . GLY A 1 2   ? 10.000 11.000 12.000 1.00 80.00
         \\#
         \\
     ;
@@ -330,9 +405,24 @@ test "rejects AlphaFold-like mmCIF when ATOM row count does not match sequence" 
         \\_atom_site.Cartn_x
         \\_atom_site.Cartn_y
         \\_atom_site.Cartn_z
-        \\ATOM 1 N N . ALA A 1 1 ? 1.000 2.000 3.000
+        \\ATOM 1    N N   . ALA A 1 1   ? 1.000  2.000  3.000
         \\
     ;
 
     try std.testing.expectError(error.AtomCountMismatch, parse(std.testing.allocator, source));
+}
+
+test "rejects AF model mmCIF when ATOM rows are not consecutive" {
+    const allocator = std.testing.allocator;
+    const cif =
+        "_struct_ref.pdbx_seq_one_letter_code A\n" ++
+        "ATOM 1    N N   . ALA A 1 1   ? 1.000  2.000  3.000  1.00 90.00\n" ++
+        "# non-ATOM row between atom records forces generic parser fallback\n" ++
+        "ATOM 2    C CA  . ALA A 1 1   ? 2.000  3.000  4.000  1.00 90.00\n" ++
+        "ATOM 3    C C   . ALA A 1 1   ? 3.000  4.000  5.000  1.00 90.00\n" ++
+        "ATOM 4    C CB  . ALA A 1 1   ? 4.000  5.000  6.000  1.00 90.00\n" ++
+        "ATOM 5    O O   . ALA A 1 1   ? 5.000  6.000  7.000  1.00 90.00\n" ++
+        "ATOM 6    O OXT . ALA A 1 1   ? 6.000  7.000  8.000  1.00 90.00\n";
+
+    try std.testing.expectError(ParseError.AtomCountMismatch, parse(allocator, cif));
 }

--- a/src/af_model_parser.zig
+++ b/src/af_model_parser.zig
@@ -1,152 +1,152 @@
 const std = @import("std");
 const compressed = @import("compressed.zig");
 const elem = @import("element.zig");
+const input_io = @import("input_io.zig");
 const mmap_reader = @import("mmap_reader.zig");
 const types = @import("types.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
+pub const InputIoMode = input_io.InputIoMode;
+
+pub const ParseOptions = struct {
+    io_mode: InputIoMode = .mmap,
+};
 
 pub const ParseError = error{
-    MissingSequence,
-    NonStandardResidue,
+    UnsupportedLayout,
     NoAtomRecord,
-    MissingCoordinateMarker,
     InvalidCoordinate,
-    AtomCountMismatch,
+    InvalidResidueNumber,
 };
-
-const ResidueSpec = struct {
-    one_letter: u8,
-    name: []const u8,
-    atoms: []const []const u8,
-};
-
-const gly_atoms = [_][]const u8{ "N", "CA", "C", "O" };
-const ala_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O" };
-const val_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG1", "CG2" };
-const leu_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2" };
-const ile_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG1", "CG2", "CD1" };
-const ser_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "OG" };
-const thr_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG2", "OG1" };
-const cys_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "SG" };
-const met_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "SD", "CE" };
-const pro_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD" };
-const phe_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2", "CE1", "CE2", "CZ" };
-const tyr_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2", "CE1", "CE2", "OH", "CZ" };
-const trp_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD1", "CD2", "CE2", "CE3", "NE1", "CH2", "CZ2", "CZ3" };
-const his_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD2", "ND1", "CE1", "NE2" };
-const glu_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "OE1", "OE2" };
-const asp_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "OD1", "OD2" };
-const asn_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "ND2", "OD1" };
-const gln_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "NE2", "OE1" };
-const lys_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "CE", "NZ" };
-const arg_atoms = [_][]const u8{ "N", "CA", "C", "CB", "O", "CG", "CD", "NE", "NH1", "NH2", "CZ" };
-
-fn residueSpec(one_letter: u8) ?ResidueSpec {
-    return switch (one_letter) {
-        'A' => .{ .one_letter = 'A', .name = "ALA", .atoms = &ala_atoms },
-        'C' => .{ .one_letter = 'C', .name = "CYS", .atoms = &cys_atoms },
-        'D' => .{ .one_letter = 'D', .name = "ASP", .atoms = &asp_atoms },
-        'E' => .{ .one_letter = 'E', .name = "GLU", .atoms = &glu_atoms },
-        'F' => .{ .one_letter = 'F', .name = "PHE", .atoms = &phe_atoms },
-        'G' => .{ .one_letter = 'G', .name = "GLY", .atoms = &gly_atoms },
-        'H' => .{ .one_letter = 'H', .name = "HIS", .atoms = &his_atoms },
-        'I' => .{ .one_letter = 'I', .name = "ILE", .atoms = &ile_atoms },
-        'K' => .{ .one_letter = 'K', .name = "LYS", .atoms = &lys_atoms },
-        'L' => .{ .one_letter = 'L', .name = "LEU", .atoms = &leu_atoms },
-        'M' => .{ .one_letter = 'M', .name = "MET", .atoms = &met_atoms },
-        'N' => .{ .one_letter = 'N', .name = "ASN", .atoms = &asn_atoms },
-        'P' => .{ .one_letter = 'P', .name = "PRO", .atoms = &pro_atoms },
-        'Q' => .{ .one_letter = 'Q', .name = "GLN", .atoms = &gln_atoms },
-        'R' => .{ .one_letter = 'R', .name = "ARG", .atoms = &arg_atoms },
-        'S' => .{ .one_letter = 'S', .name = "SER", .atoms = &ser_atoms },
-        'T' => .{ .one_letter = 'T', .name = "THR", .atoms = &thr_atoms },
-        'V' => .{ .one_letter = 'V', .name = "VAL", .atoms = &val_atoms },
-        'W' => .{ .one_letter = 'W', .name = "TRP", .atoms = &trp_atoms },
-        'Y' => .{ .one_letter = 'Y', .name = "TYR", .atoms = &tyr_atoms },
-        else => null,
-    };
-}
 
 pub fn parseFile(allocator: Allocator, io: std.Io, path: []const u8) !AtomInput {
+    return parseFileWithOptions(allocator, io, path, .{});
+}
+
+pub fn parseFileWithOptions(allocator: Allocator, io: std.Io, path: []const u8, options: ParseOptions) !AtomInput {
     if (compressed.isCompressed(path)) {
         const data = try compressed.read(allocator, path);
         defer allocator.free(data);
         return parse(allocator, data);
     }
 
-    const mapped = try mmap_reader.mmapFile(allocator, io, path);
-    defer mapped.deinit();
-    return parse(allocator, mapped.data);
+    switch (options.io_mode.resolve(.mmap)) {
+        .mmap => {
+            const mapped = try mmap_reader.mmapFile(allocator, io, path);
+            defer mapped.deinit();
+            return parse(allocator, mapped.data);
+        },
+        .read => {
+            const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+            defer file.close(io);
+            var read_buf: [64 * 1024]u8 = undefined;
+            var reader = file.reader(io, &read_buf);
+            const data = try reader.interface.allocRemaining(allocator, .unlimited);
+            defer allocator.free(data);
+            return parse(allocator, data);
+        },
+        .auto => unreachable,
+    }
 }
 
-pub fn parse(allocator: Allocator, source: []const u8) !AtomInput {
-    const sequence = try extractSequence(allocator, source);
-    defer allocator.free(sequence);
-    if (sequence.len == 0) return ParseError.MissingSequence;
+const AtomSiteLayout = struct {
+    num_cols: usize = 0,
+    data_start: usize = 0,
+    group_pdb: ?usize = null,
+    type_symbol: ?usize = null,
+    atom_name: ?usize = null,
+    residue: ?usize = null,
+    chain_id: ?usize = null,
+    residue_num: ?usize = null,
+    insertion_code: ?usize = null,
+    alt_loc: ?usize = null,
+    cartn_x: ?usize = null,
+    cartn_y: ?usize = null,
+    cartn_z: ?usize = null,
+    model_num: ?usize = null,
 
-    const expected_atoms = try expectedAtomCount(sequence);
-    var x = try allocator.alloc(f64, expected_atoms);
+    fn hasRequiredFields(self: AtomSiteLayout) bool {
+        return self.group_pdb != null and
+            self.type_symbol != null and
+            self.atom_name != null and
+            self.residue != null and
+            self.chain_id != null and
+            self.residue_num != null and
+            self.cartn_x != null and
+            self.cartn_y != null and
+            self.cartn_z != null;
+    }
+};
+
+const AtomRow = struct {
+    x: f64,
+    y: f64,
+    z: f64,
+    radius: f64,
+    residue: types.FixedString5,
+    atom_name: types.FixedString4,
+    element: u8,
+    chain_id: types.FixedString4,
+    residue_num: i32,
+    insertion_code: types.FixedString4,
+};
+
+pub fn parse(allocator: Allocator, source: []const u8) !AtomInput {
+    const layout = try findAtomSiteLayout(source);
+    const atom_count = try countSupportedRows(source, layout);
+    if (atom_count == 0) return ParseError.NoAtomRecord;
+
+    var x = try allocator.alloc(f64, atom_count);
     errdefer allocator.free(x);
-    var y = try allocator.alloc(f64, expected_atoms);
+    var y = try allocator.alloc(f64, atom_count);
     errdefer allocator.free(y);
-    var z = try allocator.alloc(f64, expected_atoms);
+    var z = try allocator.alloc(f64, atom_count);
     errdefer allocator.free(z);
-    var r = try allocator.alloc(f64, expected_atoms);
+    var r = try allocator.alloc(f64, atom_count);
     errdefer allocator.free(r);
-    var residue = try allocator.alloc(types.FixedString5, expected_atoms);
+    var residue = try allocator.alloc(types.FixedString5, atom_count);
     errdefer allocator.free(residue);
-    var atom_name = try allocator.alloc(types.FixedString4, expected_atoms);
+    var atom_name = try allocator.alloc(types.FixedString4, atom_count);
     errdefer allocator.free(atom_name);
-    var element = try allocator.alloc(u8, expected_atoms);
+    var element = try allocator.alloc(u8, atom_count);
     errdefer allocator.free(element);
-    var chain_id = try allocator.alloc(types.FixedString4, expected_atoms);
+    var chain_id = try allocator.alloc(types.FixedString4, atom_count);
     errdefer allocator.free(chain_id);
-    var residue_num = try allocator.alloc(i32, expected_atoms);
+    var residue_num = try allocator.alloc(i32, atom_count);
     errdefer allocator.free(residue_num);
-    var insertion_code = try allocator.alloc(types.FixedString4, expected_atoms);
+    var insertion_code = try allocator.alloc(types.FixedString4, atom_count);
     errdefer allocator.free(insertion_code);
 
-    const first_atom = findFirstAtomLine(source) orelse return ParseError.NoAtomRecord;
-    const first_line_end = lineEndTrimmed(source, first_atom);
-    const q_abs = std.mem.indexOfScalarPos(u8, source, first_atom, '?') orelse return ParseError.MissingCoordinateMarker;
-    if (q_abs >= first_line_end) return ParseError.MissingCoordinateMarker;
-    const coord_section_offset = q_abs + 1 - first_atom;
+    var row_index: usize = 0;
+    var line_start = layout.data_start;
+    while (line_start < source.len and row_index < atom_count) {
+        const raw_line_end = lineEnd(source, line_start);
+        const line = std.mem.trim(u8, source[line_start..trimCarriageReturn(source, raw_line_end)], " \t");
+        if (line.len != 0) {
+            var fields_storage: [64][]const u8 = undefined;
+            const fields = try splitAtomRow(line, layout.num_cols, &fields_storage);
+            if (!std.mem.eql(u8, fields[layout.group_pdb.?], "ATOM")) break;
 
-    var atom_start = first_atom;
-    var atom_index: usize = 0;
-    var cursor = AtomDescriptionCursor{ .sequence = sequence };
-    while (atom_index < expected_atoms) {
-        if (atom_start + 5 > source.len or !std.mem.startsWith(u8, source[atom_start..], "ATOM ")) break;
+            const row = try parseAtomRow(fields, layout);
+            x[row_index] = row.x;
+            y[row_index] = row.y;
+            z[row_index] = row.z;
+            r[row_index] = row.radius;
+            residue[row_index] = row.residue;
+            atom_name[row_index] = row.atom_name;
+            element[row_index] = row.element;
+            chain_id[row_index] = row.chain_id;
+            residue_num[row_index] = row.residue_num;
+            insertion_code[row_index] = row.insertion_code;
+            row_index += 1;
+        }
 
-        const raw_line_end = lineEnd(source, atom_start);
-        const trimmed_line_end = trimCarriageReturn(source, raw_line_end);
-        if (atom_start + coord_section_offset >= trimmed_line_end) return ParseError.InvalidCoordinate;
-
-        const line = source[atom_start..trimmed_line_end];
-        const xyz = try parseAtomLineCoordinatesAtOffset(line, coord_section_offset);
-        x[atom_index] = xyz[0];
-        y[atom_index] = xyz[1];
-        z[atom_index] = xyz[2];
-
-        const desc = try cursor.next();
-        residue[atom_index] = types.FixedString5.fromSlice(desc.residue_name);
-        atom_name[atom_index] = types.FixedString4.fromSlice(desc.atom_name);
-        const e = elementFromAtomName(desc.atom_name);
-        element[atom_index] = e.atomicNumber();
-        r[atom_index] = e.vdwRadius();
-        chain_id[atom_index] = types.FixedString4.fromSlice("A");
-        residue_num[atom_index] = @intCast(desc.residue_index + 1);
-        insertion_code[atom_index] = types.FixedString4.fromSlice("");
-
-        atom_index += 1;
         if (raw_line_end >= source.len) break;
-        atom_start = raw_line_end + 1;
+        line_start = raw_line_end + 1;
     }
 
-    if (atom_index == 0) return ParseError.NoAtomRecord;
-    if (atom_index != expected_atoms) return ParseError.AtomCountMismatch;
+    if (row_index != atom_count) return ParseError.UnsupportedLayout;
 
     return .{
         .x = x,
@@ -163,63 +163,163 @@ pub fn parse(allocator: Allocator, source: []const u8) !AtomInput {
     };
 }
 
-fn extractSequence(allocator: Allocator, source: []const u8) ![]u8 {
-    const marker = "_struct_ref.pdbx_seq_one_letter_code";
-    const marker_pos = std.mem.indexOf(u8, source, marker) orelse return ParseError.MissingSequence;
-    var p: usize = marker_pos + marker.len;
-    while (p < source.len and (source[p] == ' ' or source[p] == '\t')) p += 1;
-
-    var raw: []const u8 = "";
-    if (p < source.len and source[p] != '\n' and source[p] != '\r') {
-        const line_end = std.mem.indexOfScalarPos(u8, source, p, '\n') orelse source.len;
-        raw = source[p..line_end];
-    } else {
-        const newline = std.mem.indexOfScalarPos(u8, source, p, '\n') orelse return ParseError.MissingSequence;
-        p = newline + 1;
-        if (p >= source.len or source[p] != ';') return ParseError.MissingSequence;
-        const content_start = p + 1;
-        const content_end = std.mem.indexOf(u8, source[content_start..], "\n;") orelse return ParseError.MissingSequence;
-        raw = source[content_start .. content_start + content_end];
-    }
-
-    var sequence = std.ArrayListUnmanaged(u8).empty;
-    errdefer sequence.deinit(allocator);
-    for (raw) |c| {
-        if (std.ascii.isWhitespace(c) or c == ';' or c == '\'' or c == '"') continue;
-        const aa = std.ascii.toUpper(c);
-        if (residueSpec(aa) == null) return ParseError.NonStandardResidue;
-        try sequence.append(allocator, aa);
-    }
-    return sequence.toOwnedSlice(allocator);
-}
-
-fn expectedAtomCount(sequence: []const u8) !usize {
-    var count: usize = 1; // terminal OXT
-    for (sequence) |aa| {
-        const spec = residueSpec(aa) orelse return ParseError.NonStandardResidue;
-        count += spec.atoms.len;
-    }
-    return count;
-}
-
-fn findFirstAtomLine(source: []const u8) ?usize {
+fn findAtomSiteLayout(source: []const u8) !AtomSiteLayout {
     var line_start: usize = 0;
+    var in_loop = false;
+    var layout = AtomSiteLayout{};
+
     while (line_start < source.len) {
         const raw_line_end = lineEnd(source, line_start);
-        const trimmed_line_end = trimCarriageReturn(source, raw_line_end);
-        if (std.mem.startsWith(u8, source[line_start..trimmed_line_end], "ATOM ")) return line_start;
+        const line = std.mem.trim(u8, source[line_start..trimCarriageReturn(source, raw_line_end)], " \t");
+
+        if (std.mem.eql(u8, line, "loop_")) {
+            in_loop = true;
+            layout = .{};
+        } else if (in_loop and std.mem.startsWith(u8, line, "_atom_site.")) {
+            mapAtomSiteColumn(&layout, line["_atom_site.".len..], layout.num_cols);
+            layout.num_cols += 1;
+        } else if (in_loop and layout.num_cols > 0 and line.len != 0) {
+            layout.data_start = line_start;
+            if (layout.num_cols > 64 or !layout.hasRequiredFields() or layout.group_pdb.? != 0) {
+                return ParseError.UnsupportedLayout;
+            }
+            return layout;
+        } else if (in_loop and line.len != 0 and !std.mem.startsWith(u8, line, "#")) {
+            in_loop = false;
+        }
+
         if (raw_line_end >= source.len) break;
         line_start = raw_line_end + 1;
     }
-    return null;
+
+    return ParseError.UnsupportedLayout;
+}
+
+fn mapAtomSiteColumn(layout: *AtomSiteLayout, field: []const u8, index: usize) void {
+    if (std.ascii.eqlIgnoreCase(field, "group_PDB")) {
+        layout.group_pdb = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "type_symbol")) {
+        layout.type_symbol = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "label_atom_id")) {
+        layout.atom_name = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "label_comp_id")) {
+        layout.residue = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "label_asym_id")) {
+        layout.chain_id = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "label_seq_id")) {
+        layout.residue_num = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "pdbx_PDB_ins_code")) {
+        layout.insertion_code = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "label_alt_id")) {
+        layout.alt_loc = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "Cartn_x")) {
+        layout.cartn_x = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "Cartn_y")) {
+        layout.cartn_y = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "Cartn_z")) {
+        layout.cartn_z = index;
+    } else if (std.ascii.eqlIgnoreCase(field, "pdbx_PDB_model_num")) {
+        layout.model_num = index;
+    }
+}
+
+fn countSupportedRows(source: []const u8, layout: AtomSiteLayout) !usize {
+    var count: usize = 0;
+    var line_start = layout.data_start;
+    var finished = false;
+
+    while (line_start < source.len) {
+        const raw_line_end = lineEnd(source, line_start);
+        const line = std.mem.trim(u8, source[line_start..trimCarriageReturn(source, raw_line_end)], " \t");
+
+        if (line.len != 0) {
+            if (finished) {
+                if (std.mem.startsWith(u8, line, "ATOM ")) return ParseError.UnsupportedLayout;
+            } else {
+                if (!std.mem.startsWith(u8, line, "ATOM ")) {
+                    if (count == 0) return ParseError.UnsupportedLayout;
+                    finished = true;
+                } else {
+                    count += 1;
+                }
+            }
+        }
+
+        if (raw_line_end >= source.len) break;
+        line_start = raw_line_end + 1;
+    }
+
+    return count;
+}
+
+fn splitAtomRow(line: []const u8, expected_fields: usize, storage: *[64][]const u8) ![]const []const u8 {
+    var tokenizer = std.mem.tokenizeAny(u8, line, " \t");
+    var count: usize = 0;
+    while (tokenizer.next()) |field| {
+        if (count >= storage.len) return ParseError.UnsupportedLayout;
+        if (field[0] == '\'' or field[0] == '"' or field[0] == ';') return ParseError.UnsupportedLayout;
+        storage[count] = field;
+        count += 1;
+    }
+    if (count != expected_fields) return ParseError.UnsupportedLayout;
+    return storage[0..count];
+}
+
+fn parseAtomRow(fields: []const []const u8, layout: AtomSiteLayout) !AtomRow {
+    const alt_loc = if (layout.alt_loc) |index| fields[index] else ".";
+    if (!isNullValue(alt_loc)) return ParseError.UnsupportedLayout;
+
+    if (layout.model_num) |index| {
+        const model = fields[index];
+        if (!isNullValue(model) and !std.mem.eql(u8, model, "1")) {
+            return ParseError.UnsupportedLayout;
+        }
+    }
+
+    const residue_value = fields[layout.residue.?];
+    const atom_name_value = fields[layout.atom_name.?];
+    const chain_value = fields[layout.chain_id.?];
+    if (isNullValue(residue_value) or residue_value.len > 5 or
+        isNullValue(atom_name_value) or atom_name_value.len > 4 or
+        isNullValue(chain_value) or chain_value.len > 4)
+    {
+        return ParseError.UnsupportedLayout;
+    }
+
+    const element_value = fields[layout.type_symbol.?];
+    if (isNullValue(element_value)) return ParseError.UnsupportedLayout;
+    const element_enum = elem.fromSymbol(element_value);
+    if (element_enum == .X or element_enum == .H) return ParseError.UnsupportedLayout;
+
+    const residue_number_value = fields[layout.residue_num.?];
+    const residue_number: i32 = if (isNullValue(residue_number_value))
+        0
+    else
+        std.fmt.parseInt(i32, residue_number_value, 10) catch return ParseError.InvalidResidueNumber;
+
+    const insertion_value = if (layout.insertion_code) |index| fields[index] else "?";
+    if (!isNullValue(insertion_value) and insertion_value.len > 4) return ParseError.UnsupportedLayout;
+
+    return .{
+        .x = try parseCoordinate(fields[layout.cartn_x.?]),
+        .y = try parseCoordinate(fields[layout.cartn_y.?]),
+        .z = try parseCoordinate(fields[layout.cartn_z.?]),
+        .radius = element_enum.vdwRadius(),
+        .residue = types.FixedString5.fromSlice(residue_value),
+        .atom_name = types.FixedString4.fromSlice(atom_name_value),
+        .element = element_enum.atomicNumber(),
+        .chain_id = types.FixedString4.fromSlice(chain_value),
+        .residue_num = residue_number,
+        .insertion_code = types.FixedString4.fromSlice(if (isNullValue(insertion_value)) "" else insertion_value),
+    };
+}
+
+fn isNullValue(value: []const u8) bool {
+    return std.mem.eql(u8, value, ".") or std.mem.eql(u8, value, "?");
 }
 
 fn lineEnd(source: []const u8, line_start: usize) usize {
     return std.mem.indexOfScalarPos(u8, source, line_start, '\n') orelse source.len;
-}
-
-fn lineEndTrimmed(source: []const u8, line_start: usize) usize {
-    return trimCarriageReturn(source, lineEnd(source, line_start));
 }
 
 fn trimCarriageReturn(source: []const u8, raw_line_end: usize) usize {
@@ -227,24 +327,11 @@ fn trimCarriageReturn(source: []const u8, raw_line_end: usize) usize {
     return raw_line_end;
 }
 
-fn parseAtomLineCoordinatesAtOffset(line: []const u8, coord_section_offset: usize) ![3]f64 {
-    var cursor = coord_section_offset;
-    const x = try parseNextFixedFloat(line, &cursor);
-    const y = try parseNextFixedFloat(line, &cursor);
-    const z = try parseNextFixedFloat(line, &cursor);
-    return .{ x, y, z };
-}
-
-fn parseNextFixedFloat(line: []const u8, cursor: *usize) !f64 {
-    while (cursor.* < line.len and (line[cursor.*] == ' ' or line[cursor.*] == '\t')) cursor.* += 1;
-    const start = cursor.*;
-    while (cursor.* < line.len and isFixedFloatChar(line[cursor.*])) cursor.* += 1;
-    if (cursor.* == start) return ParseError.InvalidCoordinate;
-    return parseFixedFloat(line[start..cursor.*]) orelse ParseError.InvalidCoordinate;
-}
-
-fn isFixedFloatChar(c: u8) bool {
-    return (c >= '0' and c <= '9') or c == '.' or c == '-' or c == '+';
+fn parseCoordinate(field: []const u8) !f64 {
+    if (std.mem.indexOfAny(u8, field, "eE") != null) {
+        return std.fmt.parseFloat(f64, field) catch ParseError.InvalidCoordinate;
+    }
+    return parseFixedFloat(field) orelse ParseError.InvalidCoordinate;
 }
 
 fn parseFixedFloat(field: []const u8) ?f64 {
@@ -260,7 +347,7 @@ fn parseFixedFloat(field: []const u8) ?f64 {
 
     var value: f64 = 0.0;
     var has_digits = false;
-    while (i < field.len and field[i] >= '0' and field[i] <= '9') : (i += 1) {
+    while (i < field.len and std.ascii.isDigit(field[i])) : (i += 1) {
         has_digits = true;
         value = value * 10.0 + @as(f64, @floatFromInt(field[i] - '0'));
     }
@@ -268,7 +355,7 @@ fn parseFixedFloat(field: []const u8) ?f64 {
     if (i < field.len and field[i] == '.') {
         i += 1;
         var factor: f64 = 0.1;
-        while (i < field.len and field[i] >= '0' and field[i] <= '9') : (i += 1) {
+        while (i < field.len and std.ascii.isDigit(field[i])) : (i += 1) {
             has_digits = true;
             value += @as(f64, @floatFromInt(field[i] - '0')) * factor;
             factor *= 0.1;
@@ -279,65 +366,7 @@ fn parseFixedFloat(field: []const u8) ?f64 {
     return if (negative) -value else value;
 }
 
-const AtomDescription = struct {
-    residue_index: usize,
-    residue_name: []const u8,
-    atom_name: []const u8,
-};
-
-const AtomDescriptionCursor = struct {
-    sequence: []const u8,
-    residue_index: usize = 0,
-    atom_index_in_residue: usize = 0,
-    emitted_terminal_oxt: bool = false,
-
-    fn next(self: *AtomDescriptionCursor) !AtomDescription {
-        while (self.residue_index < self.sequence.len) {
-            const spec = residueSpec(self.sequence[self.residue_index]) orelse return ParseError.NonStandardResidue;
-            if (self.atom_index_in_residue < spec.atoms.len) {
-                const desc = AtomDescription{
-                    .residue_index = self.residue_index,
-                    .residue_name = spec.name,
-                    .atom_name = spec.atoms[self.atom_index_in_residue],
-                };
-                self.atom_index_in_residue += 1;
-                return desc;
-            }
-            self.residue_index += 1;
-            self.atom_index_in_residue = 0;
-        }
-
-        if (!self.emitted_terminal_oxt and self.sequence.len > 0) {
-            self.emitted_terminal_oxt = true;
-            const last = residueSpec(self.sequence[self.sequence.len - 1]) orelse return ParseError.NonStandardResidue;
-            return .{
-                .residue_index = self.sequence.len - 1,
-                .residue_name = last.name,
-                .atom_name = "OXT",
-            };
-        }
-
-        return ParseError.AtomCountMismatch;
-    }
-};
-
-fn elementFromAtomName(atom_name: []const u8) elem.Element {
-    for (atom_name) |c| {
-        const upper = std.ascii.toUpper(c);
-        return switch (upper) {
-            'H' => .H,
-            'C' => .C,
-            'N' => .N,
-            'O' => .O,
-            'P' => .P,
-            'S' => .S,
-            else => .X,
-        };
-    }
-    return .X;
-}
-
-test "parse AlphaFold-like mmCIF atom records from sequence and ATOM rows" {
+test "parse AlphaFold-like mmCIF metadata and coordinates from ATOM rows" {
     const source =
         \\data_AF_TEST
         \\_struct_ref.pdbx_seq_one_letter_code
@@ -387,10 +416,24 @@ test "parse AlphaFold-like mmCIF atom records from sequence and ATOM rows" {
     try std.testing.expectEqual(@as(u8, 8), input.element.?[9]);
 }
 
-test "rejects AlphaFold-like mmCIF when ATOM row count does not match sequence" {
+test "rejects AF model mmCIF when ATOM rows are not consecutive" {
+    const allocator = std.testing.allocator;
+    const cif =
+        "_struct_ref.pdbx_seq_one_letter_code A\n" ++
+        "ATOM 1    N N   . ALA A 1 1   ? 1.000  2.000  3.000  1.00 90.00\n" ++
+        "# non-ATOM row between atom records forces generic parser fallback\n" ++
+        "ATOM 2    C CA  . ALA A 1 1   ? 2.000  3.000  4.000  1.00 90.00\n" ++
+        "ATOM 3    C C   . ALA A 1 1   ? 3.000  4.000  5.000  1.00 90.00\n" ++
+        "ATOM 4    C CB  . ALA A 1 1   ? 4.000  5.000  6.000  1.00 90.00\n" ++
+        "ATOM 5    O O   . ALA A 1 1   ? 5.000  6.000  7.000  1.00 90.00\n" ++
+        "ATOM 6    O OXT . ALA A 1 1   ? 6.000  7.000  8.000  1.00 90.00\n";
+
+    try std.testing.expectError(ParseError.UnsupportedLayout, parse(allocator, cif));
+}
+
+test "preserves multiple chains from AF model atom rows" {
     const source =
-        \\data_AF_BAD
-        \\_struct_ref.pdbx_seq_one_letter_code AG
+        \\data_AF_MULTIMER
         \\loop_
         \\_atom_site.group_PDB
         \\_atom_site.id
@@ -405,24 +448,44 @@ test "rejects AlphaFold-like mmCIF when ATOM row count does not match sequence" 
         \\_atom_site.Cartn_x
         \\_atom_site.Cartn_y
         \\_atom_site.Cartn_z
-        \\ATOM 1    N N   . ALA A 1 1   ? 1.000  2.000  3.000
-        \\
+        \\_atom_site.pdbx_PDB_model_num
+        \\ATOM 1 N N  . GLY A 1 1 ? 1.0 2.0 3.0 1
+        \\ATOM 2 C CA . GLY A 1 1 ? 2.0 3.0 4.0 1
+        \\ATOM 3 N N  . ALA B 2 1 ? 4.0 5.0 6.0 1
+        \\ATOM 4 C CA . ALA B 2 1 ? 5.0 6.0 7.0 1
+        \\#
     ;
 
-    try std.testing.expectError(error.AtomCountMismatch, parse(std.testing.allocator, source));
+    var input = try parse(std.testing.allocator, source);
+    defer input.deinit();
+
+    try std.testing.expectEqual(@as(usize, 4), input.atomCount());
+    try std.testing.expectEqualStrings("A", input.chain_id.?[0].slice());
+    try std.testing.expectEqualStrings("B", input.chain_id.?[2].slice());
+    try std.testing.expectEqualStrings("ALA", input.residue.?[2].slice());
+    try std.testing.expectEqualStrings("CA", input.atom_name.?[3].slice());
+    try std.testing.expectEqual(@as(i32, 1), input.residue_num.?[3]);
 }
 
-test "rejects AF model mmCIF when ATOM rows are not consecutive" {
-    const allocator = std.testing.allocator;
-    const cif =
-        "_struct_ref.pdbx_seq_one_letter_code A\n" ++
-        "ATOM 1    N N   . ALA A 1 1   ? 1.000  2.000  3.000  1.00 90.00\n" ++
-        "# non-ATOM row between atom records forces generic parser fallback\n" ++
-        "ATOM 2    C CA  . ALA A 1 1   ? 2.000  3.000  4.000  1.00 90.00\n" ++
-        "ATOM 3    C C   . ALA A 1 1   ? 3.000  4.000  5.000  1.00 90.00\n" ++
-        "ATOM 4    C CB  . ALA A 1 1   ? 4.000  5.000  6.000  1.00 90.00\n" ++
-        "ATOM 5    O O   . ALA A 1 1   ? 5.000  6.000  7.000  1.00 90.00\n" ++
-        "ATOM 6    O OXT . ALA A 1 1   ? 6.000  7.000  8.000  1.00 90.00\n";
+test "rejects alternate locations as unsupported fast layout" {
+    const source =
+        \\data_AF_ALTLOC
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.pdbx_PDB_ins_code
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM 1 C CA A GLY A 1 ? 1.0 2.0 3.0
+        \\#
+    ;
 
-    try std.testing.expectError(ParseError.AtomCountMismatch, parse(allocator, cif));
+    try std.testing.expectError(ParseError.UnsupportedLayout, parse(std.testing.allocator, source));
 }

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -6,6 +6,7 @@ const json_parser = @import("json_parser.zig");
 const json_writer = @import("json_writer.zig");
 const bcif_parser = @import("bcif_parser.zig");
 const mmcif_parser = @import("mmcif_parser.zig");
+const af_model_parser = @import("af_model_parser.zig");
 const pdb_parser = @import("pdb_parser.zig");
 const shrake_rupley = @import("shrake_rupley.zig");
 const shrake_rupley_bitmask = @import("shrake_rupley_bitmask.zig");
@@ -90,6 +91,7 @@ pub const BatchConfig = struct {
     use_auth_chain: bool = false,
     alt_loc_mode: mmcif_parser.AltLocMode = .auto,
     alt_loc_id: u8 = 'A',
+    af_model_fast: bool = false,
     residue_map: bool = false,
     jsonl_decimals: ?u8 = null,
     jsonl_include_atom_areas: bool = true,
@@ -656,6 +658,15 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             break :blk .{ .input = input, .inline_ccd = parser.takeInlineCcd() };
         },
         .mmcif => blk: {
+            if (shouldTryAfModelFastParser(config)) {
+                const input = af_model_parser.parseFile(allocator, io, path) catch |err| switch (err) {
+                    error.OutOfMemory => return err,
+                    else => null,
+                };
+                if (input) |fast_input| {
+                    break :blk .{ .input = fast_input };
+                }
+            }
             var parser = mmcif_parser.MmcifParser.init(allocator);
             errdefer parser.deinitCcd();
             parser.skip_hydrogens = !config.include_hydrogens;
@@ -693,6 +704,14 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             break :blk .{ .input = try sdf_parser.toAtomInput(allocator, molecules, !config.include_hydrogens) };
         },
     };
+}
+
+fn shouldTryAfModelFastParser(config: BatchConfig) bool {
+    return config.af_model_fast and
+        config.chain_filter == null and
+        !config.use_auth_chain and
+        !config.include_hydrogens and
+        config.alt_loc_mode == .auto;
 }
 
 /// Apply built-in classifier to replace radii based on residue/atom names
@@ -2353,6 +2372,7 @@ pub const BatchArgs = struct {
     use_auth_chain: bool = false,
     alt_loc_mode: mmcif_parser.AltLocMode = .auto,
     alt_loc_id: u8 = 'A',
+    af_model_fast: bool = false,
     residue_map: bool = false,
     jsonl_decimals: ?u8 = null,
     n_threads: usize = 0,
@@ -2390,6 +2410,7 @@ pub const BatchArgs = struct {
     include_hydrogens_explicit: bool = false,
     include_hetatm_explicit: bool = false,
     alt_loc_explicit: bool = false,
+    af_model_fast_explicit: bool = false,
     use_bitmask_explicit: bool = false,
     bitmask_correction_explicit: bool = false,
     bitmask_correction_coeff_explicit: bool = false,
@@ -2778,6 +2799,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
         else if (std.mem.eql(u8, arg, "--auth-chain")) {
             result.use_auth_chain = true;
         }
+        // --af-model-fast
+        else if (std.mem.eql(u8, arg, "--af-model-fast")) {
+            result.af_model_fast = true;
+            result.af_model_fast_explicit = true;
+        }
         // --altloc=MODE or --altloc MODE
         else if (std.mem.startsWith(u8, arg, "--altloc=")) {
             const setting = parseAltLocSetting(arg["--altloc=".len..]);
@@ -3021,6 +3047,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --manifest=PATH     Compatibility alias for --workflow
         \\    --chain=ID          Filter by chain ID for non-workflow batch (e.g. A or A,B)
         \\    --auth-chain        Use auth_asym_id instead of label_asym_id for mmCIF chain matching
+        \\    --af-model-fast     Use an experimental AlphaFold-model mmCIF fast parser
+        \\                        for batch mmCIF inputs; falls back to the generic parser
         \\    --altloc=MODE       mmCIF/BCIF alternate-location handling: auto, none, all,
         \\                        highest-occupancy, or a single ID like A (default: auto)
         \\    --residue-map       Include compact residue map arrays in JSONL output
@@ -3133,6 +3161,7 @@ fn applyWorkflowToBatchConfig(
         if (calculation.use_bitmask) |v| config.use_bitmask = v;
     }
     if (calculation.auth_chain) |v| config.use_auth_chain = v;
+    if (args.af_model_fast_explicit) config.af_model_fast = args.af_model_fast;
     if (calculation.residue_map) |v| config.residue_map = v;
 
     try applyWorkflowClassifierToBatchConfig(config, args, classifier_config);
@@ -3153,6 +3182,7 @@ fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
     if (args.precision_explicit) config.precision = args.precision;
     if (args.format_explicit) config.output_format = args.output_format;
     if (args.timing_explicit) config.show_timing = args.show_timing;
+    if (args.af_model_fast_explicit) config.af_model_fast = args.af_model_fast;
     if (args.quiet_explicit) {
         config.quiet = args.quiet;
         config.show_progress = args.show_progress;
@@ -4304,6 +4334,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         .use_auth_chain = args.use_auth_chain,
         .alt_loc_mode = args.alt_loc_mode,
         .alt_loc_id = args.alt_loc_id,
+        .af_model_fast = args.af_model_fast,
         .residue_map = args.residue_map,
         .jsonl_decimals = args.jsonl_decimals,
     };
@@ -5824,6 +5855,69 @@ test "BatchArgs classifier_type defaults to ccd" {
     const args = [_][]const u8{ "zsasa", "batch", "input_dir/" };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqual(ClassifierType.ccd, parsed.classifier_type);
+}
+
+test "BatchArgs --af-model-fast" {
+    const args = [_][]const u8{ "zsasa", "batch", "--af-model-fast", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expect(parsed.af_model_fast);
+}
+
+test "readInputFile uses AF model fast parser for batch mmCIF when requested" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const source =
+        \\data_AF_FAST
+        \\_struct_ref.pdbx_seq_one_letter_code A
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_alt_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.label_entity_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.pdbx_PDB_ins_code
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM 1 N XX . BAD Z 1 9 ? 1.000 2.000 3.000
+        \\ATOM 2 C XX . BAD Z 1 9 ? 2.000 3.000 4.000
+        \\ATOM 3 C XX . BAD Z 1 9 ? 3.000 4.000 5.000
+        \\ATOM 4 C XX . BAD Z 1 9 ? 4.000 5.000 6.000
+        \\ATOM 5 O XX . BAD Z 1 9 ? 5.000 6.000 7.000
+        \\ATOM 6 O XX . BAD Z 1 9 ? 6.000 7.000 8.000
+        \\
+    ;
+
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "af.cif", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "af.cif", allocator);
+    defer allocator.free(path);
+
+    var parsed = try readInputFile(allocator, std.testing.io, path, .{
+        .af_model_fast = true,
+        .classifier_type = null,
+    });
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 6), parsed.input.atomCount());
+    try std.testing.expectEqualStrings("ALA", parsed.input.residue.?[0].slice());
+    try std.testing.expectEqualStrings("CB", parsed.input.atom_name.?[3].slice());
+    try std.testing.expectEqualStrings("OXT", parsed.input.atom_name.?[5].slice());
+    try std.testing.expectEqualStrings("A", parsed.input.chain_id.?[0].slice());
+    try std.testing.expectEqual(@as(i32, 1), parsed.input.residue_num.?[0]);
+}
+
+test "AF model fast parser is skipped when chain filtering is requested" {
+    const chains = [_][]const u8{"Z"};
+    try std.testing.expect(!shouldTryAfModelFastParser(.{
+        .af_model_fast = true,
+        .chain_filter = chains[0..],
+    }));
 }
 
 test "BatchConfig quiet suppresses progress even when show_progress defaults true" {

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -21,6 +21,7 @@ const ccd_parser = @import("ccd_parser.zig");
 const ccd_binary = @import("ccd_binary.zig");
 const sdf_parser = @import("sdf_parser.zig");
 const compressed = @import("compressed.zig");
+const input_io = @import("input_io.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -31,6 +32,7 @@ const ConfigGen = types.ConfigGen;
 const Precision = types.Precision;
 const ClassifierType = classifier.ClassifierType;
 const OutputFormat = json_writer.OutputFormat;
+pub const InputIoMode = input_io.InputIoMode;
 const LeeRichardsConfig = lee_richards.LeeRichardsConfig;
 const LeeRichardsConfigGen = lee_richards.LeeRichardsConfigGen;
 
@@ -68,6 +70,8 @@ pub const BatchConfig = struct {
     probe_radius: f64 = 1.4,
     output_format: OutputFormat = .json,
     show_timing: bool = false,
+    profile_stages: bool = false,
+    input_io: InputIoMode = .auto,
     quiet: bool = false,
     show_progress: bool = true,
     precision: Precision = .f64, // f32 or f64
@@ -371,6 +375,8 @@ pub const FileResult = struct {
     error_msg: ?[]const u8 = null,
     atom_areas: ?[]const f64 = null, // Populated for jsonl output
     residue_map: ?json_writer.ResidueMap = null, // Populated for jsonl residue-map output
+    read_parse_time_ns: u64 = 0,
+    classifier_time_ns: u64 = 0,
 
     pub const Status = enum {
         ok,
@@ -388,6 +394,9 @@ pub const BatchResult = struct {
     scan_time_ns: u64 = 0,
     build_items_time_ns: u64 = 0,
     process_time_ns: u64 = 0,
+    read_parse_time_ns: u64 = 0,
+    classifier_time_ns: u64 = 0,
+    jsonl_write_time_ns: u64 = 0,
     file_results: []FileResult,
     allocator: Allocator,
 
@@ -485,6 +494,16 @@ pub const BatchResult = struct {
         std.debug.print("BATCH_FILES:{d}\n", .{self.total_files});
         std.debug.print("BATCH_SUCCESS:{d}\n", .{self.successful});
     }
+
+    pub fn printStageProfile(self: BatchResult) void {
+        const ns_to_ms = 1_000_000.0;
+        const read_parse_ms = @as(f64, @floatFromInt(self.read_parse_time_ns)) / ns_to_ms;
+        const classifier_ms = @as(f64, @floatFromInt(self.classifier_time_ns)) / ns_to_ms;
+        const jsonl_write_ms = @as(f64, @floatFromInt(self.jsonl_write_time_ns)) / ns_to_ms;
+        std.debug.print("BATCH_READ_PARSE_TIME_MS:{d:.2}\n", .{read_parse_ms});
+        std.debug.print("BATCH_CLASSIFIER_TIME_MS:{d:.2}\n", .{classifier_ms});
+        std.debug.print("BATCH_JSONL_WRITE_TIME_MS:{d:.2}\n", .{jsonl_write_ms});
+    }
 };
 
 const WorkflowJobState = struct {
@@ -511,11 +530,17 @@ const WorkflowJobCounter = struct {
 const WorkflowJobRuntime = struct {
     state: *WorkflowJobState,
     jsonl_stream: ?JsonlStreamWriter = null,
+    jsonl_buffer: [64 * 1024]u8 = undefined,
     jsonl_file: ?std.Io.File = null,
     jsonl_file_needs_close: bool = false,
     counter: WorkflowJobCounter = .{},
 
     fn close(self: *WorkflowJobRuntime, io: std.Io) void {
+        if (self.jsonl_stream) |*stream| {
+            stream.flush() catch |err| {
+                logWarning("workflow JSONL flush failed for {s}: {s}", .{ self.state.name, @errorName(err) });
+            };
+        }
         if (self.jsonl_file_needs_close) {
             if (self.jsonl_file) |file| file.close(io);
         }
@@ -654,15 +679,14 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             parser.alt_loc_mode = config.alt_loc_mode;
             parser.alt_loc_id = config.alt_loc_id;
             parser.parse_inline_ccd = classifierUsesCcdResources(config.classifier_type);
-            const input = try parser.parseFile(io, path);
+            const input = try parser.parseFileWithInputIo(io, path, config.input_io);
             break :blk .{ .input = input, .inline_ccd = parser.takeInlineCcd() };
         },
         .mmcif => blk: {
             if (shouldTryAfModelFastParser(config)) {
-                const input = af_model_parser.parseFile(allocator, io, path) catch |err| switch (err) {
-                    error.OutOfMemory => return err,
-                    else => null,
-                };
+                const input = af_model_parser.parseFileWithOptions(allocator, io, path, .{
+                    .io_mode = config.input_io.resolve(.read),
+                }) catch |err| if (shouldFallbackAfModelFastError(err)) null else return err;
                 if (input) |fast_input| {
                     break :blk .{ .input = fast_input };
                 }
@@ -676,7 +700,7 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             parser.alt_loc_mode = config.alt_loc_mode;
             parser.alt_loc_id = config.alt_loc_id;
             parser.parse_inline_ccd = classifierUsesCcdResources(config.classifier_type);
-            const input = try parser.parseFile(io, path);
+            const input = try parser.parseFileWithInputIo(io, path, config.input_io);
             break :blk .{ .input = input, .inline_ccd = parser.takeInlineCcd() };
         },
         .pdb => blk: {
@@ -684,7 +708,7 @@ fn readInputFile(allocator: Allocator, io: std.Io, path: []const u8, config: Bat
             parser.skip_hydrogens = !config.include_hydrogens;
             parser.atom_only = !config.include_hetatm;
             parser.chain_filter = config.chain_filter;
-            break :blk .{ .input = try parser.parseFile(io, path) };
+            break :blk .{ .input = try parser.parseFileWithInputIo(io, path, config.input_io) };
         },
         .sdf => blk: {
             const source = if (compressed.isCompressed(path))
@@ -712,6 +736,10 @@ fn shouldTryAfModelFastParser(config: BatchConfig) bool {
         !config.use_auth_chain and
         !config.include_hydrogens and
         config.alt_loc_mode == .auto;
+}
+
+fn shouldFallbackAfModelFastError(err: anyerror) bool {
+    return err == error.UnsupportedLayout;
 }
 
 /// Apply built-in classifier to replace radii based on residue/atom names
@@ -1102,17 +1130,24 @@ fn processOneFile(
     };
 
     // Read and parse input (auto-detect format from extension)
+    var read_parse_timer: std.Io.Timestamp = undefined;
+    if (config.profile_stages) read_parse_timer = std.Io.Timestamp.now(io, .awake);
     var parsed = readInputFile(arena, io, input_path, config) catch |err| {
+        if (config.profile_stages) result.read_parse_time_ns = @intCast(read_parse_timer.untilNow(io, .awake).nanoseconds);
         result.status = .err;
         result.error_msg = std.fmt.allocPrint(result_allocator, "read/parse failed: {s}", .{@errorName(err)}) catch null;
         return result;
     };
+    if (config.profile_stages) result.read_parse_time_ns = @intCast(read_parse_timer.untilNow(io, .awake).nanoseconds);
     defer parsed.deinit();
 
     // Apply classifier for PDB/mmCIF input (skip JSON unless classification info exists).
+    var classifier_timer: std.Io.Timestamp = undefined;
+    if (config.profile_stages) classifier_timer = std.Io.Timestamp.now(io, .awake);
     if (config.custom_classifier) |custom_classifier| {
         if (parsed.input.hasClassificationInfo()) {
             applyCustomClassifier(&parsed.input, custom_classifier, config.quiet) catch |err| {
+                if (config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
                 result.status = .err;
                 result.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return result;
@@ -1122,14 +1157,16 @@ fn processOneFile(
         const format = format_detect.detectInputFormat(input_path);
         if (format != .json and parsed.input.hasClassificationInfo()) {
             applyBuiltinClassifier(&parsed.input, ct, config.sdf_ccd, parsed.inlineCcdPtr(), config.external_ccd) catch |err| {
+                if (config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
                 result.status = .err;
                 result.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return result;
             };
         }
     }
+    if (config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
 
-    return switch (config.precision) {
+    var calc_result = switch (config.precision) {
         .f64 => calculatePreparedInputResult(
             f64,
             arena,
@@ -1159,6 +1196,9 @@ fn processOneFile(
             fine_lut_f32,
         ),
     };
+    calc_result.read_parse_time_ns = result.read_parse_time_ns;
+    calc_result.classifier_time_ns = result.classifier_time_ns;
+    return calc_result;
 }
 
 /// Process a single SDF molecule and return result.
@@ -1391,14 +1431,33 @@ fn processOneSdfMoleculeInner(
 }
 
 /// Thread-safe JSONL streaming writer.
-/// Each call to writeResult acquires the mutex, serializes one line, and flushes.
+/// Each call to writeResult acquires the mutex and serializes one line into a
+/// persistent buffered file writer. The owner must call flush after workers join.
 const JsonlStreamWriter = struct {
+    const buffer_size = 64 * 1024;
+    const large_line_threshold = buffer_size / 2;
+
     mutex: std.Io.Mutex = .init,
     file: std.Io.File,
     io: std.Io,
     options: json_writer.JsonlOptions = .{},
+    writer: std.Io.File.Writer,
     /// Set to true if any writeResult call failed to serialize or write.
     write_failed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    pub fn init(
+        file: std.Io.File,
+        io: std.Io,
+        options: json_writer.JsonlOptions,
+        buffer: *[buffer_size]u8,
+    ) JsonlStreamWriter {
+        return .{
+            .file = file,
+            .io = io,
+            .options = options,
+            .writer = std.Io.File.Writer.initStreaming(file, io, buffer),
+        };
+    }
 
     fn recordFailure(self: *JsonlStreamWriter) void {
         self.write_failed.store(true, .release);
@@ -1422,24 +1481,50 @@ const JsonlStreamWriter = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
 
-        // 64KB stack buffer; use streaming mode so the OS seek position
-        // advances (safe under mutex — only one thread writes at a time).
-        var buf: [64 * 1024]u8 = undefined;
-        var w = std.Io.File.Writer.initStreaming(self.file, self.io, &buf);
-        w.interface.writeAll(line) catch |err| {
+        // Human AFDB PDB JSONL lines are often close to the 64 KiB buffer size.
+        // Keeping such lines in a persistent shared buffer causes extra buffer
+        // churn; use the previous per-line streaming writer behavior for large
+        // lines while retaining persistent buffering for smaller rounded JSONL.
+        if (line.len > large_line_threshold) {
+            self.writer.interface.flush() catch |err| {
+                logWarning("JSONL flush failed before large write for {s}: {s}", .{ result.filename, @errorName(err) });
+                self.recordFailure();
+                return;
+            };
+            var local_buf: [buffer_size]u8 = undefined;
+            var local_writer = std.Io.File.Writer.initStreaming(self.file, self.io, &local_buf);
+            local_writer.interface.writeAll(line) catch |err| {
+                logWarning("JSONL large write failed for {s}: {s}", .{ result.filename, @errorName(err) });
+                self.recordFailure();
+                return;
+            };
+            local_writer.interface.writeAll("\n") catch |err| {
+                logWarning("JSONL large newline write failed for {s}: {s}", .{ result.filename, @errorName(err) });
+                self.recordFailure();
+                return;
+            };
+            local_writer.interface.flush() catch |err| {
+                logWarning("JSONL large flush failed for {s}: {s}", .{ result.filename, @errorName(err) });
+                self.recordFailure();
+            };
+            return;
+        }
+
+        self.writer.interface.writeAll(line) catch |err| {
             logWarning("JSONL write failed for {s}: {s}", .{ result.filename, @errorName(err) });
             self.recordFailure();
             return;
         };
-        w.interface.writeAll("\n") catch |err| {
+        self.writer.interface.writeAll("\n") catch |err| {
             logWarning("JSONL newline write failed for {s}: {s}", .{ result.filename, @errorName(err) });
             self.recordFailure();
-            return;
         };
-        w.interface.flush() catch |err| {
-            logWarning("JSONL flush failed for {s}: {s}", .{ result.filename, @errorName(err) });
-            self.recordFailure();
-        };
+    }
+
+    pub fn flush(self: *JsonlStreamWriter) !void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        try self.writer.interface.flush();
     }
 
     /// Returns true if any write to the JSONL file failed.
@@ -1595,7 +1680,7 @@ pub fn runBatchSequential(
         try std.Io.Dir.cwd().createDirPath(io, out_dir);
     }
 
-    // Open JSONL output file (or stdout) when streaming is requested
+    // Sequential mode writes JSONL as each file completes.
     var jsonl_file: ?std.Io.File = null;
     var jsonl_file_needs_close = false;
     if (jsonl_output_path) |path| {
@@ -1614,6 +1699,9 @@ pub fn runBatchSequential(
 
     // Process each file
     var total_sasa_time_ns: u64 = 0;
+    var total_read_parse_time_ns: u64 = 0;
+    var total_classifier_time_ns: u64 = 0;
+    var total_jsonl_write_time_ns: u64 = 0;
     var successful: usize = 0;
     var failed: usize = 0;
 
@@ -1754,13 +1842,18 @@ pub fn runBatchSequential(
                 if (mol_result.status == .ok) {
                     successful += 1;
                     total_sasa_time_ns += mol_result.sasa_time_ns;
+                    total_read_parse_time_ns += mol_result.read_parse_time_ns;
+                    total_classifier_time_ns += mol_result.classifier_time_ns;
                 } else {
                     failed += 1;
                 }
 
                 // Stream JSONL output
                 if (jsonl_writer) |*w| {
+                    var write_timer: std.Io.Timestamp = undefined;
+                    if (config.profile_stages) write_timer = std.Io.Timestamp.now(io, .awake);
                     try writeJsonlResult(w, arena.allocator(), &mol_result, jsonlOptions(config));
+                    if (config.profile_stages) total_jsonl_write_time_ns += @intCast(write_timer.untilNow(io, .awake).nanoseconds);
                 }
                 mol_result.atom_areas = null;
                 mol_result.residue_map = null;
@@ -1795,13 +1888,18 @@ pub fn runBatchSequential(
             if (result.status == .ok) {
                 successful += 1;
                 total_sasa_time_ns += result.sasa_time_ns;
+                total_read_parse_time_ns += result.read_parse_time_ns;
+                total_classifier_time_ns += result.classifier_time_ns;
             } else {
                 failed += 1;
             }
 
             // Stream JSONL output
             if (jsonl_writer) |*w| {
+                var write_timer: std.Io.Timestamp = undefined;
+                if (config.profile_stages) write_timer = std.Io.Timestamp.now(io, .awake);
                 try writeJsonlResult(w, arena.allocator(), &result, jsonlOptions(config));
+                if (config.profile_stages) total_jsonl_write_time_ns += @intCast(write_timer.untilNow(io, .awake).nanoseconds);
             }
             result.atom_areas = null;
             result.residue_map = null;
@@ -1828,6 +1926,9 @@ pub fn runBatchSequential(
         .total_time_ns = total_time_ns,
         .scan_time_ns = scan_time_ns,
         .process_time_ns = process_time_ns,
+        .read_parse_time_ns = total_read_parse_time_ns,
+        .classifier_time_ns = total_classifier_time_ns,
+        .jsonl_write_time_ns = total_jsonl_write_time_ns,
         .file_results = try results_list.toOwnedSlice(allocator),
         .allocator = allocator,
     };
@@ -1863,6 +1964,7 @@ const ParallelContext = struct {
     result_allocator: Allocator,
     next_item: std.atomic.Value(usize),
     processed_count: std.atomic.Value(usize),
+    jsonl_write_time_ns: std.atomic.Value(u64),
     lut_f64: ?*const bitmask_lut.BitmaskLut,
     lut_f32: ?*const bitmask_lut.BitmaskLutGen(f32),
     coarse_lut_f64: ?*const bitmask_lut.BitmaskLut,
@@ -1988,7 +2090,13 @@ fn parallelWorker(ctx: *ParallelContext) void {
             ctx.results[item_idx] = result;
 
             if (ctx.jsonl_stream) |stream| {
+                var write_timer: std.Io.Timestamp = undefined;
+                if (ctx.config.profile_stages) write_timer = std.Io.Timestamp.now(ctx.io, .awake);
                 stream.writeResult(arena.allocator(), &result);
+                if (ctx.config.profile_stages) {
+                    const elapsed: u64 = @intCast(write_timer.untilNow(ctx.io, .awake).nanoseconds);
+                    _ = ctx.jsonl_write_time_ns.fetchAdd(elapsed, .monotonic);
+                }
             }
             ctx.results[item_idx].atom_areas = null;
             ctx.results[item_idx].residue_map = null;
@@ -2017,9 +2125,15 @@ fn parallelWorker(ctx: *ParallelContext) void {
 
             // Stream JSONL output (atom_areas on arena, valid until reset)
             if (ctx.jsonl_stream) |stream| {
+                var write_timer: std.Io.Timestamp = undefined;
+                if (ctx.config.profile_stages) write_timer = std.Io.Timestamp.now(ctx.io, .awake);
                 stream.writeResult(arena.allocator(), &result);
+                if (ctx.config.profile_stages) {
+                    const elapsed: u64 = @intCast(write_timer.untilNow(ctx.io, .awake).nanoseconds);
+                    _ = ctx.jsonl_write_time_ns.fetchAdd(elapsed, .monotonic);
+                }
             }
-            // Clear atom_areas since arena will free them
+            // Clear arena-owned payloads after streaming.
             ctx.results[item_idx].atom_areas = null;
             ctx.results[item_idx].residue_map = null;
         }
@@ -2214,6 +2328,7 @@ pub fn runBatchParallel(
     // Determine thread count
     const cpu_count = std.Thread.getCpuCount() catch 1;
     const n_threads = resolveBatchThreadCount(config.n_threads, cpu_count);
+    const actual_threads = @min(n_threads, work_items.len);
 
     // For single item or single thread, use sequential
     if (work_items.len == 1 or n_threads <= 1) {
@@ -2225,7 +2340,7 @@ pub fn runBatchParallel(
     var luts = try BatchLuts.init(allocator, config);
     defer luts.deinit();
 
-    // Open JSONL output file (or stdout) when streaming is requested
+    // Open JSONL output file (or stdout) when requested.
     var jsonl_file: ?std.Io.File = null;
     var jsonl_file_needs_close = false;
     if (jsonl_output_path) |path| {
@@ -2241,8 +2356,9 @@ pub fn runBatchParallel(
     // Set up the stream writer on the stack (if JSONL streaming is active).
     // SAFETY: `undefined` when jsonl_file is null — never accessed because
     // jsonl_stream_ptr is also null in that case.
+    var jsonl_stream_buffer: [64 * 1024]u8 = undefined;
     var jsonl_stream_storage: JsonlStreamWriter = if (jsonl_file) |jf|
-        JsonlStreamWriter{ .file = jf, .io = io, .options = jsonlOptions(config) }
+        JsonlStreamWriter.init(jf, io, jsonlOptions(config), &jsonl_stream_buffer)
     else
         undefined;
     const jsonl_stream_ptr: ?*JsonlStreamWriter = if (jsonl_file != null) &jsonl_stream_storage else null;
@@ -2257,6 +2373,7 @@ pub fn runBatchParallel(
         .result_allocator = allocator,
         .next_item = std.atomic.Value(usize).init(0),
         .processed_count = std.atomic.Value(usize).init(0),
+        .jsonl_write_time_ns = std.atomic.Value(u64).init(0),
         .lut_f64 = luts.f64Ptr(),
         .lut_f32 = luts.f32Ptr(),
         .coarse_lut_f64 = luts.coarseF64Ptr(),
@@ -2269,7 +2386,6 @@ pub fn runBatchParallel(
     };
 
     // Spawn worker threads
-    const actual_threads = @min(n_threads, work_items.len);
     const threads = try allocator.alloc(std.Thread, actual_threads);
     defer allocator.free(threads);
 
@@ -2303,6 +2419,8 @@ pub fn runBatchParallel(
 
     // Aggregate results
     var total_sasa_time_ns: u64 = 0;
+    var total_read_parse_time_ns: u64 = 0;
+    var total_classifier_time_ns: u64 = 0;
     var successful: usize = 0;
     var failed: usize = 0;
 
@@ -2310,12 +2428,15 @@ pub fn runBatchParallel(
         if (result.status == .ok) {
             successful += 1;
             total_sasa_time_ns += result.sasa_time_ns;
+            total_read_parse_time_ns += result.read_parse_time_ns;
+            total_classifier_time_ns += result.classifier_time_ns;
         } else {
             failed += 1;
         }
     }
 
     if (jsonl_stream_ptr) |stream| {
+        try stream.flush();
         if (stream.hasError()) return error.JsonlWriteFailed;
     }
 
@@ -2330,6 +2451,9 @@ pub fn runBatchParallel(
         .scan_time_ns = scan_time_ns,
         .build_items_time_ns = build_items_time_ns,
         .process_time_ns = process_time_ns,
+        .read_parse_time_ns = total_read_parse_time_ns,
+        .classifier_time_ns = total_classifier_time_ns,
+        .jsonl_write_time_ns = ctx.jsonl_write_time_ns.load(.monotonic),
         .file_results = file_results,
         .allocator = allocator,
     };
@@ -2398,6 +2522,8 @@ pub const BatchArgs = struct {
     quiet: bool = false,
     show_progress: bool = true,
     show_timing: bool = false,
+    profile_stages: bool = false,
+    input_io: InputIoMode = .auto,
     show_help: bool = false,
     threads_explicit: bool = false,
     probe_radius_explicit: bool = false,
@@ -2423,6 +2549,8 @@ pub const BatchArgs = struct {
     sdf_explicit: bool = false,
     quiet_explicit: bool = false,
     timing_explicit: bool = false,
+    profile_stages_explicit: bool = false,
+    input_io_explicit: bool = false,
     jsonl_decimals_explicit: bool = false,
 };
 
@@ -2594,6 +2722,14 @@ fn parsePrecision(value: []const u8) Precision {
     }
 }
 
+fn parseInputIoMode(value: []const u8) InputIoMode {
+    return InputIoMode.parse(value) orelse {
+        std.debug.print("Error: Invalid input I/O mode: {s}\n", .{value});
+        std.debug.print("Valid input I/O modes: auto, mmap, read\n", .{});
+        std.process.exit(1);
+    };
+}
+
 fn parseJsonlDecimals(value: []const u8) u8 {
     const decimals = std.fmt.parseInt(u8, value, 10) catch {
         std.debug.print("Error: Invalid jsonl decimals: {s}\n", .{value});
@@ -2761,6 +2897,20 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
                 std.process.exit(1);
             }
             result.precision = parsePrecision(args[i]);
+        }
+        // --input-io=MODE or --input-io MODE
+        else if (std.mem.startsWith(u8, arg, "--input-io=")) {
+            result.input_io_explicit = true;
+            const value = arg["--input-io=".len..];
+            result.input_io = parseInputIoMode(value);
+        } else if (std.mem.eql(u8, arg, "--input-io")) {
+            result.input_io_explicit = true;
+            i += 1;
+            if (i >= args.len) {
+                std.debug.print("Error: Missing value for --input-io\n", .{});
+                std.process.exit(1);
+            }
+            result.input_io = parseInputIoMode(args[i]);
         }
         // --workflow=PATH or --workflow PATH
         else if (std.mem.startsWith(u8, arg, "--workflow=")) {
@@ -2956,6 +3106,11 @@ pub fn parseArgs(args: []const []const u8, start_idx: usize) BatchArgs {
             result.show_timing = true;
             result.timing_explicit = true;
         }
+        // --profile-stages
+        else if (std.mem.eql(u8, arg, "--profile-stages")) {
+            result.profile_stages = true;
+            result.profile_stages_explicit = true;
+        }
         // --help or -h
         else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             result.show_help = true;
@@ -3048,7 +3203,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --chain=ID          Filter by chain ID for non-workflow batch (e.g. A or A,B)
         \\    --auth-chain        Use auth_asym_id instead of label_asym_id for mmCIF chain matching
         \\    --af-model-fast     Use an experimental AlphaFold-model mmCIF fast parser
-        \\                        for batch mmCIF inputs; falls back to the generic parser
+        \\                        with multi-chain metadata and safe generic fallback
         \\    --altloc=MODE       mmCIF/BCIF alternate-location handling: auto, none, all,
         \\                        highest-occupancy, or a single ID like A (default: auto)
         \\    --residue-map       Include compact residue map arrays in JSONL output
@@ -3056,6 +3211,8 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --n-points=N        Test points per atom (default: 100, for sr)
         \\    --n-slices=N        Slices per atom diameter (default: 20, for lr)
         \\    --precision=PREC    Floating-point precision: f32, f64 (default: f64)
+        \\    --input-io=MODE     File input strategy where supported: auto, mmap, read
+        \\                        Default: auto (AF fast uses read; others keep defaults)
         \\    --format=FORMAT     Output format: json, compact, csv, jsonl (default: json)
         \\    --jsonl-decimals=N  Round JSONL floating-point values to N decimals (0..15)
         \\    --include-hydrogens Include hydrogen atoms (default: exclude)
@@ -3073,6 +3230,7 @@ pub fn printHelp(program_name: []const u8) void {
         \\    --adaptive-low=X    Coarse accept low exposed fraction (default: 0.10)
         \\    --adaptive-high=X   Coarse accept high exposed fraction (default: 0.90)
         \\    --timing            Show timing breakdown for benchmarking
+        \\    --profile-stages    Include read/parse, classifier, and JSONL stage timings
         \\    -o, --output=PATH   Output directory, or file path for --format=jsonl
         \\    -q, --quiet         Suppress progress output
         \\    -h, --help          Show this help message
@@ -3182,6 +3340,8 @@ fn applyCliOverrides(config: *BatchConfig, args: BatchArgs) void {
     if (args.precision_explicit) config.precision = args.precision;
     if (args.format_explicit) config.output_format = args.output_format;
     if (args.timing_explicit) config.show_timing = args.show_timing;
+    if (args.profile_stages_explicit) config.profile_stages = args.profile_stages;
+    if (args.input_io_explicit) config.input_io = args.input_io;
     if (args.af_model_fast_explicit) config.af_model_fast = args.af_model_fast;
     if (args.quiet_explicit) {
         config.quiet = args.quiet;
@@ -4035,11 +4195,11 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
                     const file = try std.Io.Dir.cwd().createFile(io, path, .{});
                     runtimes[i].jsonl_file = file;
                     runtimes[i].jsonl_file_needs_close = true;
-                    runtimes[i].jsonl_stream = JsonlStreamWriter{ .file = file, .io = io, .options = jsonlOptions(state.config) };
+                    runtimes[i].jsonl_stream = JsonlStreamWriter.init(file, io, jsonlOptions(state.config), &runtimes[i].jsonl_buffer);
                 } else {
                     const file = std.Io.File.stdout();
                     runtimes[i].jsonl_file = file;
-                    runtimes[i].jsonl_stream = JsonlStreamWriter{ .file = file, .io = io, .options = jsonlOptions(state.config) };
+                    runtimes[i].jsonl_stream = JsonlStreamWriter.init(file, io, jsonlOptions(state.config), &runtimes[i].jsonl_buffer);
                 }
             }
             runtimes_initialized += 1;
@@ -4086,6 +4246,7 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
             successful += runtime.state.successful;
             failed += runtime.state.failed;
             if (runtime.jsonl_stream) |*stream| {
+                try stream.flush();
                 if (stream.hasError()) return error.JsonlWriteFailed;
             }
         }
@@ -4314,6 +4475,7 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         .precision = args.precision,
         .output_format = args.output_format,
         .show_timing = args.show_timing,
+        .profile_stages = args.profile_stages,
         .quiet = args.quiet,
         .show_progress = args.show_progress,
         .classifier_type = args.classifier_type,
@@ -4366,6 +4528,9 @@ pub fn run(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     if (args.show_timing) {
         std.debug.print("\n", .{});
         result.printBenchmarkOutput();
+        if (args.profile_stages) {
+            result.printStageProfile();
+        }
     }
 }
 
@@ -4630,10 +4795,10 @@ test "BatchArgs with output dir" {
 
 test "BatchArgs with options" {
     const args = [_][]const u8{
-        "zsasa",          "batch",
-        "--algorithm=lr", "--threads=4",
-        "--quiet",        "--timing",
-        "input_dir/",
+        "zsasa",            "batch",
+        "--algorithm=lr",   "--threads=4",
+        "--quiet",          "--timing",
+        "--profile-stages", "input_dir/",
     };
     const parsed = parseArgs(&args, 2);
     try std.testing.expectEqualStrings("input_dir/", parsed.input_path.?);
@@ -4642,6 +4807,7 @@ test "BatchArgs with options" {
     try std.testing.expectEqual(true, parsed.quiet);
     try std.testing.expectEqual(false, parsed.show_progress);
     try std.testing.expectEqual(true, parsed.show_timing);
+    try std.testing.expectEqual(true, parsed.profile_stages);
 }
 
 test "BatchArgs help flag" {
@@ -5538,7 +5704,8 @@ test "JsonlStreamWriter writes many parseable JSONL lines" {
     defer allocator.free(output_path);
 
     const file = try std.Io.Dir.cwd().createFile(std.testing.io, output_path, .{});
-    var stream = JsonlStreamWriter{ .file = file, .io = std.testing.io };
+    var stream_buf: [64 * 1024]u8 = undefined;
+    var stream = JsonlStreamWriter.init(file, std.testing.io, .{}, &stream_buf);
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -5559,6 +5726,7 @@ test "JsonlStreamWriter writes many parseable JSONL lines" {
         stream.writeResult(arena.allocator(), &result);
         try std.testing.expect(!stream.hasError());
     }
+    try stream.flush();
     file.close(std.testing.io);
 
     const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(64 * 1024));
@@ -5863,14 +6031,20 @@ test "BatchArgs --af-model-fast" {
     try std.testing.expect(parsed.af_model_fast);
 }
 
-test "readInputFile uses AF model fast parser for batch mmCIF when requested" {
+test "BatchArgs --input-io" {
+    const args = [_][]const u8{ "zsasa", "batch", "--input-io=read", "input_dir/" };
+    const parsed = parseArgs(&args, 2);
+    try std.testing.expectEqual(InputIoMode.read, parsed.input_io);
+    try std.testing.expect(parsed.input_io_explicit);
+}
+
+test "readInputFile preserves AF model atom metadata when fast parsing is requested" {
     const allocator = std.testing.allocator;
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
     const source =
         \\data_AF_FAST
-        \\_struct_ref.pdbx_seq_one_letter_code A
         \\loop_
         \\_atom_site.group_PDB
         \\_atom_site.id
@@ -5885,12 +6059,10 @@ test "readInputFile uses AF model fast parser for batch mmCIF when requested" {
         \\_atom_site.Cartn_x
         \\_atom_site.Cartn_y
         \\_atom_site.Cartn_z
-        \\ATOM 1 N XX . BAD Z 1 9 ? 1.000 2.000 3.000
-        \\ATOM 2 C XX . BAD Z 1 9 ? 2.000 3.000 4.000
-        \\ATOM 3 C XX . BAD Z 1 9 ? 3.000 4.000 5.000
-        \\ATOM 4 C XX . BAD Z 1 9 ? 4.000 5.000 6.000
-        \\ATOM 5 O XX . BAD Z 1 9 ? 5.000 6.000 7.000
-        \\ATOM 6 O XX . BAD Z 1 9 ? 6.000 7.000 8.000
+        \\ATOM 1 N N  . GLY A 1 1 ? 1.000 2.000 3.000
+        \\ATOM 2 C CA . GLY A 1 1 ? 2.000 3.000 4.000
+        \\ATOM 3 N N  . ALA B 2 1 ? 4.000 5.000 6.000
+        \\ATOM 4 C CA . ALA B 2 1 ? 5.000 6.000 7.000
         \\
     ;
 
@@ -5904,12 +6076,52 @@ test "readInputFile uses AF model fast parser for batch mmCIF when requested" {
     });
     defer parsed.deinit();
 
-    try std.testing.expectEqual(@as(usize, 6), parsed.input.atomCount());
-    try std.testing.expectEqualStrings("ALA", parsed.input.residue.?[0].slice());
-    try std.testing.expectEqualStrings("CB", parsed.input.atom_name.?[3].slice());
-    try std.testing.expectEqualStrings("OXT", parsed.input.atom_name.?[5].slice());
+    try std.testing.expectEqual(@as(usize, 4), parsed.input.atomCount());
+    try std.testing.expectEqualStrings("GLY", parsed.input.residue.?[0].slice());
+    try std.testing.expectEqualStrings("CA", parsed.input.atom_name.?[3].slice());
     try std.testing.expectEqualStrings("A", parsed.input.chain_id.?[0].slice());
+    try std.testing.expectEqualStrings("B", parsed.input.chain_id.?[2].slice());
     try std.testing.expectEqual(@as(i32, 1), parsed.input.residue_num.?[0]);
+}
+
+test "AF model fast fallback is limited to unsupported layouts" {
+    try std.testing.expect(shouldFallbackAfModelFastError(error.UnsupportedLayout));
+    try std.testing.expect(!shouldFallbackAfModelFastError(error.InvalidCoordinate));
+    try std.testing.expect(!shouldFallbackAfModelFastError(error.AccessDenied));
+}
+
+test "readInputFile falls back to generic mmCIF for unsupported fast layout" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const source =
+        \\data_GENERIC
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM C CA GLY 1.0 2.0 3.0
+        \\#
+    ;
+
+    try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = "generic.cif", .data = source });
+    const path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "generic.cif", allocator);
+    defer allocator.free(path);
+
+    var parsed = try readInputFile(allocator, std.testing.io, path, .{
+        .af_model_fast = true,
+        .classifier_type = null,
+    });
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.input.atomCount());
+    try std.testing.expectEqualStrings("GLY", parsed.input.residue.?[0].slice());
+    try std.testing.expectEqualStrings("CA", parsed.input.atom_name.?[0].slice());
 }
 
 test "AF model fast parser is skipped when chain filtering is requested" {

--- a/src/bcif_parser.zig
+++ b/src/bcif_parser.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const elem = @import("element.zig");
+const input_io = @import("input_io.zig");
 const mmap_reader = @import("mmap_reader.zig");
 const compressed = @import("compressed.zig");
 const types = @import("types.zig");
@@ -8,6 +9,7 @@ const ccd_parser = @import("ccd_parser.zig");
 const hyb = @import("hybridization.zig");
 const altloc = @import("altloc.zig");
 const AtomInput = types.AtomInput;
+pub const InputIoMode = input_io.InputIoMode;
 pub const ParseError = error{
     InvalidMessagePack,
     UnexpectedEof,
@@ -831,14 +833,32 @@ pub const BcifParser = struct {
     }
 
     pub fn parseFile(self: *BcifParser, io: std.Io, path: []const u8) !AtomInput {
+        return self.parseFileWithInputIo(io, path, .auto);
+    }
+
+    pub fn parseFileWithInputIo(self: *BcifParser, io: std.Io, path: []const u8, input_io_mode: InputIoMode) !AtomInput {
         if (compressed.isCompressed(path)) {
             const data = try compressed.read(self.allocator, path);
             defer self.allocator.free(data);
             return self.parse(data);
         }
-        const mapped = try mmap_reader.mmapFile(self.allocator, io, path);
-        defer mapped.deinit();
-        return self.parse(mapped.data);
+        switch (input_io_mode.resolve(.mmap)) {
+            .mmap => {
+                const mapped = try mmap_reader.mmapFile(self.allocator, io, path);
+                defer mapped.deinit();
+                return self.parse(mapped.data);
+            },
+            .read => {
+                const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+                defer file.close(io);
+                var read_buf: [64 * 1024]u8 = undefined;
+                var reader = file.reader(io, &read_buf);
+                const data = try reader.interface.allocRemaining(self.allocator, .unlimited);
+                defer self.allocator.free(data);
+                return self.parse(data);
+            },
+            .auto => unreachable,
+        }
     }
 
     const AtomRecord = struct {

--- a/src/input_io.zig
+++ b/src/input_io.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub const InputIoMode = enum {
+    /// Let the caller choose its established default.
+    auto,
+    /// Parse directly from a memory-mapped file.
+    mmap,
+    /// Read the complete file into an allocated buffer before parsing.
+    read,
+
+    pub fn parse(value: []const u8) ?InputIoMode {
+        if (std.mem.eql(u8, value, "auto")) return .auto;
+        if (std.mem.eql(u8, value, "mmap")) return .mmap;
+        if (std.mem.eql(u8, value, "read")) return .read;
+        return null;
+    }
+
+    pub fn resolve(self: InputIoMode, auto_mode: InputIoMode) InputIoMode {
+        std.debug.assert(auto_mode != .auto);
+        return if (self == .auto) auto_mode else self;
+    }
+};
+
+test "InputIoMode parses CLI values" {
+    try std.testing.expectEqual(InputIoMode.auto, InputIoMode.parse("auto").?);
+    try std.testing.expectEqual(InputIoMode.mmap, InputIoMode.parse("mmap").?);
+    try std.testing.expectEqual(InputIoMode.read, InputIoMode.parse("read").?);
+    try std.testing.expect(InputIoMode.parse("invalid") == null);
+}
+
+test "InputIoMode resolves auto without overriding explicit modes" {
+    try std.testing.expectEqual(InputIoMode.read, InputIoMode.auto.resolve(.read));
+    try std.testing.expectEqual(InputIoMode.mmap, InputIoMode.mmap.resolve(.read));
+}

--- a/src/mmcif_parser.zig
+++ b/src/mmcif_parser.zig
@@ -31,12 +31,14 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const cif = @import("cif_tokenizer.zig");
 const elem = @import("element.zig");
+const input_io = @import("input_io.zig");
 const mmap_reader = @import("mmap_reader.zig");
 const compressed = @import("compressed.zig");
 const types = @import("types.zig");
 const AtomInput = types.AtomInput;
 const ccd_parser = @import("ccd_parser.zig");
 const altloc = @import("altloc.zig");
+pub const InputIoMode = input_io.InputIoMode;
 
 /// Error types for mmCIF parsing
 pub const ParseError = error{
@@ -205,14 +207,32 @@ pub const MmcifParser = struct {
 
     /// Parse mmCIF from a file (handles plain, .gz, and .zst compressed)
     pub fn parseFile(self: *MmcifParser, io: std.Io, path: []const u8) !AtomInput {
+        return self.parseFileWithInputIo(io, path, .auto);
+    }
+
+    pub fn parseFileWithInputIo(self: *MmcifParser, io: std.Io, path: []const u8, input_io_mode: InputIoMode) !AtomInput {
         if (compressed.isCompressed(path)) {
             const data = try compressed.read(self.allocator, path);
             defer self.allocator.free(data);
             return self.parse(data);
         }
-        const mapped = try mmap_reader.mmapFile(self.allocator, io, path);
-        defer mapped.deinit();
-        return self.parse(mapped.data);
+        switch (input_io_mode.resolve(.mmap)) {
+            .mmap => {
+                const mapped = try mmap_reader.mmapFile(self.allocator, io, path);
+                defer mapped.deinit();
+                return self.parse(mapped.data);
+            },
+            .read => {
+                const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+                defer file.close(io);
+                var read_buf: [64 * 1024]u8 = undefined;
+                var reader = file.reader(io, &read_buf);
+                const data = try reader.interface.allocRemaining(self.allocator, .unlimited);
+                defer self.allocator.free(data);
+                return self.parse(data);
+            },
+            .auto => unreachable,
+        }
     }
 
     /// Result from findAtomSiteLoop containing columns and their count

--- a/src/pdb_parser.zig
+++ b/src/pdb_parser.zig
@@ -34,10 +34,12 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const elem = @import("element.zig");
+const input_io = @import("input_io.zig");
 const mmap_reader = @import("mmap_reader.zig");
 const compressed = @import("compressed.zig");
 const types = @import("types.zig");
 const AtomInput = types.AtomInput;
+pub const InputIoMode = input_io.InputIoMode;
 
 /// Error types for PDB parsing
 pub const ParseError = error{
@@ -209,14 +211,32 @@ pub const PdbParser = struct {
 
     /// Parse PDB from a file (handles plain, .gz, and .zst compressed)
     pub fn parseFile(self: *PdbParser, io: std.Io, path: []const u8) !AtomInput {
+        return self.parseFileWithInputIo(io, path, .auto);
+    }
+
+    pub fn parseFileWithInputIo(self: *PdbParser, io: std.Io, path: []const u8, input_io_mode: InputIoMode) !AtomInput {
         if (compressed.isCompressed(path)) {
             const data = try compressed.read(self.allocator, path);
             defer self.allocator.free(data);
             return self.parse(data);
         }
-        const mapped = try mmap_reader.mmapFile(self.allocator, io, path);
-        defer mapped.deinit();
-        return self.parse(mapped.data);
+        switch (input_io_mode.resolve(.mmap)) {
+            .mmap => {
+                const mapped = try mmap_reader.mmapFile(self.allocator, io, path);
+                defer mapped.deinit();
+                return self.parse(mapped.data);
+            },
+            .read => {
+                const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+                defer file.close(io);
+                var read_buf: [64 * 1024]u8 = undefined;
+                var reader = file.reader(io, &read_buf);
+                const data = try reader.interface.allocRemaining(self.allocator, .unlimited);
+                defer self.allocator.free(data);
+                return self.parse(data);
+            },
+            .auto => unreachable,
+        }
     }
 
     /// Parsed atom data

--- a/src/root.zig
+++ b/src/root.zig
@@ -28,6 +28,7 @@ pub const lee_richards = @import("lee_richards.zig");
 pub const types = @import("types.zig");
 pub const pdb_parser = @import("pdb_parser.zig");
 pub const mmcif_parser = @import("mmcif_parser.zig");
+pub const af_model_parser = @import("af_model_parser.zig");
 pub const bcif_parser = @import("bcif_parser.zig");
 pub const json_parser = @import("json_parser.zig");
 pub const classifier = @import("classifier.zig");
@@ -54,6 +55,7 @@ test {
     _ = types;
     _ = pdb_parser;
     _ = mmcif_parser;
+    _ = af_model_parser;
     _ = bcif_parser;
     _ = json_parser;
     _ = classifier;

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -10,7 +10,13 @@ All notable changes to zsasa. See [GitHub Releases](https://github.com/N283T/zsa
 
 ### Added
 
-- **Batch AF model fast parser**: add experimental `zsasa batch --af-model-fast` for AlphaFold-like mmCIF batches, with fallback to the generic parser when the input does not match the expected standard amino-acid layout.
+- **Batch AF model fast parser**: add experimental `zsasa batch --af-model-fast` for AlphaFold-like mmCIF batches. The fast path preserves multiple chains and atom metadata, and falls back to the generic parser for unsupported layouts.
+- **Batch input I/O selection**: add `--input-io=auto|mmap|read` to compare or select file input strategies where supported.
+- **Batch stage profiling**: add `--profile-stages` with `--timing` to report aggregate read/parse, classifier, and JSONL write times.
+
+### Changed
+
+- **Batch JSONL streaming**: buffer normal-sized JSONL records while streaming large records directly to avoid regressions for PDB batches with large atom-area payloads.
 
 ## [v0.8.0](https://github.com/N283T/zsasa/releases/tag/v0.8.0) — 2026-07-01
 

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -8,6 +8,10 @@ All notable changes to zsasa. See [GitHub Releases](https://github.com/N283T/zsa
 
 ## Unreleased
 
+### Added
+
+- **Batch AF model fast parser**: add experimental `zsasa batch --af-model-fast` for AlphaFold-like mmCIF batches, with fallback to the generic parser when the input does not match the expected standard amino-acid layout.
+
 ## [v0.8.0](https://github.com/N283T/zsasa/releases/tag/v0.8.0) — 2026-07-01
 
 ### Added

--- a/website/docs/guide/batch.md
+++ b/website/docs/guide/batch.md
@@ -84,9 +84,8 @@ This can improve throughput on fast local SSDs, but the best value is machine- a
 
 ## Experimental AlphaFold mmCIF Fast Parser
 
-For AlphaFold-like single-chain protein mmCIF batches, `--af-model-fast`
-enables an experimental parser that reads the sequence and consecutive `ATOM`
-coordinate rows directly:
+For AlphaFold-like protein mmCIF batches, `--af-model-fast` enables an
+experimental parser for simple, consecutive `_atom_site` `ATOM` rows:
 
 ```bash
 zsasa batch afdb/ results.jsonl \
@@ -94,10 +93,22 @@ zsasa batch afdb/ results.jsonl \
   --af-model-fast
 ```
 
-This path is intended for benchmarking AFDB-style model files. It falls back to
-the generic mmCIF parser when the file does not match the expected standard
-amino-acid atom layout. Chain filters, author-chain matching, alternate-location
-overrides, and explicit hydrogen inclusion use the generic parser.
+This path preserves chain, residue, atom, element, and residue-number metadata,
+including multiple chains. It falls back to the generic mmCIF parser for
+unsupported layouts, alternate locations, multiple models, hydrogens, and
+extended chain IDs. Malformed coordinates and I/O errors are reported instead
+of being hidden by fallback. Chain filters, author-chain matching,
+alternate-location overrides, and explicit hydrogen inclusion use the generic
+parser directly.
+
+The input strategy can be selected independently with
+`--input-io=auto|mmap|read`. `auto` uses whole-file reads for the AF fast path
+and keeps each generic parser's existing default. Explicit `mmap` or `read`
+values are useful when benchmarking storage and operating-system behavior.
+
+For parser and output profiling, combine `--timing` with `--profile-stages`.
+The additional machine-readable lines report aggregate read/parse, classifier,
+and JSONL write times across the batch.
 
 ## Experimental Adaptive Bitmask SR
 

--- a/website/docs/guide/batch.md
+++ b/website/docs/guide/batch.md
@@ -82,6 +82,23 @@ zsasa batch structures/ results.jsonl \
 
 This can improve throughput on fast local SSDs, but the best value is machine- and dataset-dependent. Higher thread counts increase memory use and may stop helping once storage or CPU scheduling becomes saturated.
 
+## Experimental AlphaFold mmCIF Fast Parser
+
+For AlphaFold-like single-chain protein mmCIF batches, `--af-model-fast`
+enables an experimental parser that reads the sequence and consecutive `ATOM`
+coordinate rows directly:
+
+```bash
+zsasa batch afdb/ results.jsonl \
+  --format=jsonl \
+  --af-model-fast
+```
+
+This path is intended for benchmarking AFDB-style model files. It falls back to
+the generic mmCIF parser when the file does not match the expected standard
+amino-acid atom layout. Chain filters, author-chain matching, alternate-location
+overrides, and explicit hydrogen inclusion use the generic parser.
+
 ## Experimental Adaptive Bitmask SR
 
 For large SR batch jobs that already use bitmask mode, `--adaptive-sr` runs a coarse bitmask pass for every atom and recomputes only intermediate-exposure atoms with a fine point count:


### PR DESCRIPTION
## Summary

- add an experimental AlphaFold-model mmCIF fast parser for batch processing
- preserve atom metadata and multiple chains instead of synthesizing single-chain metadata from the sequence
- fall back to the generic mmCIF parser for unsupported layouts while surfacing malformed coordinates and I/O errors
- add `--input-io=auto|mmap|read`; AF fast defaults to whole-file reads while generic parsers retain their existing defaults
- add optional batch stage profiling and hybrid buffered/direct JSONL streaming to avoid large-record regressions
- document the new behavior and CLI options

## Why

AFDB-style mmCIF batches spend a significant portion of wall time in file input and parsing. A specialized parser improves throughput, but the initial single-chain/minimal-metadata approach was too narrow. This version keeps the fast path specialized while preserving metadata needed for multi-chain models and retaining a safe generic fallback.

## Validation

- `zig fmt --check src/`
- `zig build test`: 1705 passed, 3 skipped
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json`
- `npm run build` in `website/`
- Human AFDB batch: 23,586/23,586 files succeeded
- generic and AF-fast JSONL matched exactly when keyed by filename (0 missing, 0 extra, 0 differing records)

## Practical benchmark

Single-run measurements on the Human AFDB CIF batch with 10 threads, f32, 128 points, ProtOr, bitmask SR, and JSONL output:

| path | wall |
|---|---:|
| generic auto (mmap) | 35.19s |
| AF fast auto (read) | 17.30s |
| AF fast mmap | 26.03s |

These are practical development measurements rather than controlled benchmark results; a dedicated benchmark rerun can follow separately.
