### PR TITLE
feat: add per-file chain maps to batch workflows

### DIFF
--- a/src/batch.zig
+++ b/src/batch.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const workflow_manifest = @import("workflow_manifest.zig");
+const chain_map = @import("chain_map.zig");
 const types = @import("types.zig");
 const format_detect = @import("format_detect.zig");
 const json_parser = @import("json_parser.zig");
@@ -92,6 +93,7 @@ pub const BatchConfig = struct {
     custom_classifier: ?*const classifier.Classifier = null,
     custom_classifier_path: ?[]const u8 = null,
     chain_filter: ?[]const []const u8 = null,
+    chain_map: ?*const chain_map.ChainMap = null,
     use_auth_chain: bool = false,
     alt_loc_mode: mmcif_parser.AltLocMode = .auto,
     alt_loc_id: u8 = 'A',
@@ -1122,6 +1124,17 @@ fn processOneFile(
         .status = .ok,
     };
 
+    var file_config = config;
+    if (config.chain_map) |map| {
+        const selection = map.get(filename) orelse {
+            result.status = .err;
+            result.error_msg = std.fmt.allocPrint(result_allocator, "chain map entry not found", .{}) catch null;
+            return result;
+        };
+        file_config.chain_filter = selection.chains;
+        file_config.use_auth_chain = selection.asym_id_type == .auth;
+    }
+
     // Build input path
     const input_path = std.fs.path.join(arena, &.{ input_dir, filename }) catch |err| {
         result.status = .err;
@@ -1131,42 +1144,42 @@ fn processOneFile(
 
     // Read and parse input (auto-detect format from extension)
     var read_parse_timer: std.Io.Timestamp = undefined;
-    if (config.profile_stages) read_parse_timer = std.Io.Timestamp.now(io, .awake);
-    var parsed = readInputFile(arena, io, input_path, config) catch |err| {
-        if (config.profile_stages) result.read_parse_time_ns = @intCast(read_parse_timer.untilNow(io, .awake).nanoseconds);
+    if (file_config.profile_stages) read_parse_timer = std.Io.Timestamp.now(io, .awake);
+    var parsed = readInputFile(arena, io, input_path, file_config) catch |err| {
+        if (file_config.profile_stages) result.read_parse_time_ns = @intCast(read_parse_timer.untilNow(io, .awake).nanoseconds);
         result.status = .err;
         result.error_msg = std.fmt.allocPrint(result_allocator, "read/parse failed: {s}", .{@errorName(err)}) catch null;
         return result;
     };
-    if (config.profile_stages) result.read_parse_time_ns = @intCast(read_parse_timer.untilNow(io, .awake).nanoseconds);
+    if (file_config.profile_stages) result.read_parse_time_ns = @intCast(read_parse_timer.untilNow(io, .awake).nanoseconds);
     defer parsed.deinit();
 
     // Apply classifier for PDB/mmCIF input (skip JSON unless classification info exists).
     var classifier_timer: std.Io.Timestamp = undefined;
-    if (config.profile_stages) classifier_timer = std.Io.Timestamp.now(io, .awake);
-    if (config.custom_classifier) |custom_classifier| {
+    if (file_config.profile_stages) classifier_timer = std.Io.Timestamp.now(io, .awake);
+    if (file_config.custom_classifier) |custom_classifier| {
         if (parsed.input.hasClassificationInfo()) {
-            applyCustomClassifier(&parsed.input, custom_classifier, config.quiet) catch |err| {
-                if (config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
+            applyCustomClassifier(&parsed.input, custom_classifier, file_config.quiet) catch |err| {
+                if (file_config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
                 result.status = .err;
                 result.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return result;
             };
         }
-    } else if (config.classifier_type) |ct| {
+    } else if (file_config.classifier_type) |ct| {
         const format = format_detect.detectInputFormat(input_path);
         if (format != .json and parsed.input.hasClassificationInfo()) {
-            applyBuiltinClassifier(&parsed.input, ct, config.sdf_ccd, parsed.inlineCcdPtr(), config.external_ccd) catch |err| {
-                if (config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
+            applyBuiltinClassifier(&parsed.input, ct, file_config.sdf_ccd, parsed.inlineCcdPtr(), file_config.external_ccd) catch |err| {
+                if (file_config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
                 result.status = .err;
                 result.error_msg = std.fmt.allocPrint(result_allocator, "classifier failed: {s}", .{@errorName(err)}) catch null;
                 return result;
             };
         }
     }
-    if (config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
+    if (file_config.profile_stages) result.classifier_time_ns = @intCast(classifier_timer.untilNow(io, .awake).nanoseconds);
 
-    var calc_result = switch (config.precision) {
+    var calc_result = switch (file_config.precision) {
         .f64 => calculatePreparedInputResult(
             f64,
             arena,
@@ -1175,7 +1188,7 @@ fn processOneFile(
             parsed.input,
             output_dir,
             filename,
-            config,
+            file_config,
             n_threads,
             lut_f64,
             coarse_lut_f64,
@@ -1189,7 +1202,7 @@ fn processOneFile(
             parsed.input,
             output_dir,
             filename,
-            config,
+            file_config,
             n_threads,
             lut_f32,
             coarse_lut_f32,
@@ -1667,6 +1680,7 @@ pub fn runBatchSequential(
         for (files) |f| allocator.free(f);
         allocator.free(files);
     }
+    try validateChainMapInputFormats(files, config);
 
     var progress_root: std.Progress.Node = if (shouldShowProgress(config))
         std.Progress.start(io, .{ .root_name = "Processing files", .estimated_total_items = files.len })
@@ -2282,6 +2296,7 @@ pub fn runBatchParallel(
         for (files) |f| allocator.free(f);
         allocator.free(files);
     }
+    try validateChainMapInputFormats(files, config);
 
     if (files.len == 0) {
         return BatchResult{
@@ -2587,6 +2602,20 @@ fn validateBatchOutputFormat(output_format: OutputFormat) !void {
     switch (output_format) {
         .json, .compact, .csv, .jsonl => {},
         .freesasa, .rsa => return error.InvalidArgument,
+    }
+}
+
+fn validateChainMapInputFormats(files: []const []const u8, config: BatchConfig) !void {
+    return validateMappedChainInputFormats(files, config.chain_map != null);
+}
+
+fn validateMappedChainInputFormats(files: []const []const u8, enabled: bool) !void {
+    if (!enabled) return;
+    for (files) |filename| {
+        switch (format_detect.detectInputFormat(filename)) {
+            .pdb, .mmcif, .bcif => {},
+            .json, .sdf => return error.UnsupportedChainMapInputFormat,
+        }
     }
 }
 
@@ -3472,6 +3501,7 @@ fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
     if (workflow.analysis != null) return runWorkflowBsaAnalysis(allocator, io, args, workflow);
 
     if (workflow.jobs.len == 0) return runWorkflowFileFirst(allocator, io, args, null);
+    if (workflowHasChainMap(workflow)) return runWorkflowJobFirst(allocator, io, args);
     const input_dir = args.input_path orelse workflow.input.dir orelse return runWorkflowFileFirst(allocator, io, args, null);
     const output_dir = args.output_path orelse workflow.output.dir;
     if (workflow.jobs.len > 1 and output_dir == null) return runWorkflowFileFirst(allocator, io, args, null);
@@ -3494,6 +3524,13 @@ fn runWorkflow(allocator: Allocator, io: std.Io, args: BatchArgs) !void {
         return runWorkflowJobFirst(allocator, io, args);
     }
     return runWorkflowFileFirst(allocator, io, args, files);
+}
+
+fn workflowHasChainMap(workflow: workflow_manifest.Workflow) bool {
+    for (workflow.jobs) |job| {
+        if (job.chain_map != null) return true;
+    }
+    return false;
 }
 
 fn freeScannedFiles(allocator: Allocator, files: []const []const u8) void {
@@ -3531,8 +3568,8 @@ fn runWorkflowBsaAnalysis(
     workflow: workflow_manifest.Workflow,
 ) !void {
     const analysis = workflow.analysis orelse return error.InvalidArgument;
-    const partner_a = analysis.partner_a orelse return error.InvalidArgument;
-    const partner_b = analysis.partner_b orelse return error.InvalidArgument;
+    const fixed_partner_a = analysis.partner_a;
+    const fixed_partner_b = analysis.partner_b;
     const level = analysisLevel(analysis);
     const name = analysisName(analysis);
 
@@ -3610,6 +3647,15 @@ fn runWorkflowBsaAnalysis(
     config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
     if (custom_classifier) |*c| config.custom_classifier = c;
 
+    var interface_map: ?chain_map.InterfaceMap = null;
+    if (analysis.chain_map) |path| {
+        interface_map = chain_map.loadInterfaceFile(allocator, io, path) catch |err| {
+            std.debug.print("Error loading interface chain map '{s}' for BSA analysis '{s}': {s}\n", .{ path, name, @errorName(err) });
+            return err;
+        };
+    }
+    defer if (interface_map) |*map| map.deinit();
+
     if ((config.classifier_type == .ccd or config.classifier_type == .protor) and config.include_hydrogens and !config.quiet) {
         std.debug.print("Warning: --include-hydrogens with CCD classifier may give inaccurate results\n", .{});
         std.debug.print("         CCD uses united-atom radii that already account for implicit hydrogens\n", .{});
@@ -3617,12 +3663,10 @@ fn runWorkflowBsaAnalysis(
 
     const files = try scanDirectory(allocator, io, input_dir);
     defer freeScannedFiles(allocator, files);
+    try validateMappedChainInputFormats(files, interface_map != null);
 
     var luts = try BatchLuts.init(allocator, config);
     defer luts.deinit();
-
-    const complex_chains = try appendChainGroups(allocator, partner_a, partner_b);
-    defer allocator.free(complex_chains);
 
     var successful: usize = 0;
     var failed: usize = 0;
@@ -3632,10 +3676,24 @@ fn runWorkflowBsaAnalysis(
     defer arena.deinit();
 
     for (files) |filename| {
-        const input_path = try std.fs.path.join(arena.allocator(), &.{ input_dir, filename });
-
+        var partner_a = fixed_partner_a orelse &.{};
+        var partner_b = fixed_partner_b orelse &.{};
         var source_config = config;
         source_config.chain_filter = null;
+        if (interface_map) |*map| {
+            const selection = map.get(filename) orelse {
+                failed += 1;
+                std.debug.print("Error running BSA analysis '{s}' on '{s}': interface chain map entry not found\n", .{ name, filename });
+                _ = arena.reset(.retain_capacity);
+                continue;
+            };
+            partner_a = selection.partner_a;
+            partner_b = selection.partner_b;
+            source_config.use_auth_chain = selection.asym_id_type == .auth;
+        }
+        const complex_chains = try appendChainGroups(arena.allocator(), partner_a, partner_b);
+        const input_path = try std.fs.path.join(arena.allocator(), &.{ input_dir, filename });
+
         var source_parsed = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
             failed += 1;
             std.debug.print("Error running BSA analysis '{s}' on '{s}': read/parse failed: {s}\n", .{ name, filename, @errorName(err) });
@@ -3973,6 +4031,9 @@ fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void 
     var failed: usize = 0;
 
     for (workflow.jobs) |job| {
+        var loaded_chain_map: ?chain_map.ChainMap = null;
+        defer if (loaded_chain_map) |*map| map.deinit();
+
         var config = BatchConfig{};
         try applyWorkflowToBatchConfig(&config, args, workflow.calculation, workflow.output, workflow.classifier);
         applyCliOverrides(&config, args);
@@ -3983,6 +4044,13 @@ fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void 
         config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
         if (custom_classifier) |*c| config.custom_classifier = c;
         applyWorkflowJobOverrides(&config, args, job);
+        if (job.chain_map) |path| {
+            loaded_chain_map = chain_map.loadFile(allocator, io, path) catch |err| {
+                std.debug.print("Error loading chain map '{s}' for workflow job '{s}': {s}\n", .{ path, job.name, @errorName(err) });
+                return err;
+            };
+            config.chain_map = &loaded_chain_map.?;
+        }
         try validateBitmaskCorrectionConfig(config);
         validateBatchOutputFormat(config.output_format) catch {
             std.debug.print("Error: freesasa and rsa output formats are only supported by the calc command\n", .{});
@@ -5244,6 +5312,123 @@ test "workflow file-first keeps existing output layout" {
     try std.testing.expect(std.mem.indexOf(u8, chain_a_json_content_2, "\"total_area\"") != null);
 }
 
+test "workflow chain map selects per-file PDB and mmCIF chain complexes" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const output_dir = try std.fs.path.join(allocator, &.{ root, "output" });
+    defer allocator.free(output_dir);
+    const pdb_path = try std.fs.path.join(allocator, &.{ input_dir, "pdb-complex.pdb" });
+    defer allocator.free(pdb_path);
+    const auth_cif_path = try std.fs.path.join(allocator, &.{ input_dir, "auth-complex.cif" });
+    defer allocator.free(auth_cif_path);
+    const label_cif_path = try std.fs.path.join(allocator, &.{ input_dir, "label-complex.cif" });
+    defer allocator.free(label_cif_path);
+    const map_path = try std.fs.path.join(allocator, &.{ root, "chains.csv" });
+    defer allocator.free(map_path);
+    const workflow_path = try std.fs.path.join(allocator, &.{ root, "workflow.toml" });
+    defer allocator.free(workflow_path);
+
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = pdb_path,
+        .data =
+        \\ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00 20.00           N
+        \\ATOM      2  N   ALA B   1       4.000   0.000   0.000  1.00 20.00           N
+        \\ATOM      3  N   ALA C   1       8.000   0.000   0.000  1.00 20.00           N
+        \\END
+        \\
+        ,
+    });
+
+    const cif_template =
+        \\data_CHAIN_MAP
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.auth_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM 1 N N ALA L1 A 1 0.000 0.000 0.000
+        \\ATOM 2 N N ALA L2 B 1 4.000 0.000 0.000
+        \\ATOM 3 N N ALA L3 C 1 8.000 0.000 0.000
+        \\#
+        \\
+    ;
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = auth_cif_path, .data = cif_template });
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = label_cif_path, .data = cif_template });
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = map_path,
+        .data =
+        \\filename,chains,asym_id_type
+        \\pdb-complex.pdb,"A,C",label
+        \\auth-complex.cif,"A,C",auth
+        \\label-complex.cif,"L1,L3",label
+        \\
+        ,
+    });
+
+    const workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "jsonl"
+        \\
+        \\[calculation]
+        \\threads = 2
+        \\n_points = 8
+        \\quiet = true
+        \\
+        \\[classifier]
+        \\type = "naccess"
+        \\
+        \\[[jobs]]
+        \\name = "selected_complexes"
+        \\chain_map = "{s}"
+        \\
+    , .{ input_dir, output_dir, map_path });
+    defer allocator.free(workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = workflow_path });
+
+    const output_path = try std.fs.path.join(allocator, &.{ output_dir, "selected_complexes.jsonl" });
+    defer allocator.free(output_path);
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(16384));
+    defer allocator.free(content);
+
+    var found: usize = 0;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const object = parsed.value.object;
+        try std.testing.expectEqualStrings("ok", object.get("status").?.string);
+        try std.testing.expectEqual(@as(usize, 2), object.get("atom_areas").?.array.items.len);
+        found += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 3), found);
+}
+
 test "workflow BSA analysis writes analysis JSONL" {
     const allocator = std.testing.allocator;
     var tmp_dir = std.testing.tmpDir(.{});
@@ -5308,6 +5493,114 @@ test "workflow BSA analysis writes analysis JSONL" {
     try std.testing.expect(std.mem.indexOf(u8, content, "\"delta_sasa_total\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, content, "\"bsa\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, content, "\"residue_delta_sasa\"") != null);
+}
+
+test "workflow BSA analysis uses per-file multi-chain interface map" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const output_dir = try std.fs.path.join(allocator, &.{ root, "output" });
+    defer allocator.free(output_dir);
+    const cif_path = try std.fs.path.join(allocator, &.{ input_dir, "abcd.cif" });
+    defer allocator.free(cif_path);
+    const map_path = try std.fs.path.join(allocator, &.{ root, "interfaces.csv" });
+    defer allocator.free(map_path);
+    const workflow_path = try std.fs.path.join(allocator, &.{ root, "bsa-map.toml" });
+    defer allocator.free(workflow_path);
+
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = cif_path,
+        .data =
+        \\data_ABCD
+        \\loop_
+        \\_atom_site.group_PDB
+        \\_atom_site.id
+        \\_atom_site.type_symbol
+        \\_atom_site.label_atom_id
+        \\_atom_site.label_comp_id
+        \\_atom_site.label_asym_id
+        \\_atom_site.auth_asym_id
+        \\_atom_site.label_seq_id
+        \\_atom_site.Cartn_x
+        \\_atom_site.Cartn_y
+        \\_atom_site.Cartn_z
+        \\ATOM 1 N N GLY L1 A 1 0.000 0.000 0.000
+        \\ATOM 2 N N GLY L2 B 1 2.000 0.000 0.000
+        \\ATOM 3 N N GLY L3 C 1 4.000 0.000 0.000
+        \\ATOM 4 N N GLY L4 D 1 6.000 0.000 0.000
+        \\#
+        \\
+        ,
+    });
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = map_path,
+        .data =
+        \\filename,partner_a,partner_b,asym_id_type
+        \\abcd.cif,"A,B","C,D",auth
+        \\
+        ,
+    });
+
+    const workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "jsonl"
+        \\
+        \\[calculation]
+        \\n_points = 8
+        \\quiet = true
+        \\
+        \\[classifier]
+        \\type = "naccess"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\name = "interfaces"
+        \\chain_map = "{s}"
+        \\level = "residue"
+        \\
+    , .{ input_dir, output_dir, map_path });
+    defer allocator.free(workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = workflow_path });
+
+    const output_path = try std.fs.path.join(allocator, &.{ output_dir, "interfaces.jsonl" });
+    defer allocator.free(output_path);
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(16384));
+    defer allocator.free(content);
+    const line = std.mem.trim(u8, content, " \t\r\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+    defer parsed.deinit();
+    const object = parsed.value.object;
+
+    const partner_a = object.get("partner_a").?.array.items;
+    const partner_b = object.get("partner_b").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), partner_a.len);
+    try std.testing.expectEqualStrings("A", partner_a[0].string);
+    try std.testing.expectEqualStrings("B", partner_a[1].string);
+    try std.testing.expectEqual(@as(usize, 2), partner_b.len);
+    try std.testing.expectEqualStrings("C", partner_b[0].string);
+    try std.testing.expectEqualStrings("D", partner_b[1].string);
+
+    const residue_chains = object.get("residue_chain").?.array.items;
+    try std.testing.expectEqual(@as(usize, 4), residue_chains.len);
+    try std.testing.expectEqualStrings("A", residue_chains[0].string);
+    try std.testing.expectEqualStrings("D", residue_chains[3].string);
 }
 
 test "workflow mmCIF chain filters preserve long chain IDs" {

--- a/src/chain_map.zig
+++ b/src/chain_map.zig
@@ -1,0 +1,617 @@
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+pub const AsymIdType = enum {
+    label,
+    auth,
+
+    fn parse(value: []const u8) !AsymIdType {
+        if (std.ascii.eqlIgnoreCase(value, "label")) return .label;
+        if (std.ascii.eqlIgnoreCase(value, "auth")) return .auth;
+        return error.InvalidAsymIdType;
+    }
+};
+
+pub const Entry = struct {
+    filename: []const u8,
+    chains: []const []const u8,
+    asym_id_type: AsymIdType,
+
+    fn deinit(self: Entry, allocator: Allocator) void {
+        allocator.free(self.filename);
+        for (self.chains) |chain| allocator.free(chain);
+        allocator.free(self.chains);
+    }
+};
+
+pub const ChainMap = struct {
+    allocator: Allocator,
+    entries: []Entry,
+    index: std.StringHashMapUnmanaged(usize),
+
+    pub fn deinit(self: *ChainMap) void {
+        self.index.deinit(self.allocator);
+        for (self.entries) |entry| entry.deinit(self.allocator);
+        self.allocator.free(self.entries);
+        self.* = undefined;
+    }
+
+    pub fn get(self: *const ChainMap, filename: []const u8) ?Entry {
+        const index = self.index.get(filename) orelse return null;
+        return self.entries[index];
+    }
+};
+
+pub const InterfaceEntry = struct {
+    filename: []const u8,
+    partner_a: []const []const u8,
+    partner_b: []const []const u8,
+    asym_id_type: AsymIdType,
+
+    fn deinit(self: InterfaceEntry, allocator: Allocator) void {
+        allocator.free(self.filename);
+        freeChains(allocator, self.partner_a);
+        freeChains(allocator, self.partner_b);
+    }
+};
+
+pub const InterfaceMap = struct {
+    allocator: Allocator,
+    entries: []InterfaceEntry,
+    index: std.StringHashMapUnmanaged(usize),
+
+    pub fn deinit(self: *InterfaceMap) void {
+        self.index.deinit(self.allocator);
+        for (self.entries) |entry| entry.deinit(self.allocator);
+        self.allocator.free(self.entries);
+        self.* = undefined;
+    }
+
+    pub fn get(self: *const InterfaceMap, filename: []const u8) ?InterfaceEntry {
+        const index = self.index.get(filename) orelse return null;
+        return self.entries[index];
+    }
+};
+
+pub fn loadFile(allocator: Allocator, io: std.Io, path: []const u8) !ChainMap {
+    const content = try readFile(allocator, io, path);
+    defer allocator.free(content);
+
+    if (endsWithIgnoreCase(path, ".csv")) return parseCsv(allocator, content);
+    if (endsWithIgnoreCase(path, ".json")) return parseJson(allocator, content);
+    return error.UnsupportedChainMapFormat;
+}
+
+pub fn loadInterfaceFile(allocator: Allocator, io: std.Io, path: []const u8) !InterfaceMap {
+    const content = try readFile(allocator, io, path);
+    defer allocator.free(content);
+
+    if (endsWithIgnoreCase(path, ".csv")) return parseInterfaceCsv(allocator, content);
+    if (endsWithIgnoreCase(path, ".json")) return parseInterfaceJson(allocator, content);
+    return error.UnsupportedChainMapFormat;
+}
+
+pub fn parseCsv(allocator: Allocator, content: []const u8) !ChainMap {
+    var entries = std.ArrayListUnmanaged(Entry).empty;
+    errdefer deinitEntryList(allocator, &entries);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    var header: ?[]const []const u8 = null;
+    defer if (header) |fields| freeFields(allocator, fields);
+
+    var filename_col: ?usize = null;
+    var chains_col: ?usize = null;
+    var asym_id_type_col: ?usize = null;
+
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trimEnd(u8, raw_line, "\r");
+        if (std.mem.trim(u8, line, " \t").len == 0) continue;
+
+        const fields = try parseCsvRecord(allocator, line);
+        if (header == null) {
+            header = fields;
+            for (fields, 0..) |field, i| {
+                const normalized = if (i == 0) std.mem.trimStart(u8, field, "\xEF\xBB\xBF") else field;
+                if (std.ascii.eqlIgnoreCase(normalized, "filename")) filename_col = i;
+                if (std.ascii.eqlIgnoreCase(normalized, "chains")) chains_col = i;
+                if (std.ascii.eqlIgnoreCase(normalized, "asym_id_type")) asym_id_type_col = i;
+            }
+            if (filename_col == null or chains_col == null) return error.MissingChainMapColumn;
+            continue;
+        }
+        defer freeFields(allocator, fields);
+
+        if (fields.len != header.?.len) return error.InvalidCsv;
+        const required_max = @max(filename_col.?, chains_col.?);
+        if (fields.len <= required_max) return error.MissingChainMapField;
+        if (asym_id_type_col) |col| {
+            if (fields.len <= col) return error.MissingChainMapField;
+        }
+
+        const asym_id_type = if (asym_id_type_col) |col|
+            try parseAsymIdTypeOrDefault(fields[col])
+        else
+            AsymIdType.label;
+        try appendEntry(allocator, &entries, fields[filename_col.?], fields[chains_col.?], asym_id_type);
+    }
+
+    if (header == null) return error.MissingChainMapHeader;
+    return finish(allocator, &entries);
+}
+
+const JsonEntry = struct {
+    filename: []const u8,
+    chains: []const []const u8,
+    asym_id_type: ?[]const u8 = null,
+};
+
+pub fn parseJson(allocator: Allocator, content: []const u8) !ChainMap {
+    const parsed = try std.json.parseFromSlice([]const JsonEntry, allocator, content, .{});
+    defer parsed.deinit();
+
+    var entries = std.ArrayListUnmanaged(Entry).empty;
+    errdefer deinitEntryList(allocator, &entries);
+
+    for (parsed.value) |json_entry| {
+        const asym_id_type = try parseAsymIdTypeOrDefault(json_entry.asym_id_type orelse "");
+        try appendEntryFromChains(allocator, &entries, json_entry.filename, json_entry.chains, asym_id_type);
+    }
+    return finish(allocator, &entries);
+}
+
+pub fn parseInterfaceCsv(allocator: Allocator, content: []const u8) !InterfaceMap {
+    var entries = std.ArrayListUnmanaged(InterfaceEntry).empty;
+    errdefer deinitInterfaceEntryList(allocator, &entries);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    var header: ?[]const []const u8 = null;
+    defer if (header) |fields| freeFields(allocator, fields);
+
+    var filename_col: ?usize = null;
+    var partner_a_col: ?usize = null;
+    var partner_b_col: ?usize = null;
+    var asym_id_type_col: ?usize = null;
+
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trimEnd(u8, raw_line, "\r");
+        if (std.mem.trim(u8, line, " \t").len == 0) continue;
+
+        const fields = try parseCsvRecord(allocator, line);
+        if (header == null) {
+            header = fields;
+            for (fields, 0..) |field, i| {
+                const normalized = if (i == 0) std.mem.trimStart(u8, field, "\xEF\xBB\xBF") else field;
+                if (std.ascii.eqlIgnoreCase(normalized, "filename")) filename_col = i;
+                if (std.ascii.eqlIgnoreCase(normalized, "partner_a")) partner_a_col = i;
+                if (std.ascii.eqlIgnoreCase(normalized, "partner_b")) partner_b_col = i;
+                if (std.ascii.eqlIgnoreCase(normalized, "asym_id_type")) asym_id_type_col = i;
+            }
+            if (filename_col == null or partner_a_col == null or partner_b_col == null) {
+                return error.MissingChainMapColumn;
+            }
+            continue;
+        }
+        defer freeFields(allocator, fields);
+
+        if (fields.len != header.?.len) return error.InvalidCsv;
+        const required_max = @max(filename_col.?, @max(partner_a_col.?, partner_b_col.?));
+        if (fields.len <= required_max) return error.MissingChainMapField;
+        if (asym_id_type_col) |col| {
+            if (fields.len <= col) return error.MissingChainMapField;
+        }
+
+        const asym_id_type = if (asym_id_type_col) |col|
+            try parseAsymIdTypeOrDefault(fields[col])
+        else
+            AsymIdType.label;
+        try appendInterfaceEntryCsv(
+            allocator,
+            &entries,
+            fields[filename_col.?],
+            fields[partner_a_col.?],
+            fields[partner_b_col.?],
+            asym_id_type,
+        );
+    }
+
+    if (header == null) return error.MissingChainMapHeader;
+    return finishInterface(allocator, &entries);
+}
+
+const JsonInterfaceEntry = struct {
+    filename: []const u8,
+    partner_a: []const []const u8,
+    partner_b: []const []const u8,
+    asym_id_type: ?[]const u8 = null,
+};
+
+pub fn parseInterfaceJson(allocator: Allocator, content: []const u8) !InterfaceMap {
+    const parsed = try std.json.parseFromSlice([]const JsonInterfaceEntry, allocator, content, .{});
+    defer parsed.deinit();
+
+    var entries = std.ArrayListUnmanaged(InterfaceEntry).empty;
+    errdefer deinitInterfaceEntryList(allocator, &entries);
+
+    for (parsed.value) |json_entry| {
+        const asym_id_type = try parseAsymIdTypeOrDefault(json_entry.asym_id_type orelse "");
+        try appendInterfaceEntryJson(
+            allocator,
+            &entries,
+            json_entry.filename,
+            json_entry.partner_a,
+            json_entry.partner_b,
+            asym_id_type,
+        );
+    }
+    return finishInterface(allocator, &entries);
+}
+
+fn parseAsymIdTypeOrDefault(value: []const u8) !AsymIdType {
+    const trimmed = std.mem.trim(u8, value, " \t\r");
+    if (trimmed.len == 0) return .label;
+    return AsymIdType.parse(trimmed);
+}
+
+fn appendEntry(
+    allocator: Allocator,
+    entries: *std.ArrayListUnmanaged(Entry),
+    filename_value: []const u8,
+    chains_value: []const u8,
+    asym_id_type: AsymIdType,
+) !void {
+    const owned_chains = try parseCommaSeparatedChains(allocator, chains_value);
+    errdefer freeChains(allocator, owned_chains);
+    try appendOwnedEntry(allocator, entries, filename_value, owned_chains, asym_id_type);
+}
+
+fn appendEntryFromChains(
+    allocator: Allocator,
+    entries: *std.ArrayListUnmanaged(Entry),
+    filename_value: []const u8,
+    chain_values: []const []const u8,
+    asym_id_type: AsymIdType,
+) !void {
+    const chains = try dupeChains(allocator, chain_values);
+    errdefer freeChains(allocator, chains);
+    try appendOwnedEntry(allocator, entries, filename_value, chains, asym_id_type);
+}
+
+fn appendInterfaceEntryCsv(
+    allocator: Allocator,
+    entries: *std.ArrayListUnmanaged(InterfaceEntry),
+    filename_value: []const u8,
+    partner_a_value: []const u8,
+    partner_b_value: []const u8,
+    asym_id_type: AsymIdType,
+) !void {
+    const partner_a = try parseCommaSeparatedChains(allocator, partner_a_value);
+    errdefer freeChains(allocator, partner_a);
+    const partner_b = try parseCommaSeparatedChains(allocator, partner_b_value);
+    errdefer freeChains(allocator, partner_b);
+    try appendOwnedInterfaceEntry(allocator, entries, filename_value, partner_a, partner_b, asym_id_type);
+}
+
+fn appendInterfaceEntryJson(
+    allocator: Allocator,
+    entries: *std.ArrayListUnmanaged(InterfaceEntry),
+    filename_value: []const u8,
+    partner_a_values: []const []const u8,
+    partner_b_values: []const []const u8,
+    asym_id_type: AsymIdType,
+) !void {
+    const partner_a = try dupeChains(allocator, partner_a_values);
+    errdefer freeChains(allocator, partner_a);
+    const partner_b = try dupeChains(allocator, partner_b_values);
+    errdefer freeChains(allocator, partner_b);
+    try appendOwnedInterfaceEntry(allocator, entries, filename_value, partner_a, partner_b, asym_id_type);
+}
+
+fn appendOwnedEntry(
+    allocator: Allocator,
+    entries: *std.ArrayListUnmanaged(Entry),
+    filename_value: []const u8,
+    chains: []const []const u8,
+    asym_id_type: AsymIdType,
+) !void {
+    const filename = try validateFilename(filename_value);
+    const owned_filename = try allocator.dupe(u8, filename);
+    errdefer allocator.free(owned_filename);
+    try entries.append(allocator, .{
+        .filename = owned_filename,
+        .chains = chains,
+        .asym_id_type = asym_id_type,
+    });
+}
+
+fn appendOwnedInterfaceEntry(
+    allocator: Allocator,
+    entries: *std.ArrayListUnmanaged(InterfaceEntry),
+    filename_value: []const u8,
+    partner_a: []const []const u8,
+    partner_b: []const []const u8,
+    asym_id_type: AsymIdType,
+) !void {
+    const filename = try validateFilename(filename_value);
+    const owned_filename = try allocator.dupe(u8, filename);
+    errdefer allocator.free(owned_filename);
+    try entries.append(allocator, .{
+        .filename = owned_filename,
+        .partner_a = partner_a,
+        .partner_b = partner_b,
+        .asym_id_type = asym_id_type,
+    });
+}
+
+fn finish(allocator: Allocator, entries: *std.ArrayListUnmanaged(Entry)) !ChainMap {
+    const owned_entries = try entries.toOwnedSlice(allocator);
+    errdefer {
+        for (owned_entries) |entry| entry.deinit(allocator);
+        allocator.free(owned_entries);
+    }
+
+    var index = std.StringHashMapUnmanaged(usize){};
+    errdefer index.deinit(allocator);
+    for (owned_entries, 0..) |entry, i| {
+        if (index.contains(entry.filename)) return error.DuplicateFilename;
+        try index.put(allocator, entry.filename, i);
+    }
+
+    return .{
+        .allocator = allocator,
+        .entries = owned_entries,
+        .index = index,
+    };
+}
+
+fn finishInterface(allocator: Allocator, entries: *std.ArrayListUnmanaged(InterfaceEntry)) !InterfaceMap {
+    const owned_entries = try entries.toOwnedSlice(allocator);
+    errdefer {
+        for (owned_entries) |entry| entry.deinit(allocator);
+        allocator.free(owned_entries);
+    }
+
+    var index = std.StringHashMapUnmanaged(usize){};
+    errdefer index.deinit(allocator);
+    for (owned_entries, 0..) |entry, i| {
+        if (index.contains(entry.filename)) return error.DuplicateFilename;
+        try index.put(allocator, entry.filename, i);
+    }
+
+    return .{
+        .allocator = allocator,
+        .entries = owned_entries,
+        .index = index,
+    };
+}
+
+fn readFile(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+
+    var read_buf: [65536]u8 = undefined;
+    var reader = file.reader(io, &read_buf);
+    return reader.interface.allocRemaining(allocator, .unlimited);
+}
+
+fn validateFilename(filename_value: []const u8) ![]const u8 {
+    const filename = std.mem.trim(u8, filename_value, " \t\r");
+    if (filename.len == 0) return error.EmptyFilename;
+    if (std.mem.findAny(u8, filename, "/\\") != null or std.mem.indexOf(u8, filename, "..") != null) {
+        return error.UnsafeFilename;
+    }
+    return filename;
+}
+
+fn parseCommaSeparatedChains(allocator: Allocator, value: []const u8) ![]const []const u8 {
+    var chains = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer {
+        for (chains.items) |chain| allocator.free(chain);
+        chains.deinit(allocator);
+    }
+
+    var iter = std.mem.splitScalar(u8, value, ',');
+    while (iter.next()) |raw_chain| {
+        const chain = std.mem.trim(u8, raw_chain, " \t\r");
+        if (chain.len == 0) return error.EmptyChainId;
+        const owned_chain = try allocator.dupe(u8, chain);
+        chains.append(allocator, owned_chain) catch |err| {
+            allocator.free(owned_chain);
+            return err;
+        };
+    }
+    if (chains.items.len == 0) return error.EmptyChains;
+    return chains.toOwnedSlice(allocator);
+}
+
+fn dupeChains(allocator: Allocator, values: []const []const u8) ![]const []const u8 {
+    if (values.len == 0) return error.EmptyChains;
+    const chains = try allocator.alloc([]const u8, values.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (chains[0..initialized]) |chain| allocator.free(chain);
+        allocator.free(chains);
+    }
+    for (values, 0..) |value, i| {
+        const chain = std.mem.trim(u8, value, " \t\r");
+        if (chain.len == 0) return error.EmptyChainId;
+        chains[i] = try allocator.dupe(u8, chain);
+        initialized += 1;
+    }
+    return chains;
+}
+
+fn freeChains(allocator: Allocator, chains: []const []const u8) void {
+    for (chains) |chain| allocator.free(chain);
+    allocator.free(chains);
+}
+
+fn parseCsvRecord(allocator: Allocator, line: []const u8) ![]const []const u8 {
+    var fields = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer freeFieldList(allocator, &fields);
+
+    var i: usize = 0;
+    while (true) {
+        while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
+
+        var value = std.ArrayListUnmanaged(u8).empty;
+        errdefer value.deinit(allocator);
+        if (i < line.len and line[i] == '"') {
+            i += 1;
+            var closed = false;
+            while (i < line.len) {
+                if (line[i] == '"') {
+                    if (i + 1 < line.len and line[i + 1] == '"') {
+                        try value.append(allocator, '"');
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                    closed = true;
+                    break;
+                }
+                try value.append(allocator, line[i]);
+                i += 1;
+            }
+            if (!closed) return error.InvalidCsv;
+            while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
+            if (i < line.len and line[i] != ',') return error.InvalidCsv;
+        } else {
+            const start = i;
+            while (i < line.len and line[i] != ',') : (i += 1) {}
+            try value.appendSlice(allocator, std.mem.trim(u8, line[start..i], " \t"));
+        }
+
+        const owned_value = try value.toOwnedSlice(allocator);
+        fields.append(allocator, owned_value) catch |err| {
+            allocator.free(owned_value);
+            return err;
+        };
+        if (i >= line.len) break;
+        i += 1;
+        if (i == line.len) {
+            const empty = try allocator.alloc(u8, 0);
+            fields.append(allocator, empty) catch |err| {
+                allocator.free(empty);
+                return err;
+            };
+            break;
+        }
+    }
+    return fields.toOwnedSlice(allocator);
+}
+
+fn freeFields(allocator: Allocator, fields: []const []const u8) void {
+    for (fields) |field| allocator.free(field);
+    allocator.free(fields);
+}
+
+fn freeFieldList(allocator: Allocator, fields: *std.ArrayListUnmanaged([]const u8)) void {
+    for (fields.items) |field| allocator.free(field);
+    fields.deinit(allocator);
+}
+
+fn deinitEntryList(allocator: Allocator, entries: *std.ArrayListUnmanaged(Entry)) void {
+    for (entries.items) |entry| entry.deinit(allocator);
+    entries.deinit(allocator);
+}
+
+fn deinitInterfaceEntryList(allocator: Allocator, entries: *std.ArrayListUnmanaged(InterfaceEntry)) void {
+    for (entries.items) |entry| entry.deinit(allocator);
+    entries.deinit(allocator);
+}
+
+fn endsWithIgnoreCase(value: []const u8, suffix: []const u8) bool {
+    if (value.len < suffix.len) return false;
+    return std.ascii.eqlIgnoreCase(value[value.len - suffix.len ..], suffix);
+}
+
+test "parse CSV chain map with multi-chain auth selection" {
+    var map = try parseCsv(
+        std.testing.allocator,
+        "filename,chains,asym_id_type\r\n" ++
+            "1abc.cif,\"A,C\",auth\r\n" ++
+            "2xyz.pdb,B,label\r\n",
+    );
+    defer map.deinit();
+
+    const first = map.get("1abc.cif").?;
+    try std.testing.expectEqual(@as(usize, 2), first.chains.len);
+    try std.testing.expectEqualStrings("A", first.chains[0]);
+    try std.testing.expectEqualStrings("C", first.chains[1]);
+    try std.testing.expectEqual(AsymIdType.auth, first.asym_id_type);
+    try std.testing.expectEqual(AsymIdType.label, map.get("2xyz.pdb").?.asym_id_type);
+}
+
+test "parse JSON chain map defaults to label IDs" {
+    var map = try parseJson(std.testing.allocator,
+        \\[
+        \\  {"filename":"1abc.cif","chains":["A","C"]},
+        \\  {"filename":"2xyz.cif","chains":["X"],"asym_id_type":"auth"}
+        \\]
+    );
+    defer map.deinit();
+
+    try std.testing.expectEqual(AsymIdType.label, map.get("1abc.cif").?.asym_id_type);
+    try std.testing.expectEqual(AsymIdType.auth, map.get("2xyz.cif").?.asym_id_type);
+}
+
+test "reject duplicate chain map filenames" {
+    try std.testing.expectError(
+        error.DuplicateFilename,
+        parseCsv(
+            std.testing.allocator,
+            "filename,chains\n" ++
+                "1abc.cif,A\n" ++
+                "1abc.cif,B\n",
+        ),
+    );
+}
+
+test "reject unquoted multi-chain CSV field" {
+    try std.testing.expectError(
+        error.InvalidCsv,
+        parseCsv(
+            std.testing.allocator,
+            "filename,chains\n" ++
+                "1abc.cif,A,C\n",
+        ),
+    );
+}
+
+test "parse CSV interface map with multi-chain partners" {
+    var map = try parseInterfaceCsv(
+        std.testing.allocator,
+        "filename,partner_a,partner_b,asym_id_type\n" ++
+            "1abc.cif,\"A,B\",\"C,D\",auth\n",
+    );
+    defer map.deinit();
+
+    const entry = map.get("1abc.cif").?;
+    try std.testing.expectEqual(@as(usize, 2), entry.partner_a.len);
+    try std.testing.expectEqualStrings("A", entry.partner_a[0]);
+    try std.testing.expectEqualStrings("B", entry.partner_a[1]);
+    try std.testing.expectEqual(@as(usize, 2), entry.partner_b.len);
+    try std.testing.expectEqualStrings("C", entry.partner_b[0]);
+    try std.testing.expectEqualStrings("D", entry.partner_b[1]);
+    try std.testing.expectEqual(AsymIdType.auth, entry.asym_id_type);
+}
+
+test "parse JSON interface map" {
+    var map = try parseInterfaceJson(std.testing.allocator,
+        \\[
+        \\  {
+        \\    "filename":"1abc.cif",
+        \\    "partner_a":["A","B"],
+        \\    "partner_b":["C","D"],
+        \\    "asym_id_type":"label"
+        \\  }
+        \\]
+    );
+    defer map.deinit();
+
+    const entry = map.get("1abc.cif").?;
+    try std.testing.expectEqualStrings("B", entry.partner_a[1]);
+    try std.testing.expectEqualStrings("D", entry.partner_b[1]);
+    try std.testing.expectEqual(AsymIdType.label, entry.asym_id_type);
+}

--- a/src/workflow_manifest.zig
+++ b/src/workflow_manifest.zig
@@ -71,12 +71,14 @@ pub const Analysis = struct {
     name: ?[]const u8 = null,
     partner_a: ?[]const []const u8 = null,
     partner_b: ?[]const []const u8 = null,
+    chain_map: ?[]const u8 = null,
     level: ?[]const u8 = null,
 };
 
 pub const Job = struct {
     name: []const u8,
     chains: ?[]const []const u8 = null,
+    chain_map: ?[]const u8 = null,
     auth_chain: ?bool = null,
 };
 
@@ -306,12 +308,13 @@ fn parseClassifier(allocator: Allocator, table: toml_parser.Table) Error!Classif
 }
 
 fn parseAnalysis(allocator: Allocator, table: toml_parser.Table) Error!Analysis {
-    try rejectUnknownFields(table.entries, &.{ "type", "name", "partner_a", "partner_b", "level" });
+    try rejectUnknownFields(table.entries, &.{ "type", "name", "partner_a", "partner_b", "chain_map", "level" });
     const analysis = Analysis{
         .type = try optionalString(table.entries, "type"),
         .name = try optionalString(table.entries, "name"),
         .partner_a = try optionalStringArray(allocator, table.entries, "partner_a"),
         .partner_b = try optionalStringArray(allocator, table.entries, "partner_b"),
+        .chain_map = try optionalString(table.entries, "chain_map"),
         .level = try optionalString(table.entries, "level"),
     };
     errdefer {
@@ -345,14 +348,23 @@ fn validateAnalysis(analysis: Analysis) WorkflowError!void {
     if (analysis.name) |name| {
         if (name.len == 0 or !isSafeJobName(name)) return error.InvalidAnalysisConfig;
     }
-    const partner_a = analysis.partner_a orelse return error.InvalidAnalysisConfig;
-    const partner_b = analysis.partner_b orelse return error.InvalidAnalysisConfig;
-    if (partner_a.len == 0 or partner_b.len == 0) return error.InvalidAnalysisConfig;
-    for (partner_a) |chain| {
-        if (chain.len == 0) return error.InvalidAnalysisConfig;
+    if (analysis.chain_map) |path| {
+        if (path.len == 0 or analysis.partner_a != null or analysis.partner_b != null) {
+            return error.InvalidAnalysisConfig;
+        }
+    } else if (analysis.partner_a == null or analysis.partner_b == null) {
+        return error.InvalidAnalysisConfig;
     }
-    for (partner_b) |chain| {
-        if (chain.len == 0) return error.InvalidAnalysisConfig;
+    if (analysis.chain_map == null) {
+        const partner_a = analysis.partner_a.?;
+        const partner_b = analysis.partner_b.?;
+        if (partner_a.len == 0 or partner_b.len == 0) return error.InvalidAnalysisConfig;
+        for (partner_a) |chain| {
+            if (chain.len == 0) return error.InvalidAnalysisConfig;
+        }
+        for (partner_b) |chain| {
+            if (chain.len == 0) return error.InvalidAnalysisConfig;
+        }
     }
     if (analysis.level) |level| {
         if (!std.mem.eql(u8, level, "total") and !std.mem.eql(u8, level, "residue")) {
@@ -383,7 +395,7 @@ fn parseJobs(allocator: Allocator, array_tables: []const toml_parser.Document.Ar
 }
 
 fn parseJob(allocator: Allocator, entries: []const toml_parser.Value.Entry, existing_jobs: []const Job) Error!Job {
-    try rejectUnknownFields(entries, &.{ "name", "chains", "auth_chain" });
+    try rejectUnknownFields(entries, &.{ "name", "chains", "chain_map", "auth_chain" });
 
     const name = try optionalString(entries, "name") orelse return error.MissingJobName;
     if (name.len == 0) return error.MissingJobName;
@@ -394,11 +406,15 @@ fn parseJob(allocator: Allocator, entries: []const toml_parser.Value.Entry, exis
 
     const chains = try optionalStringArray(allocator, entries, "chains");
     errdefer if (chains) |items| allocator.free(items);
+    const chain_map = try optionalString(entries, "chain_map");
+    if (chains != null and chain_map != null) return error.InvalidFieldType;
     const auth_chain = try optionalBool(entries, "auth_chain");
+    if (chain_map != null and auth_chain != null) return error.InvalidFieldType;
 
     return .{
         .name = name,
         .chains = chains,
+        .chain_map = chain_map,
         .auth_chain = auth_chain,
     };
 }
@@ -690,6 +706,39 @@ test "parse sectioned batch workflow with jobs" {
     try std.testing.expectEqual(true, workflow.jobs[1].auth_chain.?);
 }
 
+test "parse workflow job with per-file chain map" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "structures"
+        \\
+        \\[[jobs]]
+        \\name = "selected_complexes"
+        \\chain_map = "chains.csv"
+    ;
+    var workflow = try parse(std.testing.allocator, input);
+    defer workflow.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), workflow.jobs.len);
+    try std.testing.expectEqualStrings("chains.csv", workflow.jobs[0].chain_map.?);
+    try std.testing.expect(workflow.jobs[0].chains == null);
+}
+
+test "reject workflow job with both chains and chain map" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[[jobs]]
+        \\name = "ambiguous"
+        \\chains = ["A"]
+        \\chain_map = "chains.csv"
+    ;
+    try std.testing.expectError(error.InvalidFieldType, parse(std.testing.allocator, input));
+}
+
 test "parse output jsonl workflow options" {
     const input =
         \\version = 1
@@ -761,6 +810,39 @@ test "parse BSA analysis workflow" {
     try std.testing.expectEqual(@as(usize, 1), workflow.analysis.?.partner_b.?.len);
     try std.testing.expectEqualStrings("B", workflow.analysis.?.partner_b.?[0]);
     try std.testing.expectEqualStrings("residue", workflow.analysis.?.level.?);
+}
+
+test "parse BSA analysis workflow with per-file chain map" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\name = "interfaces"
+        \\chain_map = "interfaces.csv"
+        \\level = "total"
+    ;
+    var workflow = try parse(std.testing.allocator, input);
+    defer workflow.deinit();
+
+    try std.testing.expectEqualStrings("interfaces.csv", workflow.analysis.?.chain_map.?);
+    try std.testing.expect(workflow.analysis.?.partner_a == null);
+    try std.testing.expect(workflow.analysis.?.partner_b == null);
+}
+
+test "reject BSA analysis with fixed partners and chain map" {
+    const input =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\chain_map = "interfaces.csv"
+    ;
+    try std.testing.expectError(error.InvalidAnalysisConfig, parse(std.testing.allocator, input));
 }
 
 test "reject BSA analysis without both partners" {

--- a/website/docs/guide/batch.md
+++ b/website/docs/guide/batch.md
@@ -162,6 +162,11 @@ Use `--chain` for label/asym chain IDs. Add `--auth-chain` as a boolean modifier
 
 For named multi-job runs such as chain A, chain B, and AB complex calculations, use [Workflow Files](workflows.md) instead of repeating shell commands.
 
+When the desired chain set differs by input file, use a workflow
+[`chain_map`](workflows.md#per-file-chain-maps). Chain maps accept CSV or JSON
+and can choose `label` or `auth` chain IDs independently for each mmCIF or
+BinaryCIF file.
+
 ## When to Use Workflow Files
 
 Use workflow files when you need:

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -106,6 +106,65 @@ zsasa batch --workflow bsa.toml
 
 For ordinary PDB, JSON, and unfiltered mmCIF/BinaryCIF workflow batch runs with compatible chain-ID settings, zsasa reuses each parsed input structure across jobs internally. For named chain analyses such as chain A, chain B, and complex AB, list only the jobs you want; eligible runs parse each input structure once and then compute each requested chain selection independently. Some inputs or settings, such as SDF files, per-job `auth_chain` changes, or mmCIF/BinaryCIF workflows with chain filters, use the compatibility job-first path instead so full chain-ID selection matches parser behavior.
 
+## Per-file Chain Maps
+
+Use a chain map when each structure needs a different chain selection. Set
+`chain_map` on a workflow job instead of `chains`:
+
+```toml
+version = 1
+kind = "workflow"
+
+[input]
+dir = "structures"
+
+[output]
+dir = "results"
+format = "jsonl"
+
+[[jobs]]
+name = "selected_complexes"
+chain_map = "chains.csv"
+```
+
+The CSV must contain `filename` and `chains` columns. `asym_id_type` is optional
+and defaults to `label`:
+
+```csv
+filename,chains,asym_id_type
+1abc.pdb,"A,C",label
+2xyz.cif,"A,C",auth
+3def.cif,"B,D",label
+```
+
+`chains` is a comma-separated set. A row containing `A,C` calculates the SASA
+of the A+C complex: atoms in both chains are included and occlude each other.
+It does not calculate A and C independently. A map has one selection per
+filename; to calculate multiple selections for each file, add multiple named
+workflow jobs with separate chain maps.
+
+JSON chain maps are also accepted:
+
+```json
+[
+  {"filename": "1abc.pdb", "chains": ["A", "C"], "asym_id_type": "label"},
+  {"filename": "2xyz.cif", "chains": ["A", "C"], "asym_id_type": "auth"}
+]
+```
+
+For mmCIF and BinaryCIF, `label` matches `_atom_site.label_asym_id` and `auth`
+matches `_atom_site.auth_asym_id`. PDB has one chain-ID field, so `label` and
+`auth` select the same value for PDB input.
+
+Filenames must be basenames that exactly match files in the input directory,
+including their structure and compression extensions. Every discovered
+structure must have one map entry; a missing entry is written as a failed batch
+result. Keep a JSON chain map outside the input directory because `.json` is
+also a supported structure-input extension. Duplicate filenames, empty chain
+lists, and jobs that specify both
+`chains` and `chain_map` are rejected. Chain maps are supported for PDB,
+mmCIF, and BinaryCIF inputs, not JSON atom arrays or SDF molecule batches.
+
 ## BSA / ΔSASA Analysis
 
 Batch workflows can also write an analysis JSONL file for a two-partner interface:
@@ -136,6 +195,51 @@ partner_a = ["A"]
 partner_b = ["B"]
 level = "residue"
 ```
+
+When the two partner groups differ by structure, replace `partner_a` and
+`partner_b` with an analysis `chain_map`:
+
+```toml
+[analysis]
+type = "bsa"
+name = "interfaces"
+chain_map = "interfaces.csv"
+level = "residue"
+```
+
+CSV interface maps use one comma-separated chain set for each partner:
+
+```csv
+filename,partner_a,partner_b,asym_id_type
+1abc.cif,"A,B","C,D",auth
+2xyz.cif,A,"B,C",label
+```
+
+The equivalent JSON is:
+
+```json
+[
+  {
+    "filename": "1abc.cif",
+    "partner_a": ["A", "B"],
+    "partner_b": ["C", "D"],
+    "asym_id_type": "auth"
+  }
+]
+```
+
+For the first row, zsasa calculates isolated A+B, isolated C+D, and the
+A+B+C+D complex. The reported values are therefore:
+
+```text
+delta_sasa_total = sasa(A+B) + sasa(C+D) - sasa(A+B+C+D)
+bsa = delta_sasa_total / 2
+```
+
+`asym_id_type` defaults to `label` and may be set independently for each
+mmCIF or BinaryCIF file. Fixed `partner_a`/`partner_b` settings and
+`analysis.chain_map` are mutually exclusive. As with job chain maps, every
+discovered PDB, mmCIF, or BinaryCIF file must have exactly one entry.
 
 Run it with:
 


### PR DESCRIPTION
## Summary

- add CSV and JSON chain maps for selecting different single- or multi-chain complexes per input file
- support per-file `label`/`auth` mmCIF and BinaryCIF asym ID selection through `asym_id_type`
- extend BSA/ΔSASA workflows with per-file multi-chain partner groups such as A+B versus C+D
- validate map schemas, duplicate filenames, missing entries, and incompatible workflow settings
- document both job chain maps and BSA interface maps

## Motivation

Batch directories can contain complexes whose relevant chains differ by structure. A global `chains`, `partner_a`, or `partner_b` setting cannot represent those heterogeneous selections. External maps make these workflows reproducible without generating a separate workflow file or command for every structure.

## Validation

- `zig fmt --check src/`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `npm --prefix website run build`
