### PR TITLE
feat: support multiple BSA interfaces per structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-interface BSA workflows**: allow CSV and JSON interface maps to request multiple stable-ID interfaces per structure while reusing one parsed/classified input, emitting per-interface success/error JSONL rows, auditable residue SASA components, and opt-in atom-level detail. (#408)
+
 ## [0.9.1] - 2026-07-28
 
 ### Added

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -23,6 +23,7 @@ const ccd_binary = @import("ccd_binary.zig");
 const sdf_parser = @import("sdf_parser.zig");
 const compressed = @import("compressed.zig");
 const input_io = @import("input_io.zig");
+const element_module = @import("element.zig");
 
 const Allocator = std.mem.Allocator;
 const AtomInput = types.AtomInput;
@@ -1610,6 +1611,19 @@ fn appendBsaAnalysisJsonlToFile(io: std.Io, file: std.Io.File, allocator: Alloca
     try writer.interface.flush();
 }
 
+fn appendBsaAnalysisErrorJsonlToFile(io: std.Io, file: std.Io.File, allocator: Allocator, row: json_writer.BsaAnalysisErrorJsonl) !void {
+    const line = try json_writer.bsaAnalysisErrorToJsonlLine(allocator, row);
+    defer allocator.free(line);
+
+    const file_len = try file.length(io);
+    var write_buf: [64 * 1024]u8 = undefined;
+    var writer = std.Io.File.Writer.init(file, io, &write_buf);
+    try writer.seekTo(file_len);
+    try writer.interface.writeAll(line);
+    try writer.interface.writeByte('\n');
+    try writer.interface.flush();
+}
+
 fn analysisName(analysis: workflow_manifest.Analysis) []const u8 {
     return analysis.name orelse "bsa";
 }
@@ -1626,35 +1640,101 @@ fn appendChainGroups(allocator: Allocator, a: []const []const u8, b: []const []c
 }
 
 const BsaResidueDeltaArrays = struct {
+    residue_partner: []const []const u8 = &.{},
     residue_chain: []const []const u8 = &.{},
     residue_name: []const []const u8 = &.{},
     residue_number: []const i32 = &.{},
     residue_insertion_code: []const []const u8 = &.{},
+    residue_sasa_isolated: []const f64 = &.{},
+    residue_sasa_complex: []const f64 = &.{},
     residue_delta_sasa: []const f64 = &.{},
 };
 
-fn buildBsaResidueDeltaArrays(allocator: Allocator, input: AtomInput, atom_delta_sasa: []const f64) !BsaResidueDeltaArrays {
-    var map = try json_writer.buildResidueMap(allocator, input, atom_delta_sasa);
-    defer map.deinit();
+fn buildBsaResidueDeltaArrays(
+    allocator: Allocator,
+    input: AtomInput,
+    atom_sasa_isolated: []const f64,
+    atom_sasa_complex: []const f64,
+    partner_a: []const []const u8,
+) !BsaResidueDeltaArrays {
+    var isolated_map = try json_writer.buildResidueMap(allocator, input, atom_sasa_isolated);
+    defer isolated_map.deinit();
+    var complex_map = try json_writer.buildResidueMap(allocator, input, atom_sasa_complex);
+    defer complex_map.deinit();
+    if (isolated_map.len() != complex_map.len()) return error.InvalidResidueMap;
 
-    const residue_chain = try allocator.alloc([]const u8, map.len());
-    const residue_name = try allocator.alloc([]const u8, map.len());
-    const residue_insertion_code = try allocator.alloc([]const u8, map.len());
-    const residue_number = try allocator.dupe(i32, map.residue_number);
-    const residue_delta_sasa = try allocator.dupe(f64, map.residue_sasa);
+    const residue_partner = try allocator.alloc([]const u8, isolated_map.len());
+    const residue_chain = try allocator.alloc([]const u8, isolated_map.len());
+    const residue_name = try allocator.alloc([]const u8, isolated_map.len());
+    const residue_insertion_code = try allocator.alloc([]const u8, isolated_map.len());
+    const residue_number = try allocator.dupe(i32, isolated_map.residue_number);
+    const residue_sasa_isolated = try allocator.dupe(f64, isolated_map.residue_sasa);
+    const residue_sasa_complex = try allocator.dupe(f64, complex_map.residue_sasa);
+    const residue_delta_sasa = try allocator.alloc(f64, isolated_map.len());
 
-    for (0..map.len()) |i| {
-        residue_chain[i] = try allocator.dupe(u8, map.residue_chain[i].slice());
-        residue_name[i] = try allocator.dupe(u8, map.residue_name[i].slice());
-        residue_insertion_code[i] = try allocator.dupe(u8, map.residue_insertion_code[i].slice());
+    for (0..isolated_map.len()) |i| {
+        residue_partner[i] = if (atomSelectedByChains(input, isolated_map.residue_atom_start[i], partner_a)) "a" else "b";
+        residue_chain[i] = try allocator.dupe(u8, isolated_map.residue_chain[i].slice());
+        residue_name[i] = try allocator.dupe(u8, isolated_map.residue_name[i].slice());
+        residue_insertion_code[i] = try allocator.dupe(u8, isolated_map.residue_insertion_code[i].slice());
+        residue_delta_sasa[i] = residue_sasa_isolated[i] - residue_sasa_complex[i];
     }
 
     return .{
+        .residue_partner = residue_partner,
         .residue_chain = residue_chain,
         .residue_name = residue_name,
         .residue_number = residue_number,
         .residue_insertion_code = residue_insertion_code,
+        .residue_sasa_isolated = residue_sasa_isolated,
+        .residue_sasa_complex = residue_sasa_complex,
         .residue_delta_sasa = residue_delta_sasa,
+    };
+}
+
+const BsaAtomArrays = struct {
+    atom_index: []const usize = &.{},
+    atom_partner: []const []const u8 = &.{},
+    atom_chain: []const []const u8 = &.{},
+    atom_residue_name: []const []const u8 = &.{},
+    atom_residue_number: []const i32 = &.{},
+    atom_insertion_code: []const []const u8 = &.{},
+    atom_name: []const []const u8 = &.{},
+    atom_element: []const []const u8 = &.{},
+};
+
+fn buildBsaAtomArrays(allocator: Allocator, input: AtomInput, partner_a: []const []const u8) !BsaAtomArrays {
+    if (!input.hasResidueInfo() or input.atom_name == null or input.element == null) return error.MissingAtomMetadata;
+
+    const atom_count = input.atomCount();
+    const atom_index = try allocator.alloc(usize, atom_count);
+    const atom_partner = try allocator.alloc([]const u8, atom_count);
+    const atom_chain = try allocator.alloc([]const u8, atom_count);
+    const atom_residue_name = try allocator.alloc([]const u8, atom_count);
+    const atom_residue_number = try allocator.dupe(i32, input.residue_num.?);
+    const atom_insertion_code = try allocator.alloc([]const u8, atom_count);
+    const atom_name = try allocator.alloc([]const u8, atom_count);
+    const atom_element = try allocator.alloc([]const u8, atom_count);
+
+    for (0..atom_count) |i| {
+        atom_index[i] = i;
+        atom_partner[i] = if (atomSelectedByChains(input, i, partner_a)) "a" else "b";
+        atom_chain[i] = try allocator.dupe(u8, if (input.chain_id_full) |chains| chains[i] else input.chain_id.?[i].slice());
+        atom_residue_name[i] = try allocator.dupe(u8, input.residue.?[i].slice());
+        atom_insertion_code[i] = try allocator.dupe(u8, input.insertion_code.?[i].slice());
+        atom_name[i] = try allocator.dupe(u8, input.atom_name.?[i].slice());
+        atom_element[i] = element_module.fromAtomicNumber(input.element.?[i]).symbol();
+    }
+
+    return .{
+        .atom_index = atom_index,
+        .atom_partner = atom_partner,
+        .atom_chain = atom_chain,
+        .atom_residue_name = atom_residue_name,
+        .atom_residue_number = atom_residue_number,
+        .atom_insertion_code = atom_insertion_code,
+        .atom_name = atom_name,
+        .atom_element = atom_element,
     };
 }
 
@@ -3561,6 +3641,195 @@ fn workflowRequiresJobFirstForAuthChain(args: BatchArgs, workflow: workflow_mani
     return false;
 }
 
+const BsaInterfaceSelection = struct {
+    id: []const u8,
+    partner_a: []const []const u8,
+    partner_b: []const []const u8,
+};
+
+const BsaInterfaceStats = struct {
+    successful: bool,
+    sasa_time_ns: u64 = 0,
+};
+
+fn bsaPartnersOverlap(partner_a: []const []const u8, partner_b: []const []const u8) bool {
+    for (partner_a) |a| {
+        for (partner_b) |b| {
+            if (std.mem.eql(u8, a, b)) return true;
+        }
+    }
+    return false;
+}
+
+fn bsaInputContainsChain(input: AtomInput, target: []const u8) bool {
+    for (0..input.atomCount()) |i| {
+        if (input.chain_id_full) |chains| {
+            if (std.mem.eql(u8, chains[i], target)) return true;
+        } else if (input.chain_id) |chains| {
+            if (chains[i].eqlSlice(target)) return true;
+        }
+    }
+    return false;
+}
+
+fn bsaInputContainsAllChains(input: AtomInput, chains: []const []const u8) bool {
+    for (chains) |chain| {
+        if (!bsaInputContainsChain(input, chain)) return false;
+    }
+    return true;
+}
+
+fn writeBsaInterfaceError(
+    io: std.Io,
+    jsonl_file: std.Io.File,
+    allocator: Allocator,
+    filename: []const u8,
+    id: []const u8,
+    name: []const u8,
+    error_message: []const u8,
+) !BsaInterfaceStats {
+    try appendBsaAnalysisErrorJsonlToFile(io, jsonl_file, allocator, .{
+        .filename = filename,
+        .id = id,
+        .name = name,
+        .error_message = error_message,
+    });
+    return .{ .successful = false };
+}
+
+fn processBsaInterface(
+    allocator: Allocator,
+    io: std.Io,
+    jsonl_file: std.Io.File,
+    filename: []const u8,
+    name: []const u8,
+    level: []const u8,
+    atom_output: bool,
+    selection: BsaInterfaceSelection,
+    source_input: AtomInput,
+    config: BatchConfig,
+    luts: *const BatchLuts,
+) !BsaInterfaceStats {
+    if (bsaPartnersOverlap(selection.partner_a, selection.partner_b)) {
+        return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, "partner chain groups overlap");
+    }
+    if (!bsaInputContainsAllChains(source_input, selection.partner_a)) {
+        return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, "partner A chain not found");
+    }
+    if (!bsaInputContainsAllChains(source_input, selection.partner_b)) {
+        return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, "partner B chain not found");
+    }
+
+    const complex_chains = try appendChainGroups(allocator, selection.partner_a, selection.partner_b);
+    const partner_a_input = try copySelectedAtomInput(allocator, source_input, selection.partner_a);
+    const partner_b_input = try copySelectedAtomInput(allocator, source_input, selection.partner_b);
+    const complex_input = try copySelectedAtomInput(allocator, source_input, complex_chains);
+
+    const n_threads = effectiveWorkflowSasaThreads(config);
+    const partner_a_result = switch (config.precision) {
+        .f64 => calculatePreparedInputResult(f64, allocator, io, allocator, partner_a_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+        .f32 => calculatePreparedInputResult(f32, allocator, io, allocator, partner_a_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+    };
+    const partner_b_result = switch (config.precision) {
+        .f64 => calculatePreparedInputResult(f64, allocator, io, allocator, partner_b_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+        .f32 => calculatePreparedInputResult(f32, allocator, io, allocator, partner_b_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+    };
+    const complex_result = switch (config.precision) {
+        .f64 => calculatePreparedInputResult(f64, allocator, io, allocator, complex_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
+        .f32 => calculatePreparedInputResult(f32, allocator, io, allocator, complex_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
+    };
+
+    if (partner_a_result.status != .ok or partner_b_result.status != .ok or complex_result.status != .ok) {
+        const detail = partner_a_result.error_msg orelse partner_b_result.error_msg orelse complex_result.error_msg orelse "unknown error";
+        const message = try std.fmt.allocPrint(allocator, "SASA calculation failed: {s}", .{detail});
+        return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, message);
+    }
+
+    const partner_a_areas = partner_a_result.atom_areas orelse
+        return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, "partner A atom areas unavailable");
+    const partner_b_areas = partner_b_result.atom_areas orelse
+        return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, "partner B atom areas unavailable");
+    const complex_areas = complex_result.atom_areas orelse
+        return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, "complex atom areas unavailable");
+
+    const atom_sasa_isolated = try allocator.alloc(f64, complex_input.atomCount());
+    const atom_delta_sasa = try allocator.alloc(f64, complex_input.atomCount());
+    var a_index: usize = 0;
+    var b_index: usize = 0;
+    for (0..complex_input.atomCount()) |i| {
+        atom_sasa_isolated[i] = if (atomSelectedByChains(complex_input, i, selection.partner_a)) blk: {
+            defer a_index += 1;
+            break :blk partner_a_areas[a_index];
+        } else blk: {
+            defer b_index += 1;
+            break :blk partner_b_areas[b_index];
+        };
+        atom_delta_sasa[i] = atom_sasa_isolated[i] - complex_areas[i];
+    }
+
+    var residue_arrays = BsaResidueDeltaArrays{};
+    if (std.mem.eql(u8, level, "residue")) {
+        residue_arrays = buildBsaResidueDeltaArrays(
+            allocator,
+            complex_input,
+            atom_sasa_isolated,
+            complex_areas,
+            selection.partner_a,
+        ) catch |err| {
+            const message = try std.fmt.allocPrint(allocator, "residue detail failed: {s}", .{@errorName(err)});
+            return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, message);
+        };
+    }
+
+    var atom_arrays = BsaAtomArrays{};
+    if (atom_output) {
+        atom_arrays = buildBsaAtomArrays(allocator, complex_input, selection.partner_a) catch |err| {
+            const message = try std.fmt.allocPrint(allocator, "atom detail failed: {s}", .{@errorName(err)});
+            return writeBsaInterfaceError(io, jsonl_file, allocator, filename, selection.id, name, message);
+        };
+    }
+
+    const delta_total = partner_a_result.total_sasa + partner_b_result.total_sasa - complex_result.total_sasa;
+    try appendBsaAnalysisJsonlToFile(io, jsonl_file, allocator, .{
+        .filename = filename,
+        .id = selection.id,
+        .name = name,
+        .partner_a = selection.partner_a,
+        .partner_b = selection.partner_b,
+        .sasa_partner_a = partner_a_result.total_sasa,
+        .sasa_partner_b = partner_b_result.total_sasa,
+        .sasa_complex = complex_result.total_sasa,
+        .delta_sasa_total = delta_total,
+        .bsa = delta_total / 2.0,
+        .delta_sasa_level = level,
+        .atom_output = atom_output,
+        .residue_partner = residue_arrays.residue_partner,
+        .residue_chain = residue_arrays.residue_chain,
+        .residue_name = residue_arrays.residue_name,
+        .residue_number = residue_arrays.residue_number,
+        .residue_insertion_code = residue_arrays.residue_insertion_code,
+        .residue_sasa_isolated = residue_arrays.residue_sasa_isolated,
+        .residue_sasa_complex = residue_arrays.residue_sasa_complex,
+        .residue_delta_sasa = residue_arrays.residue_delta_sasa,
+        .atom_index = atom_arrays.atom_index,
+        .atom_partner = atom_arrays.atom_partner,
+        .atom_chain = atom_arrays.atom_chain,
+        .atom_residue_name = atom_arrays.atom_residue_name,
+        .atom_residue_number = atom_arrays.atom_residue_number,
+        .atom_insertion_code = atom_arrays.atom_insertion_code,
+        .atom_name = atom_arrays.atom_name,
+        .atom_element = atom_arrays.atom_element,
+        .atom_sasa_isolated = if (atom_output) atom_sasa_isolated else &.{},
+        .atom_sasa_complex = if (atom_output) complex_areas else &.{},
+        .atom_delta_sasa = if (atom_output) atom_delta_sasa else &.{},
+    }, jsonlOptions(config));
+
+    return .{
+        .successful = true,
+        .sasa_time_ns = partner_a_result.sasa_time_ns + partner_b_result.sasa_time_ns + complex_result.sasa_time_ns,
+    };
+}
+
 fn runWorkflowBsaAnalysis(
     allocator: Allocator,
     io: std.Io,
@@ -3571,6 +3840,7 @@ fn runWorkflowBsaAnalysis(
     const fixed_partner_a = analysis.partner_a;
     const fixed_partner_b = analysis.partner_b;
     const level = analysisLevel(analysis);
+    const atom_output = analysis.atom_output orelse false;
     const name = analysisName(analysis);
 
     if (workflow.output.format) |format| {
@@ -3672,154 +3942,171 @@ fn runWorkflowBsaAnalysis(
     var failed: usize = 0;
     var total_sasa_time_ns: u64 = 0;
 
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
+    var discovered_files = std.StringHashMapUnmanaged(void){};
+    defer discovered_files.deinit(allocator);
+    for (files) |filename| try discovered_files.put(allocator, filename, {});
 
     for (files) |filename| {
-        var partner_a = fixed_partner_a orelse &.{};
-        var partner_b = fixed_partner_b orelse &.{};
+        var source_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer source_arena.deinit();
+
+        const map_indices: ?[]const usize = if (interface_map) |*map| map.getIndices(filename) else null;
+        if (interface_map != null and map_indices == null) {
+            var error_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer error_arena.deinit();
+            const stats = try writeBsaInterfaceError(
+                io,
+                jsonl_file,
+                error_arena.allocator(),
+                filename,
+                filename,
+                name,
+                "interface chain map entry not found",
+            );
+            _ = stats;
+            failed += 1;
+            continue;
+        }
+
         var source_config = config;
         source_config.chain_filter = null;
         if (interface_map) |*map| {
-            const selection = map.get(filename) orelse {
-                failed += 1;
-                std.debug.print("Error running BSA analysis '{s}' on '{s}': interface chain map entry not found\n", .{ name, filename });
-                _ = arena.reset(.retain_capacity);
-                continue;
-            };
-            partner_a = selection.partner_a;
-            partner_b = selection.partner_b;
-            source_config.use_auth_chain = selection.asym_id_type == .auth;
-        }
-        const complex_chains = try appendChainGroups(arena.allocator(), partner_a, partner_b);
-        const input_path = try std.fs.path.join(arena.allocator(), &.{ input_dir, filename });
-
-        var source_parsed = readInputFile(arena.allocator(), io, input_path, source_config) catch |err| {
-            failed += 1;
-            std.debug.print("Error running BSA analysis '{s}' on '{s}': read/parse failed: {s}\n", .{ name, filename, @errorName(err) });
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-
-        workflowClassifySourceInput(&source_parsed.input, source_parsed.inlineCcdPtr(), input_path, source_config) catch |err| {
-            failed += 1;
-            std.debug.print("Error running BSA analysis '{s}' on '{s}': classifier failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-
-        const partner_a_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, partner_a) catch |err| {
-            failed += 1;
-            std.debug.print("Error running BSA analysis '{s}' on '{s}': partner A selection failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-        const partner_b_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, partner_b) catch |err| {
-            failed += 1;
-            std.debug.print("Error running BSA analysis '{s}' on '{s}': partner B selection failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-        const complex_input = copySelectedAtomInput(arena.allocator(), source_parsed.input, complex_chains) catch |err| {
-            failed += 1;
-            std.debug.print("Error running BSA analysis '{s}' on '{s}': complex selection failed: {s}\n", .{ name, filename, @errorName(err) });
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-
-        const n_threads = effectiveWorkflowSasaThreads(config);
-        const partner_a_result = switch (config.precision) {
-            .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, arena.allocator(), partner_a_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
-            .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, arena.allocator(), partner_a_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
-        };
-        const partner_b_result = switch (config.precision) {
-            .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, arena.allocator(), partner_b_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
-            .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, arena.allocator(), partner_b_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
-        };
-        const complex_result = switch (config.precision) {
-            .f64 => calculatePreparedInputResult(f64, arena.allocator(), io, arena.allocator(), complex_input, null, filename, config, n_threads, luts.f64Ptr(), luts.coarseF64Ptr(), luts.fineF64Ptr()),
-            .f32 => calculatePreparedInputResult(f32, arena.allocator(), io, arena.allocator(), complex_input, null, filename, config, n_threads, luts.f32Ptr(), luts.coarseF32Ptr(), luts.fineF32Ptr()),
-        };
-
-        if (partner_a_result.status != .ok or partner_b_result.status != .ok or complex_result.status != .ok) {
-            failed += 1;
-            std.debug.print("Error running BSA analysis '{s}' on '{s}': SASA calculation failed\n", .{ name, filename });
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        }
-
-        const partner_a_areas = partner_a_result.atom_areas orelse {
-            failed += 1;
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-        const partner_b_areas = partner_b_result.atom_areas orelse {
-            failed += 1;
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-        const complex_areas = complex_result.atom_areas orelse {
-            failed += 1;
-            source_parsed.deinit();
-            _ = arena.reset(.retain_capacity);
-            continue;
-        };
-
-        const delta_total = partner_a_result.total_sasa + partner_b_result.total_sasa - complex_result.total_sasa;
-        const bsa = delta_total / 2.0;
-
-        var residue_arrays = BsaResidueDeltaArrays{};
-        if (std.mem.eql(u8, level, "residue")) {
-            const atom_delta_sasa = try arena.allocator().alloc(f64, complex_input.atomCount());
-            var a_index: usize = 0;
-            var b_index: usize = 0;
-            for (0..complex_input.atomCount()) |i| {
-                if (atomSelectedByChains(complex_input, i, partner_a)) {
-                    atom_delta_sasa[i] = partner_a_areas[a_index] - complex_areas[i];
-                    a_index += 1;
-                } else {
-                    atom_delta_sasa[i] = partner_b_areas[b_index] - complex_areas[i];
-                    b_index += 1;
+            const indices = map_indices.?;
+            const first_type = map.entries[indices[0]].asym_id_type;
+            var mixed_asym_id_type = false;
+            for (indices[1..]) |entry_index| {
+                if (map.entries[entry_index].asym_id_type != first_type) {
+                    mixed_asym_id_type = true;
+                    break;
                 }
             }
-            residue_arrays = buildBsaResidueDeltaArrays(arena.allocator(), complex_input, atom_delta_sasa) catch |err| {
-                failed += 1;
-                std.debug.print("Error running BSA analysis '{s}' on '{s}': residue delta map failed: {s}\n", .{ name, filename, @errorName(err) });
-                source_parsed.deinit();
-                _ = arena.reset(.retain_capacity);
+            if (mixed_asym_id_type) {
+                for (indices) |entry_index| {
+                    var error_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+                    defer error_arena.deinit();
+                    const entry = map.entries[entry_index];
+                    _ = try writeBsaInterfaceError(
+                        io,
+                        jsonl_file,
+                        error_arena.allocator(),
+                        filename,
+                        entry.id orelse filename,
+                        name,
+                        "interfaces for one file must use the same asym_id_type",
+                    );
+                    failed += 1;
+                }
                 continue;
-            };
+            }
+            source_config.use_auth_chain = first_type == .auth;
         }
+        const input_path = try std.fs.path.join(source_arena.allocator(), &.{ input_dir, filename });
 
-        try appendBsaAnalysisJsonlToFile(io, jsonl_file, arena.allocator(), .{
-            .filename = filename,
-            .name = name,
-            .partner_a = partner_a,
-            .partner_b = partner_b,
-            .sasa_partner_a = partner_a_result.total_sasa,
-            .sasa_partner_b = partner_b_result.total_sasa,
-            .sasa_complex = complex_result.total_sasa,
-            .delta_sasa_total = delta_total,
-            .bsa = bsa,
-            .delta_sasa_level = level,
-            .residue_chain = residue_arrays.residue_chain,
-            .residue_name = residue_arrays.residue_name,
-            .residue_number = residue_arrays.residue_number,
-            .residue_insertion_code = residue_arrays.residue_insertion_code,
-            .residue_delta_sasa = residue_arrays.residue_delta_sasa,
-        }, jsonlOptions(config));
+        var source_parsed = readInputFile(source_arena.allocator(), io, input_path, source_config) catch |err| {
+            const message = try std.fmt.allocPrint(source_arena.allocator(), "read/parse failed: {s}", .{@errorName(err)});
+            if (interface_map) |*map| {
+                for (map_indices.?) |entry_index| {
+                    const entry = map.entries[entry_index];
+                    _ = try writeBsaInterfaceError(io, jsonl_file, source_arena.allocator(), filename, entry.id orelse filename, name, message);
+                    failed += 1;
+                }
+            } else {
+                _ = try writeBsaInterfaceError(io, jsonl_file, source_arena.allocator(), filename, filename, name, message);
+                failed += 1;
+            }
+            continue;
+        };
+        defer source_parsed.deinit();
 
-        successful += 1;
-        total_sasa_time_ns += partner_a_result.sasa_time_ns + partner_b_result.sasa_time_ns + complex_result.sasa_time_ns;
-        source_parsed.deinit();
-        _ = arena.reset(.retain_capacity);
+        workflowClassifySourceInput(&source_parsed.input, source_parsed.inlineCcdPtr(), input_path, source_config) catch |err| {
+            const message = try std.fmt.allocPrint(source_arena.allocator(), "classifier failed: {s}", .{@errorName(err)});
+            if (interface_map) |*map| {
+                for (map_indices.?) |entry_index| {
+                    const entry = map.entries[entry_index];
+                    _ = try writeBsaInterfaceError(io, jsonl_file, source_arena.allocator(), filename, entry.id orelse filename, name, message);
+                    failed += 1;
+                }
+            } else {
+                _ = try writeBsaInterfaceError(io, jsonl_file, source_arena.allocator(), filename, filename, name, message);
+                failed += 1;
+            }
+            continue;
+        };
+
+        if (interface_map) |*map| {
+            for (map_indices.?) |entry_index| {
+                const entry = map.entries[entry_index];
+                var interface_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+                defer interface_arena.deinit();
+                const stats = try processBsaInterface(
+                    interface_arena.allocator(),
+                    io,
+                    jsonl_file,
+                    filename,
+                    name,
+                    level,
+                    atom_output,
+                    .{
+                        .id = entry.id orelse filename,
+                        .partner_a = entry.partner_a,
+                        .partner_b = entry.partner_b,
+                    },
+                    source_parsed.input,
+                    config,
+                    &luts,
+                );
+                if (stats.successful) {
+                    successful += 1;
+                    total_sasa_time_ns += stats.sasa_time_ns;
+                } else {
+                    failed += 1;
+                }
+            }
+        } else {
+            var interface_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer interface_arena.deinit();
+            const stats = try processBsaInterface(
+                interface_arena.allocator(),
+                io,
+                jsonl_file,
+                filename,
+                name,
+                level,
+                atom_output,
+                .{
+                    .id = filename,
+                    .partner_a = fixed_partner_a.?,
+                    .partner_b = fixed_partner_b.?,
+                },
+                source_parsed.input,
+                config,
+                &luts,
+            );
+            if (stats.successful) {
+                successful += 1;
+                total_sasa_time_ns += stats.sasa_time_ns;
+            } else {
+                failed += 1;
+            }
+        }
+    }
+
+    if (interface_map) |*map| {
+        for (map.entries) |entry| {
+            if (discovered_files.contains(entry.filename)) continue;
+            var error_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer error_arena.deinit();
+            _ = try writeBsaInterfaceError(
+                io,
+                jsonl_file,
+                error_arena.allocator(),
+                entry.filename,
+                entry.id orelse entry.filename,
+                name,
+                "input structure not found",
+            );
+            failed += 1;
+        }
     }
 
     if (config.show_timing) {
@@ -5588,6 +5875,8 @@ test "workflow BSA analysis uses per-file multi-chain interface map" {
     defer parsed.deinit();
     const object = parsed.value.object;
 
+    try std.testing.expectEqualStrings("ok", object.get("status").?.string);
+    try std.testing.expectEqualStrings("abcd.cif", object.get("id").?.string);
     const partner_a = object.get("partner_a").?.array.items;
     const partner_b = object.get("partner_b").?.array.items;
     try std.testing.expectEqual(@as(usize, 2), partner_a.len);
@@ -5601,6 +5890,165 @@ test "workflow BSA analysis uses per-file multi-chain interface map" {
     try std.testing.expectEqual(@as(usize, 4), residue_chains.len);
     try std.testing.expectEqualStrings("A", residue_chains[0].string);
     try std.testing.expectEqualStrings("D", residue_chains[3].string);
+    try std.testing.expectEqual(@as(usize, 4), object.get("residue_partner").?.array.items.len);
+    try std.testing.expectEqual(@as(usize, 4), object.get("residue_sasa_isolated").?.array.items.len);
+    try std.testing.expectEqual(@as(usize, 4), object.get("residue_sasa_complex").?.array.items.len);
+}
+
+fn testJsonNumber(value: std.json.Value) f64 {
+    return switch (value) {
+        .float => |number| number,
+        .integer => |number| @floatFromInt(number),
+        else => unreachable,
+    };
+}
+
+fn testJsonNumberArraySum(values: std.json.Array) f64 {
+    var total: f64 = 0;
+    for (values.items) |value| total += testJsonNumber(value);
+    return total;
+}
+
+test "workflow BSA analysis emits one detailed row per interface and stable error IDs" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const output_dir = try std.fs.path.join(allocator, &.{ root, "output" });
+    defer allocator.free(output_dir);
+    const pdb_path = try std.fs.path.join(allocator, &.{ input_dir, "multi.pdb" });
+    defer allocator.free(pdb_path);
+    const map_path = try std.fs.path.join(allocator, &.{ root, "interfaces.csv" });
+    defer allocator.free(map_path);
+    const workflow_path = try std.fs.path.join(allocator, &.{ root, "bsa-multi.toml" });
+    defer allocator.free(workflow_path);
+
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = pdb_path,
+        .data = "ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00 20.00           N  \n" ++
+            "ATOM      2  CA  GLY A   1       1.500   0.000   0.000  1.00 20.00           C  \n" ++
+            "ATOM      3  N   ALA B   2       3.000   0.000   0.000  1.00 20.00           N  \n" ++
+            "ATOM      4  CA  ALA B   2       4.500   0.000   0.000  1.00 20.00           C  \n" ++
+            "ATOM      5  N   SER C   3       6.000   0.000   0.000  1.00 20.00           N  \n" ++
+            "ATOM      6  CA  SER C   3       7.500   0.000   0.000  1.00 20.00           C  \n" ++
+            "END\n",
+    });
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = map_path,
+        .data =
+        \\filename,id,partner_a,partner_b,asym_id_type
+        \\multi.pdb,interface-ab,A,B,label
+        \\multi.pdb,interface-cb,C,B,label
+        \\multi.pdb,interface-invalid,Z,B,label
+        \\missing.pdb,interface-missing,A,B,label
+        \\
+        ,
+    });
+
+    const workflow = try std.fmt.allocPrint(allocator,
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[input]
+        \\dir = "{s}"
+        \\
+        \\[output]
+        \\dir = "{s}"
+        \\format = "jsonl"
+        \\
+        \\[calculation]
+        \\n_points = 16
+        \\quiet = true
+        \\
+        \\[classifier]
+        \\type = "naccess"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\name = "interfaces"
+        \\chain_map = "{s}"
+        \\level = "residue"
+        \\atom_output = true
+        \\
+    , .{ input_dir, output_dir, map_path });
+    defer allocator.free(workflow);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = workflow_path, .data = workflow });
+
+    try runWorkflow(allocator, std.testing.io, .{ .workflow_path = workflow_path });
+
+    const output_path = try std.fs.path.join(allocator, &.{ output_dir, "interfaces.jsonl" });
+    defer allocator.free(output_path);
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(65536));
+    defer allocator.free(content);
+
+    var row_count: usize = 0;
+    var ok_count: usize = 0;
+    var error_count: usize = 0;
+    var saw_invalid = false;
+    var saw_missing = false;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        row_count += 1;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const object = parsed.value.object;
+        const status = object.get("status").?.string;
+        const id = object.get("id").?.string;
+        if (std.mem.eql(u8, status, "err")) {
+            error_count += 1;
+            if (std.mem.eql(u8, id, "interface-invalid")) saw_invalid = true;
+            if (std.mem.eql(u8, id, "interface-missing")) saw_missing = true;
+            try std.testing.expect(object.get("error") != null);
+            continue;
+        }
+
+        ok_count += 1;
+        try std.testing.expect(std.mem.eql(u8, id, "interface-ab") or std.mem.eql(u8, id, "interface-cb"));
+        const atom_isolated = object.get("atom_sasa_isolated").?.array;
+        const atom_complex = object.get("atom_sasa_complex").?.array;
+        const atom_delta = object.get("atom_delta_sasa").?.array;
+        try std.testing.expectEqual(atom_isolated.items.len, atom_complex.items.len);
+        try std.testing.expectEqual(atom_isolated.items.len, atom_delta.items.len);
+        try std.testing.expectEqual(atom_isolated.items.len, object.get("atom_partner").?.array.items.len);
+        try std.testing.expectApproxEqAbs(
+            testJsonNumberArraySum(atom_isolated) - testJsonNumberArraySum(atom_complex),
+            testJsonNumberArraySum(atom_delta),
+            1e-9,
+        );
+
+        const residue_isolated = object.get("residue_sasa_isolated").?.array;
+        const residue_complex = object.get("residue_sasa_complex").?.array;
+        const residue_delta = object.get("residue_delta_sasa").?.array;
+        try std.testing.expectApproxEqAbs(
+            testJsonNumberArraySum(residue_isolated) - testJsonNumberArraySum(residue_complex),
+            testJsonNumberArraySum(residue_delta),
+            1e-9,
+        );
+        try std.testing.expectApproxEqAbs(
+            testJsonNumber(object.get("delta_sasa_total").?),
+            testJsonNumberArraySum(atom_delta),
+            1e-9,
+        );
+        try std.testing.expectApproxEqAbs(
+            testJsonNumber(object.get("delta_sasa_total").?) / 2.0,
+            testJsonNumber(object.get("bsa").?),
+            1e-9,
+        );
+    }
+
+    try std.testing.expectEqual(@as(usize, 4), row_count);
+    try std.testing.expectEqual(@as(usize, 2), ok_count);
+    try std.testing.expectEqual(@as(usize, 2), error_count);
+    try std.testing.expect(saw_invalid);
+    try std.testing.expect(saw_missing);
 }
 
 test "workflow mmCIF chain filters preserve long chain IDs" {

--- a/src/chain_map.zig
+++ b/src/chain_map.zig
@@ -45,12 +45,14 @@ pub const ChainMap = struct {
 
 pub const InterfaceEntry = struct {
     filename: []const u8,
+    id: ?[]const u8,
     partner_a: []const []const u8,
     partner_b: []const []const u8,
     asym_id_type: AsymIdType,
 
     fn deinit(self: InterfaceEntry, allocator: Allocator) void {
         allocator.free(self.filename);
+        if (self.id) |id| allocator.free(id);
         freeChains(allocator, self.partner_a);
         freeChains(allocator, self.partner_b);
     }
@@ -59,18 +61,26 @@ pub const InterfaceEntry = struct {
 pub const InterfaceMap = struct {
     allocator: Allocator,
     entries: []InterfaceEntry,
-    index: std.StringHashMapUnmanaged(usize),
+    index: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(usize)),
 
     pub fn deinit(self: *InterfaceMap) void {
+        var values = self.index.valueIterator();
+        while (values.next()) |indices| indices.deinit(self.allocator);
         self.index.deinit(self.allocator);
         for (self.entries) |entry| entry.deinit(self.allocator);
         self.allocator.free(self.entries);
         self.* = undefined;
     }
 
+    pub fn getIndices(self: *const InterfaceMap, filename: []const u8) ?[]const usize {
+        const indices = self.index.get(filename) orelse return null;
+        return indices.items;
+    }
+
+    /// Return the first interface for compatibility with one-row-per-file maps.
     pub fn get(self: *const InterfaceMap, filename: []const u8) ?InterfaceEntry {
-        const index = self.index.get(filename) orelse return null;
-        return self.entries[index];
+        const indices = self.getIndices(filename) orelse return null;
+        return self.entries[indices[0]];
     }
 };
 
@@ -169,6 +179,7 @@ pub fn parseInterfaceCsv(allocator: Allocator, content: []const u8) !InterfaceMa
     defer if (header) |fields| freeFields(allocator, fields);
 
     var filename_col: ?usize = null;
+    var id_col: ?usize = null;
     var partner_a_col: ?usize = null;
     var partner_b_col: ?usize = null;
     var asym_id_type_col: ?usize = null;
@@ -183,6 +194,7 @@ pub fn parseInterfaceCsv(allocator: Allocator, content: []const u8) !InterfaceMa
             for (fields, 0..) |field, i| {
                 const normalized = if (i == 0) std.mem.trimStart(u8, field, "\xEF\xBB\xBF") else field;
                 if (std.ascii.eqlIgnoreCase(normalized, "filename")) filename_col = i;
+                if (std.ascii.eqlIgnoreCase(normalized, "id")) id_col = i;
                 if (std.ascii.eqlIgnoreCase(normalized, "partner_a")) partner_a_col = i;
                 if (std.ascii.eqlIgnoreCase(normalized, "partner_b")) partner_b_col = i;
                 if (std.ascii.eqlIgnoreCase(normalized, "asym_id_type")) asym_id_type_col = i;
@@ -209,6 +221,7 @@ pub fn parseInterfaceCsv(allocator: Allocator, content: []const u8) !InterfaceMa
             allocator,
             &entries,
             fields[filename_col.?],
+            if (id_col) |col| fields[col] else null,
             fields[partner_a_col.?],
             fields[partner_b_col.?],
             asym_id_type,
@@ -221,6 +234,7 @@ pub fn parseInterfaceCsv(allocator: Allocator, content: []const u8) !InterfaceMa
 
 const JsonInterfaceEntry = struct {
     filename: []const u8,
+    id: ?[]const u8 = null,
     partner_a: []const []const u8,
     partner_b: []const []const u8,
     asym_id_type: ?[]const u8 = null,
@@ -239,6 +253,7 @@ pub fn parseInterfaceJson(allocator: Allocator, content: []const u8) !InterfaceM
             allocator,
             &entries,
             json_entry.filename,
+            json_entry.id,
             json_entry.partner_a,
             json_entry.partner_b,
             asym_id_type,
@@ -281,6 +296,7 @@ fn appendInterfaceEntryCsv(
     allocator: Allocator,
     entries: *std.ArrayListUnmanaged(InterfaceEntry),
     filename_value: []const u8,
+    id_value: ?[]const u8,
     partner_a_value: []const u8,
     partner_b_value: []const u8,
     asym_id_type: AsymIdType,
@@ -289,13 +305,14 @@ fn appendInterfaceEntryCsv(
     errdefer freeChains(allocator, partner_a);
     const partner_b = try parseCommaSeparatedChains(allocator, partner_b_value);
     errdefer freeChains(allocator, partner_b);
-    try appendOwnedInterfaceEntry(allocator, entries, filename_value, partner_a, partner_b, asym_id_type);
+    try appendOwnedInterfaceEntry(allocator, entries, filename_value, id_value, partner_a, partner_b, asym_id_type);
 }
 
 fn appendInterfaceEntryJson(
     allocator: Allocator,
     entries: *std.ArrayListUnmanaged(InterfaceEntry),
     filename_value: []const u8,
+    id_value: ?[]const u8,
     partner_a_values: []const []const u8,
     partner_b_values: []const []const u8,
     asym_id_type: AsymIdType,
@@ -304,7 +321,7 @@ fn appendInterfaceEntryJson(
     errdefer freeChains(allocator, partner_a);
     const partner_b = try dupeChains(allocator, partner_b_values);
     errdefer freeChains(allocator, partner_b);
-    try appendOwnedInterfaceEntry(allocator, entries, filename_value, partner_a, partner_b, asym_id_type);
+    try appendOwnedInterfaceEntry(allocator, entries, filename_value, id_value, partner_a, partner_b, asym_id_type);
 }
 
 fn appendOwnedEntry(
@@ -328,6 +345,7 @@ fn appendOwnedInterfaceEntry(
     allocator: Allocator,
     entries: *std.ArrayListUnmanaged(InterfaceEntry),
     filename_value: []const u8,
+    id_value: ?[]const u8,
     partner_a: []const []const u8,
     partner_b: []const []const u8,
     asym_id_type: AsymIdType,
@@ -335,8 +353,14 @@ fn appendOwnedInterfaceEntry(
     const filename = try validateFilename(filename_value);
     const owned_filename = try allocator.dupe(u8, filename);
     errdefer allocator.free(owned_filename);
+    const owned_id = if (id_value) |value| blk: {
+        const id = std.mem.trim(u8, value, " \t\r");
+        break :blk if (id.len == 0) null else try allocator.dupe(u8, try validateInterfaceId(id));
+    } else null;
+    errdefer if (owned_id) |id| allocator.free(id);
     try entries.append(allocator, .{
         .filename = owned_filename,
+        .id = owned_id,
         .partner_a = partner_a,
         .partner_b = partner_b,
         .asym_id_type = asym_id_type,
@@ -371,11 +395,30 @@ fn finishInterface(allocator: Allocator, entries: *std.ArrayListUnmanaged(Interf
         allocator.free(owned_entries);
     }
 
-    var index = std.StringHashMapUnmanaged(usize){};
-    errdefer index.deinit(allocator);
+    var index = std.StringHashMapUnmanaged(std.ArrayListUnmanaged(usize)){};
+    errdefer {
+        var values = index.valueIterator();
+        while (values.next()) |indices| indices.deinit(allocator);
+        index.deinit(allocator);
+    }
     for (owned_entries, 0..) |entry, i| {
-        if (index.contains(entry.filename)) return error.DuplicateFilename;
-        try index.put(allocator, entry.filename, i);
+        const result = try index.getOrPut(allocator, entry.filename);
+        if (!result.found_existing) result.value_ptr.* = .empty;
+        try result.value_ptr.append(allocator, i);
+    }
+    var values = index.valueIterator();
+    while (values.next()) |indices| {
+        if (indices.items.len <= 1) continue;
+        for (indices.items) |entry_index| {
+            if (owned_entries[entry_index].id == null) return error.MissingInterfaceId;
+        }
+    }
+    var ids = std.StringHashMapUnmanaged(void){};
+    defer ids.deinit(allocator);
+    for (owned_entries) |entry| {
+        const id = entry.id orelse entry.filename;
+        if (ids.contains(id)) return error.DuplicateInterfaceId;
+        try ids.put(allocator, id, {});
     }
 
     return .{
@@ -401,6 +444,12 @@ fn validateFilename(filename_value: []const u8) ![]const u8 {
         return error.UnsafeFilename;
     }
     return filename;
+}
+
+fn validateInterfaceId(id_value: []const u8) ![]const u8 {
+    const id = std.mem.trim(u8, id_value, " \t\r");
+    if (id.len == 0) return error.EmptyInterfaceId;
+    return id;
 }
 
 fn parseCommaSeparatedChains(allocator: Allocator, value: []const u8) ![]const []const u8 {
@@ -587,7 +636,7 @@ test "parse CSV interface map with multi-chain partners" {
     );
     defer map.deinit();
 
-    const entry = map.get("1abc.cif").?;
+    const entry = map.entries[map.getIndices("1abc.cif").?[0]];
     try std.testing.expectEqual(@as(usize, 2), entry.partner_a.len);
     try std.testing.expectEqualStrings("A", entry.partner_a[0]);
     try std.testing.expectEqualStrings("B", entry.partner_a[1]);
@@ -610,8 +659,74 @@ test "parse JSON interface map" {
     );
     defer map.deinit();
 
-    const entry = map.get("1abc.cif").?;
+    const entry = map.entries[map.getIndices("1abc.cif").?[0]];
     try std.testing.expectEqualStrings("B", entry.partner_a[1]);
     try std.testing.expectEqualStrings("D", entry.partner_b[1]);
     try std.testing.expectEqual(AsymIdType.label, entry.asym_id_type);
+}
+
+test "parse multiple CSV interfaces for one filename with stable IDs" {
+    var map = try parseInterfaceCsv(
+        std.testing.allocator,
+        "filename,id,partner_a,partner_b,asym_id_type\n" ++
+            "1abc.cif,interaction-001,A,\"B,C\",label\n" ++
+            "1abc.cif,interaction-002,D,\"B,C\",label\n",
+    );
+    defer map.deinit();
+
+    const indices = map.getIndices("1abc.cif").?;
+    try std.testing.expectEqual(@as(usize, 2), indices.len);
+    try std.testing.expectEqualStrings("interaction-001", map.entries[indices[0]].id.?);
+    try std.testing.expectEqualStrings("interaction-002", map.entries[indices[1]].id.?);
+}
+
+test "parse multiple JSON interfaces for one filename with stable IDs" {
+    var map = try parseInterfaceJson(std.testing.allocator,
+        \\[
+        \\  {"filename":"1abc.cif","id":"one","partner_a":["A"],"partner_b":["B"]},
+        \\  {"filename":"1abc.cif","id":"two","partner_a":["C"],"partner_b":["D"]}
+        \\]
+    );
+    defer map.deinit();
+
+    const indices = map.getIndices("1abc.cif").?;
+    try std.testing.expectEqual(@as(usize, 2), indices.len);
+    try std.testing.expectEqualStrings("one", map.entries[indices[0]].id.?);
+    try std.testing.expectEqualStrings("two", map.entries[indices[1]].id.?);
+}
+
+test "require IDs when a filename has multiple interfaces" {
+    try std.testing.expectError(
+        error.MissingInterfaceId,
+        parseInterfaceCsv(
+            std.testing.allocator,
+            "filename,id,partner_a,partner_b\n" ++
+                "1abc.cif,one,A,B\n" ++
+                "1abc.cif,,C,D\n",
+        ),
+    );
+}
+
+test "reject duplicate interface IDs" {
+    try std.testing.expectError(
+        error.DuplicateInterfaceId,
+        parseInterfaceCsv(
+            std.testing.allocator,
+            "filename,id,partner_a,partner_b\n" ++
+                "1abc.cif,same,A,B\n" ++
+                "2xyz.cif,same,C,D\n",
+        ),
+    );
+}
+
+test "reject explicit interface ID that collides with legacy filename ID" {
+    try std.testing.expectError(
+        error.DuplicateInterfaceId,
+        parseInterfaceCsv(
+            std.testing.allocator,
+            "filename,id,partner_a,partner_b\n" ++
+                "1abc.cif,,A,B\n" ++
+                "2xyz.cif,1abc.cif,C,D\n",
+        ),
+    );
 }

--- a/src/json_writer.zig
+++ b/src/json_writer.zig
@@ -918,6 +918,7 @@ pub fn fileResultWithResidueMapToJsonlLineOptions(
 
 pub const BsaAnalysisJsonl = struct {
     filename: []const u8,
+    id: []const u8,
     name: []const u8,
     partner_a: []const []const u8,
     partner_b: []const []const u8,
@@ -927,24 +928,147 @@ pub const BsaAnalysisJsonl = struct {
     delta_sasa_total: f64,
     bsa: f64,
     delta_sasa_level: []const u8,
+    atom_output: bool = false,
+    residue_partner: []const []const u8 = &.{},
     residue_chain: []const []const u8 = &.{},
     residue_name: []const []const u8 = &.{},
     residue_number: []const i32 = &.{},
     residue_insertion_code: []const []const u8 = &.{},
+    residue_sasa_isolated: []const f64 = &.{},
+    residue_sasa_complex: []const f64 = &.{},
     residue_delta_sasa: []const f64 = &.{},
+    atom_index: []const usize = &.{},
+    atom_partner: []const []const u8 = &.{},
+    atom_chain: []const []const u8 = &.{},
+    atom_residue_name: []const []const u8 = &.{},
+    atom_residue_number: []const i32 = &.{},
+    atom_insertion_code: []const []const u8 = &.{},
+    atom_name: []const []const u8 = &.{},
+    atom_element: []const []const u8 = &.{},
+    atom_sasa_isolated: []const f64 = &.{},
+    atom_sasa_complex: []const f64 = &.{},
+    atom_delta_sasa: []const f64 = &.{},
 };
+
+pub const BsaAnalysisErrorJsonl = struct {
+    filename: []const u8,
+    id: []const u8,
+    name: []const u8,
+    error_message: []const u8,
+};
+
+pub fn bsaAnalysisErrorToJsonlLine(allocator: Allocator, row: BsaAnalysisErrorJsonl) ![]u8 {
+    const Entry = struct {
+        status: []const u8,
+        filename: []const u8,
+        id: []const u8,
+        analysis: []const u8,
+        name: []const u8,
+        @"error": []const u8,
+    };
+    return std.json.Stringify.valueAlloc(allocator, Entry{
+        .status = "err",
+        .filename = row.filename,
+        .id = row.id,
+        .analysis = "bsa",
+        .name = row.name,
+        .@"error" = row.error_message,
+    }, .{});
+}
 
 pub fn bsaAnalysisToJsonlLine(allocator: Allocator, row: BsaAnalysisJsonl) ![]u8 {
     return bsaAnalysisToJsonlLineOptions(allocator, row, .{});
 }
 
 pub fn bsaAnalysisToJsonlLineOptions(allocator: Allocator, row: BsaAnalysisJsonl, options: JsonlOptions) ![]u8 {
+    const output_residue_sasa_isolated = try maybeRoundJsonlFloatSlice(allocator, row.residue_sasa_isolated, options);
+    defer if (options.decimals != null) allocator.free(output_residue_sasa_isolated);
+    const output_residue_sasa_complex = try maybeRoundJsonlFloatSlice(allocator, row.residue_sasa_complex, options);
+    defer if (options.decimals != null) allocator.free(output_residue_sasa_complex);
     const output_residue_delta_sasa = try maybeRoundJsonlFloatSlice(allocator, row.residue_delta_sasa, options);
     defer if (options.decimals != null) allocator.free(output_residue_delta_sasa);
+    const output_atom_sasa_isolated = try maybeRoundJsonlFloatSlice(allocator, row.atom_sasa_isolated, options);
+    defer if (options.decimals != null) allocator.free(output_atom_sasa_isolated);
+    const output_atom_sasa_complex = try maybeRoundJsonlFloatSlice(allocator, row.atom_sasa_complex, options);
+    defer if (options.decimals != null) allocator.free(output_atom_sasa_complex);
+    const output_atom_delta_sasa = try maybeRoundJsonlFloatSlice(allocator, row.atom_delta_sasa, options);
+    defer if (options.decimals != null) allocator.free(output_atom_delta_sasa);
 
     if (std.mem.eql(u8, row.delta_sasa_level, "residue")) {
+        if (row.atom_output) {
+            const Entry = struct {
+                status: []const u8,
+                filename: []const u8,
+                id: []const u8,
+                analysis: []const u8,
+                name: []const u8,
+                partner_a: []const []const u8,
+                partner_b: []const []const u8,
+                sasa_partner_a: f64,
+                sasa_partner_b: f64,
+                sasa_complex: f64,
+                delta_sasa_total: f64,
+                bsa: f64,
+                delta_sasa_level: []const u8,
+                residue_partner: []const []const u8,
+                residue_chain: []const []const u8,
+                residue_name: []const []const u8,
+                residue_number: []const i32,
+                residue_insertion_code: []const []const u8,
+                residue_sasa_isolated: []const f64,
+                residue_sasa_complex: []const f64,
+                residue_delta_sasa: []const f64,
+                atom_index: []const usize,
+                atom_partner: []const []const u8,
+                atom_chain: []const []const u8,
+                atom_residue_name: []const []const u8,
+                atom_residue_number: []const i32,
+                atom_insertion_code: []const []const u8,
+                atom_name: []const []const u8,
+                atom_element: []const []const u8,
+                atom_sasa_isolated: []const f64,
+                atom_sasa_complex: []const f64,
+                atom_delta_sasa: []const f64,
+            };
+            return std.json.Stringify.valueAlloc(allocator, Entry{
+                .status = "ok",
+                .filename = row.filename,
+                .id = row.id,
+                .analysis = "bsa",
+                .name = row.name,
+                .partner_a = row.partner_a,
+                .partner_b = row.partner_b,
+                .sasa_partner_a = maybeRoundJsonlFloat(row.sasa_partner_a, options),
+                .sasa_partner_b = maybeRoundJsonlFloat(row.sasa_partner_b, options),
+                .sasa_complex = maybeRoundJsonlFloat(row.sasa_complex, options),
+                .delta_sasa_total = maybeRoundJsonlFloat(row.delta_sasa_total, options),
+                .bsa = maybeRoundJsonlFloat(row.bsa, options),
+                .delta_sasa_level = row.delta_sasa_level,
+                .residue_partner = row.residue_partner,
+                .residue_chain = row.residue_chain,
+                .residue_name = row.residue_name,
+                .residue_number = row.residue_number,
+                .residue_insertion_code = row.residue_insertion_code,
+                .residue_sasa_isolated = output_residue_sasa_isolated,
+                .residue_sasa_complex = output_residue_sasa_complex,
+                .residue_delta_sasa = output_residue_delta_sasa,
+                .atom_index = row.atom_index,
+                .atom_partner = row.atom_partner,
+                .atom_chain = row.atom_chain,
+                .atom_residue_name = row.atom_residue_name,
+                .atom_residue_number = row.atom_residue_number,
+                .atom_insertion_code = row.atom_insertion_code,
+                .atom_name = row.atom_name,
+                .atom_element = row.atom_element,
+                .atom_sasa_isolated = output_atom_sasa_isolated,
+                .atom_sasa_complex = output_atom_sasa_complex,
+                .atom_delta_sasa = output_atom_delta_sasa,
+            }, .{});
+        }
         const Entry = struct {
+            status: []const u8,
             filename: []const u8,
+            id: []const u8,
             analysis: []const u8,
             name: []const u8,
             partner_a: []const []const u8,
@@ -955,14 +1079,19 @@ pub fn bsaAnalysisToJsonlLineOptions(allocator: Allocator, row: BsaAnalysisJsonl
             delta_sasa_total: f64,
             bsa: f64,
             delta_sasa_level: []const u8,
+            residue_partner: []const []const u8,
             residue_chain: []const []const u8,
             residue_name: []const []const u8,
             residue_number: []const i32,
             residue_insertion_code: []const []const u8,
+            residue_sasa_isolated: []const f64,
+            residue_sasa_complex: []const f64,
             residue_delta_sasa: []const f64,
         };
         return std.json.Stringify.valueAlloc(allocator, Entry{
+            .status = "ok",
             .filename = row.filename,
+            .id = row.id,
             .analysis = "bsa",
             .name = row.name,
             .partner_a = row.partner_a,
@@ -973,16 +1102,21 @@ pub fn bsaAnalysisToJsonlLineOptions(allocator: Allocator, row: BsaAnalysisJsonl
             .delta_sasa_total = maybeRoundJsonlFloat(row.delta_sasa_total, options),
             .bsa = maybeRoundJsonlFloat(row.bsa, options),
             .delta_sasa_level = row.delta_sasa_level,
+            .residue_partner = row.residue_partner,
             .residue_chain = row.residue_chain,
             .residue_name = row.residue_name,
             .residue_number = row.residue_number,
             .residue_insertion_code = row.residue_insertion_code,
+            .residue_sasa_isolated = output_residue_sasa_isolated,
+            .residue_sasa_complex = output_residue_sasa_complex,
             .residue_delta_sasa = output_residue_delta_sasa,
         }, .{});
     }
 
     const Entry = struct {
+        status: []const u8,
         filename: []const u8,
+        id: []const u8,
         analysis: []const u8,
         name: []const u8,
         partner_a: []const []const u8,
@@ -995,7 +1129,9 @@ pub fn bsaAnalysisToJsonlLineOptions(allocator: Allocator, row: BsaAnalysisJsonl
         delta_sasa_level: []const u8,
     };
     return std.json.Stringify.valueAlloc(allocator, Entry{
+        .status = "ok",
         .filename = row.filename,
+        .id = row.id,
         .analysis = "bsa",
         .name = row.name,
         .partner_a = row.partner_a,
@@ -1223,10 +1359,14 @@ test "BSA analysis JSONL includes total and residue delta fields" {
     const residue_name = [_][]const u8{ "GLY", "ALA" };
     const residue_number = [_]i32{ 1, 2 };
     const residue_insertion_code = [_][]const u8{ "", "" };
+    const residue_partner = [_][]const u8{ "a", "b" };
+    const residue_sasa_isolated = [_]f64{ 7.0, 9.0 };
+    const residue_sasa_complex = [_]f64{ 4.0, 4.0 };
     const residue_delta_sasa = [_]f64{ 3.0, 5.0 };
 
     const line = try bsaAnalysisToJsonlLine(allocator, .{
         .filename = "tiny.pdb",
+        .id = "interaction-001",
         .name = "interface_ab",
         .partner_a = partner_a[0..],
         .partner_b = partner_b[0..],
@@ -1236,18 +1376,26 @@ test "BSA analysis JSONL includes total and residue delta fields" {
         .delta_sasa_total = 16.0,
         .bsa = 8.0,
         .delta_sasa_level = "residue",
+        .residue_partner = residue_partner[0..],
         .residue_chain = residue_chain[0..],
         .residue_name = residue_name[0..],
         .residue_number = residue_number[0..],
         .residue_insertion_code = residue_insertion_code[0..],
+        .residue_sasa_isolated = residue_sasa_isolated[0..],
+        .residue_sasa_complex = residue_sasa_complex[0..],
         .residue_delta_sasa = residue_delta_sasa[0..],
     });
     defer allocator.free(line);
 
     try std.testing.expect(std.mem.indexOf(u8, line, "\"analysis\":\"bsa\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"status\":\"ok\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"id\":\"interaction-001\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"delta_sasa_total\":16") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"bsa\":8") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_delta_sasa\":[3,5]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_partner\":[\"a\",\"b\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_sasa_isolated\":[7,9]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_sasa_complex\":[4,4]") != null);
 }
 
 test "BSA analysis JSONL rounds floats when decimals option is set" {
@@ -1258,6 +1406,7 @@ test "BSA analysis JSONL rounds floats when decimals option is set" {
 
     const line = try bsaAnalysisToJsonlLineOptions(allocator, .{
         .filename = "tiny.pdb",
+        .id = "tiny.pdb",
         .name = "interface_ab",
         .partner_a = partner_a[0..],
         .partner_b = partner_b[0..],
@@ -1277,6 +1426,71 @@ test "BSA analysis JSONL rounds floats when decimals option is set" {
     try std.testing.expect(std.mem.indexOf(u8, line, "\"delta_sasa_total\":16.67") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"bsa\":8.33") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"residue_delta_sasa\":[3.14,5.56]") != null);
+}
+
+test "BSA analysis JSONL includes opt-in atom detail" {
+    const allocator = std.testing.allocator;
+    const partner_a = [_][]const u8{"A"};
+    const partner_b = [_][]const u8{"B"};
+    const atom_index = [_]usize{ 0, 1 };
+    const atom_partner = [_][]const u8{ "a", "b" };
+    const atom_chain = [_][]const u8{ "A", "B" };
+    const atom_residue_name = [_][]const u8{ "GLY", "ALA" };
+    const atom_residue_number = [_]i32{ 1, 2 };
+    const atom_insertion_code = [_][]const u8{ "", "" };
+    const atom_name = [_][]const u8{ "CA", "N" };
+    const atom_element = [_][]const u8{ "C", "N" };
+    const atom_sasa_isolated = [_]f64{ 7.0, 9.0 };
+    const atom_sasa_complex = [_]f64{ 4.0, 4.0 };
+    const atom_delta_sasa = [_]f64{ 3.0, 5.0 };
+
+    const line = try bsaAnalysisToJsonlLine(allocator, .{
+        .filename = "tiny.pdb",
+        .id = "atoms",
+        .name = "interface_ab",
+        .partner_a = partner_a[0..],
+        .partner_b = partner_b[0..],
+        .sasa_partner_a = 10.0,
+        .sasa_partner_b = 20.0,
+        .sasa_complex = 14.0,
+        .delta_sasa_total = 16.0,
+        .bsa = 8.0,
+        .delta_sasa_level = "residue",
+        .atom_output = true,
+        .atom_index = atom_index[0..],
+        .atom_partner = atom_partner[0..],
+        .atom_chain = atom_chain[0..],
+        .atom_residue_name = atom_residue_name[0..],
+        .atom_residue_number = atom_residue_number[0..],
+        .atom_insertion_code = atom_insertion_code[0..],
+        .atom_name = atom_name[0..],
+        .atom_element = atom_element[0..],
+        .atom_sasa_isolated = atom_sasa_isolated[0..],
+        .atom_sasa_complex = atom_sasa_complex[0..],
+        .atom_delta_sasa = atom_delta_sasa[0..],
+    });
+    defer allocator.free(line);
+
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"atom_partner\":[\"a\",\"b\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"atom_element\":[\"C\",\"N\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"atom_sasa_isolated\":[7,9]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"atom_sasa_complex\":[4,4]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"atom_delta_sasa\":[3,5]") != null);
+}
+
+test "BSA analysis error JSONL includes stable ID" {
+    const line = try bsaAnalysisErrorToJsonlLine(std.testing.allocator, .{
+        .filename = "bad.cif",
+        .id = "interaction-bad",
+        .name = "interfaces",
+        .error_message = "read/parse failed: InvalidFormat",
+    });
+    defer std.testing.allocator.free(line);
+
+    try std.testing.expectEqualStrings(
+        "{\"status\":\"err\",\"filename\":\"bad.cif\",\"id\":\"interaction-bad\",\"analysis\":\"bsa\",\"name\":\"interfaces\",\"error\":\"read/parse failed: InvalidFormat\"}",
+        line,
+    );
 }
 
 test "sasaResultToJson basic" {

--- a/src/workflow_manifest.zig
+++ b/src/workflow_manifest.zig
@@ -73,6 +73,7 @@ pub const Analysis = struct {
     partner_b: ?[]const []const u8 = null,
     chain_map: ?[]const u8 = null,
     level: ?[]const u8 = null,
+    atom_output: ?bool = null,
 };
 
 pub const Job = struct {
@@ -308,7 +309,7 @@ fn parseClassifier(allocator: Allocator, table: toml_parser.Table) Error!Classif
 }
 
 fn parseAnalysis(allocator: Allocator, table: toml_parser.Table) Error!Analysis {
-    try rejectUnknownFields(table.entries, &.{ "type", "name", "partner_a", "partner_b", "chain_map", "level" });
+    try rejectUnknownFields(table.entries, &.{ "type", "name", "partner_a", "partner_b", "chain_map", "level", "atom_output" });
     const analysis = Analysis{
         .type = try optionalString(table.entries, "type"),
         .name = try optionalString(table.entries, "name"),
@@ -316,6 +317,7 @@ fn parseAnalysis(allocator: Allocator, table: toml_parser.Table) Error!Analysis 
         .partner_b = try optionalStringArray(allocator, table.entries, "partner_b"),
         .chain_map = try optionalString(table.entries, "chain_map"),
         .level = try optionalString(table.entries, "level"),
+        .atom_output = try optionalBool(table.entries, "atom_output"),
     };
     errdefer {
         if (analysis.partner_a) |items| allocator.free(items);
@@ -370,6 +372,9 @@ fn validateAnalysis(analysis: Analysis) WorkflowError!void {
         if (!std.mem.eql(u8, level, "total") and !std.mem.eql(u8, level, "residue")) {
             return error.InvalidAnalysisConfig;
         }
+    }
+    if ((analysis.atom_output orelse false) and !std.mem.eql(u8, analysis.level orelse "total", "residue")) {
+        return error.InvalidAnalysisConfig;
     }
 }
 
@@ -869,6 +874,38 @@ test "reject BSA analysis invalid level" {
         \\level = "chain"
     ;
     try std.testing.expectError(error.InvalidAnalysisConfig, parse(std.testing.allocator, input));
+}
+
+test "parse BSA analysis with opt-in atom output" {
+    const content =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\level = "residue"
+        \\atom_output = true
+    ;
+    var workflow = try parse(std.testing.allocator, content);
+    defer workflow.deinit();
+
+    try std.testing.expectEqual(true, workflow.analysis.?.atom_output.?);
+}
+
+test "reject BSA atom output without residue detail" {
+    const content =
+        \\version = 1
+        \\kind = "workflow"
+        \\
+        \\[analysis]
+        \\type = "bsa"
+        \\partner_a = ["A"]
+        \\partner_b = ["B"]
+        \\atom_output = true
+    ;
+    try std.testing.expectError(error.InvalidAnalysisConfig, parse(std.testing.allocator, content));
 }
 
 test "parse legacy flat batch manifest" {

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -8,6 +8,10 @@ All notable changes to zsasa. See [GitHub Releases](https://github.com/N283T/zsa
 
 ## Unreleased
 
+### Added
+
+- **Multi-interface BSA workflows**: allow CSV and JSON interface maps to request multiple stable-ID interfaces per structure while reusing one parsed/classified input, emitting per-interface success/error JSONL rows, auditable residue SASA components, and opt-in atom-level detail. (#408)
+
 ## [v0.9.1](https://github.com/N283T/zsasa/releases/tag/v0.9.1) — 2026-07-28
 
 ### Added

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -314,6 +314,11 @@ By default, hydrogen atoms are excluded. HETATM records are included automatical
 ./zig-out/bin/zsasa batch --workflow bsa.toml
 ```
 
+BSA workflow interface maps may contain multiple stable-ID rows for one input
+filename. The command writes one JSONL success or error row per requested
+interface; residue components and opt-in atom detail are configured in the
+workflow. See [Workflow Files](../guide/workflows.md#bsa-analysis).
+
 ### Trajectory Analysis
 
 ```bash

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -165,7 +165,7 @@ lists, and jobs that specify both
 `chains` and `chain_map` are rejected. Chain maps are supported for PDB,
 mmCIF, and BinaryCIF inputs, not JSON atom arrays or SDF molecule batches.
 
-## BSA / ΔSASA Analysis
+## BSA / ΔSASA Analysis {#bsa-analysis}
 
 Batch workflows can also write an analysis JSONL file for a two-partner interface:
 
@@ -210,9 +210,10 @@ level = "residue"
 CSV interface maps use one comma-separated chain set for each partner:
 
 ```csv
-filename,partner_a,partner_b,asym_id_type
-1abc.cif,"A,B","C,D",auth
-2xyz.cif,A,"B,C",label
+filename,id,partner_a,partner_b,asym_id_type
+1abc.cif,interaction-001,"A,B","C,D",auth
+1abc.cif,interaction-002,E,"C,D",auth
+2xyz.cif,interaction-003,A,"B,C",label
 ```
 
 The equivalent JSON is:
@@ -221,12 +222,28 @@ The equivalent JSON is:
 [
   {
     "filename": "1abc.cif",
+    "id": "interaction-001",
     "partner_a": ["A", "B"],
+    "partner_b": ["C", "D"],
+    "asym_id_type": "auth"
+  },
+  {
+    "filename": "1abc.cif",
+    "id": "interaction-002",
+    "partner_a": ["E"],
     "partner_b": ["C", "D"],
     "asym_id_type": "auth"
   }
 ]
 ```
+
+Multiple rows may name the same input file. `id` is required for every row
+when a filename occurs more than once and must be unique across the map. A
+legacy one-row-per-file map may omit `id`; its stable output ID defaults to the
+filename. Fixed `partner_a`/`partner_b` workflows also use the filename as the
+interface ID. All rows for one file must use the same `asym_id_type`, allowing
+zsasa to read, decompress, parse, and classify that structure once before
+processing its interfaces.
 
 For the first row, zsasa calculates isolated A+B, isolated C+D, and the
 A+B+C+D complex. The reported values are therefore:
@@ -238,8 +255,7 @@ bsa = delta_sasa_total / 2
 
 `asym_id_type` defaults to `label` and may be set independently for each
 mmCIF or BinaryCIF file. Fixed `partner_a`/`partner_b` settings and
-`analysis.chain_map` are mutually exclusive. As with job chain maps, every
-discovered PDB, mmCIF, or BinaryCIF file must have exactly one entry.
+`analysis.chain_map` are mutually exclusive.
 
 Run it with:
 
@@ -247,16 +263,51 @@ Run it with:
 zsasa batch --workflow bsa.toml
 ```
 
-This writes `results/interface_ab.jsonl`, with one row per input structure. The initial implementation computes partner A, partner B, and the AB complex internally, then reports:
+This writes `results/interface_ab.jsonl`, with one row per requested
+interface. Each success row has `status = "ok"` and its stable `id`. Invalid
+chain selections and read, parse, classification, or calculation failures are
+written as `status = "err"` rows with the same `filename` and `id`. A map row
+whose source file is missing also produces an error row. A discovered file
+without a map entry uses its filename as the error-row ID.
+
+The workflow computes partner A, partner B, and the AB complex internally,
+then reports:
 
 ```text
 delta_sasa_total = sasa_partner_a + sasa_partner_b - sasa_complex
 bsa = delta_sasa_total / 2
 ```
 
-`ΔSASA` and `BSA` are deliberately separate fields. `delta_sasa_total` and `residue_delta_sasa` are not halved; `bsa` is the two-partner buried surface area after the `1/2` factor.
+`ΔSASA` and `BSA` are deliberately separate fields. `delta_sasa_total`,
+`residue_delta_sasa`, and `atom_delta_sasa` are not halved; `bsa` is the
+two-partner buried surface area after the `1/2` factor.
 
-BSA analysis JSONL uses analysis-specific fields such as `sasa_partner_a`, `sasa_partner_b`, `sasa_complex`, `delta_sasa_total`, `bsa`, and `residue_delta_sasa`. It does not use the normal SASA JSONL `total_area` and `atom_areas` fields, because those names are ambiguous for interface analysis.
+BSA analysis JSONL uses analysis-specific fields such as `sasa_partner_a`,
+`sasa_partner_b`, `sasa_complex`, `delta_sasa_total`, and `bsa`. With
+`level = "residue"`, parallel residue arrays include `residue_partner`,
+residue identity, `residue_sasa_isolated`, `residue_sasa_complex`, and
+`residue_delta_sasa`.
+
+Atom detail is disabled by default because it can greatly increase JSONL
+volume. Enable it only with residue detail:
+
+```toml
+[analysis]
+type = "bsa"
+chain_map = "interfaces.csv"
+level = "residue"
+atom_output = true
+```
+
+Atom-detail rows include `atom_index` (zero-based in the selected interface
+complex), `atom_partner`, chain, residue and atom identity, element,
+`atom_sasa_isolated`, `atom_sasa_complex`, and
+`atom_delta_sasa`. Atom and residue ΔSASA arrays reconcile to the unhalved
+`delta_sasa_total` within floating-point tolerance before optional JSONL
+decimal rounding. Polar/apolar decomposition
+is not emitted; the atom metadata is available for downstream classification.
+The schema does not use normal SASA JSONL `total_area` and `atom_areas` fields,
+because those names are ambiguous for interface analysis.
 
 ## Override Precedence
 


### PR DESCRIPTION
## Summary

- allow CSV and JSON BSA interface maps to contain multiple stable-ID interfaces for one structure
- parse and classify each source structure once, then evaluate every requested interface
- emit per-interface JSONL success/error rows with stable IDs
- add auditable residue-level isolated/complex/ΔSASA values and opt-in atom-level detail
- preserve legacy one-row-per-file interface maps
- update workflow/CLI documentation and changelogs

## Design notes

- `id` is required when a filename has multiple interface rows; legacy single rows use the filename as their stable ID
- atom detail is opt-in with `atom_output = true` and keeps ΔSASA unhalved
- only scalar `bsa` applies the `1/2` factor
- polar/apolar decomposition is intentionally out of scope

## Validation

- `zig fmt --check src/`
- `zig build test --summary all` (1753 passed, 3 skipped)
- `zig test src/chain_map.zig` (11 passed)
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa --version`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json`
- `npm run build` in `website/`
- `git diff --check`

Closes #408