### PR TITLE
feat: add parse-once SASA selection maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parse-once SASA selection maps**: allow ordinary workflow chain maps to request multiple globally identified chain selections per structure, reuse one parsed/classified input and duplicate chain-set calculations, emit per-selection JSONL success/error rows, and optionally include stable source-indexed atom identity metadata.
 - **Multi-interface BSA workflows**: allow CSV and JSON interface maps to request multiple stable-ID interfaces per structure while reusing one parsed/classified input, emitting per-interface success/error JSONL rows, auditable residue SASA components, and opt-in atom-level detail. (#408)
 
 ### Fixed

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -102,6 +102,7 @@ pub const BatchConfig = struct {
     residue_map: bool = false,
     jsonl_decimals: ?u8 = null,
     jsonl_include_atom_areas: bool = true,
+    jsonl_include_atom_identity: bool = false,
     jsonl_include_total_area: bool = true,
     jsonl_metadata: JsonlMetadataMode = .none,
 };
@@ -881,6 +882,7 @@ fn jsonlOptions(config: BatchConfig) json_writer.JsonlOptions {
     return .{
         .decimals = config.jsonl_decimals,
         .include_atom_areas = config.jsonl_include_atom_areas,
+        .include_atom_identity = config.jsonl_include_atom_identity,
         .include_total_area = config.jsonl_include_total_area,
     };
 }
@@ -924,6 +926,7 @@ fn writeWorkflowJsonlMetadata(
 
     const JsonlMeta = struct {
         atom_areas: bool,
+        atom_identity: bool,
         total_area: bool,
         decimals: ?u8,
     };
@@ -951,6 +954,7 @@ fn writeWorkflowJsonlMetadata(
         .metadata = "sidecar",
         .jsonl = .{
             .atom_areas = config.jsonl_include_atom_areas,
+            .atom_identity = config.jsonl_include_atom_identity,
             .total_area = config.jsonl_include_total_area,
             .decimals = config.jsonl_decimals,
         },
@@ -3407,6 +3411,7 @@ fn applyWorkflowToBatchConfig(
         if (output.jsonl.decimals) |v| config.jsonl_decimals = v;
     }
     if (output.jsonl.atom_areas) |v| config.jsonl_include_atom_areas = v;
+    if (output.jsonl.atom_identity) |v| config.jsonl_include_atom_identity = v;
     if (output.jsonl.total_area) |v| config.jsonl_include_total_area = v;
     if (output.jsonl.metadata) |v| config.jsonl_metadata = parseWorkflowJsonlMetadata(v) catch |err| {
         std.debug.print("Error: output.jsonl.metadata must be \"none\" or \"sidecar\": {s}\n", .{v});
@@ -4206,6 +4211,501 @@ fn runWorkflowBsaAnalysis(
     std.debug.print("Workflow complete: {d} successful, {d} failed\n", .{ successful, failed });
 }
 
+const SelectionMapBatchStats = struct {
+    successful: usize,
+    failed: usize,
+    total_sasa_time_ns: u64,
+    read_parse_count: usize,
+    classifier_count: usize,
+    calculation_count: usize,
+    file_threads: usize,
+    sasa_threads: usize,
+};
+
+const SelectionMapCounter = struct {
+    successful: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    failed: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    total_sasa_time_ns: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    read_parse_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    classifier_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    calculation_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+};
+
+const SelectionGroup = struct {
+    representative_entry_index: usize,
+    result: FileResult,
+    atom_identity: ?json_writer.SelectionAtomIdentity = null,
+};
+
+const SelectionMapContext = struct {
+    files: []const []const u8,
+    input_dir: []const u8,
+    map: *const chain_map.ChainMap,
+    config: BatchConfig,
+    sasa_threads: usize,
+    luts: *const BatchLuts,
+    jsonl_stream: *JsonlStreamWriter,
+    next_file: std.atomic.Value(usize),
+    processed_count: std.atomic.Value(usize),
+    progress_node: std.Progress.Node,
+    counter: SelectionMapCounter = .{},
+    worker_failed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    io: std.Io,
+};
+
+fn chainsContain(chains: []const []const u8, target: []const u8) bool {
+    for (chains) |chain| {
+        if (std.mem.eql(u8, chain, target)) return true;
+    }
+    return false;
+}
+
+fn uniqueChainCount(chains: []const []const u8) usize {
+    var count: usize = 0;
+    for (chains, 0..) |chain, i| {
+        var seen = false;
+        for (chains[0..i]) |previous| {
+            if (std.mem.eql(u8, chain, previous)) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen) count += 1;
+    }
+    return count;
+}
+
+fn sameCanonicalChainSet(a: []const []const u8, b: []const []const u8) bool {
+    if (uniqueChainCount(a) != uniqueChainCount(b)) return false;
+    for (a) |chain| {
+        if (!chainsContain(b, chain)) return false;
+    }
+    return true;
+}
+
+fn missingSelectedChain(input: AtomInput, chains: []const []const u8) ?[]const u8 {
+    for (chains) |chain| {
+        if (!bsaInputContainsChain(input, chain)) return chain;
+    }
+    return null;
+}
+
+fn selectedSourceAtomIndices(allocator: Allocator, source_input: AtomInput, chains: []const []const u8) ![]const usize {
+    const count = countSelectedAtoms(source_input, chains);
+    const indices = try allocator.alloc(usize, count);
+    var out_index: usize = 0;
+    for (0..source_input.atomCount()) |source_index| {
+        if (!atomSelectedByChains(source_input, source_index, chains)) continue;
+        indices[out_index] = source_index;
+        out_index += 1;
+    }
+    return indices;
+}
+
+fn buildSelectionAtomIdentity(
+    allocator: Allocator,
+    selected_input: AtomInput,
+    source_atom_index: []const usize,
+) !json_writer.SelectionAtomIdentity {
+    if (!selected_input.hasResidueInfo() or selected_input.atom_name == null or selected_input.element == null) {
+        return error.MissingAtomMetadata;
+    }
+    if (source_atom_index.len != selected_input.atomCount()) return error.LengthMismatch;
+
+    const atom_count = selected_input.atomCount();
+    const atom_chain = try allocator.alloc([]const u8, atom_count);
+    const atom_residue_name = try allocator.alloc([]const u8, atom_count);
+    const atom_residue_number = try allocator.dupe(i32, selected_input.residue_num.?);
+    const atom_insertion_code = try allocator.alloc([]const u8, atom_count);
+    const atom_name = try allocator.alloc([]const u8, atom_count);
+    const atom_element = try allocator.alloc([]const u8, atom_count);
+    for (0..atom_count) |i| {
+        atom_chain[i] = if (selected_input.chain_id_full) |chains|
+            chains[i]
+        else
+            selected_input.chain_id.?[i].slice();
+        atom_residue_name[i] = selected_input.residue.?[i].slice();
+        atom_insertion_code[i] = selected_input.insertion_code.?[i].slice();
+        atom_name[i] = selected_input.atom_name.?[i].slice();
+        atom_element[i] = element_module.fromAtomicNumber(selected_input.element.?[i]).symbol();
+    }
+    return .{
+        .source_atom_index = source_atom_index,
+        .atom_chain = atom_chain,
+        .atom_residue_name = atom_residue_name,
+        .atom_residue_number = atom_residue_number,
+        .atom_insertion_code = atom_insertion_code,
+        .atom_name = atom_name,
+        .atom_element = atom_element,
+    };
+}
+
+fn selectionErrorResult(allocator: Allocator, filename: []const u8, comptime format: []const u8, args: anytype) FileResult {
+    return .{
+        .filename = filename,
+        .n_atoms = 0,
+        .sasa_time_ns = 0,
+        .total_sasa = 0,
+        .status = .err,
+        .error_msg = std.fmt.allocPrint(allocator, format, args) catch null,
+    };
+}
+
+fn writeSelectionError(
+    stream: *JsonlStreamWriter,
+    allocator: Allocator,
+    filename: []const u8,
+    id: []const u8,
+    chains: []const []const u8,
+    message: []const u8,
+) !void {
+    const line = try json_writer.selectionErrorToJsonlLine(allocator, .{
+        .filename = filename,
+        .id = id,
+        .chains = chains,
+        .error_message = message,
+    });
+    defer allocator.free(line);
+    try stream.writeLine(filename, line);
+}
+
+fn writeSelectionSuccess(
+    stream: *JsonlStreamWriter,
+    allocator: Allocator,
+    entry: chain_map.Entry,
+    result: FileResult,
+    identity: ?json_writer.SelectionAtomIdentity,
+) !void {
+    const line = try json_writer.selectionResultToJsonlLineOptions(allocator, .{
+        .filename = entry.filename,
+        .id = entry.id orelse entry.filename,
+        .chains = entry.chains,
+        .total_area = result.total_sasa,
+        .atom_areas = result.atom_areas orelse &.{},
+        .residue_map = result.residue_map,
+        .atom_identity = identity,
+    }, stream.options);
+    defer allocator.free(line);
+    try stream.writeLine(entry.filename, line);
+}
+
+fn writeSelectionSourceErrorRows(
+    ctx: *SelectionMapContext,
+    allocator: Allocator,
+    filename: []const u8,
+    map_indices: ?[]const usize,
+    message: []const u8,
+) !void {
+    if (map_indices) |indices| {
+        for (indices) |entry_index| {
+            const entry = ctx.map.entries[entry_index];
+            try writeSelectionError(
+                ctx.jsonl_stream,
+                allocator,
+                filename,
+                entry.id orelse filename,
+                entry.chains,
+                message,
+            );
+            _ = ctx.counter.failed.fetchAdd(1, .monotonic);
+        }
+        return;
+    }
+    try writeSelectionError(ctx.jsonl_stream, allocator, filename, filename, &.{}, message);
+    _ = ctx.counter.failed.fetchAdd(1, .monotonic);
+}
+
+fn calculateSelectionGroup(
+    ctx: *SelectionMapContext,
+    allocator: Allocator,
+    filename: []const u8,
+    source_input: AtomInput,
+    representative_entry_index: usize,
+) SelectionGroup {
+    const entry = ctx.map.entries[representative_entry_index];
+    if (missingSelectedChain(source_input, entry.chains)) |missing_chain| {
+        return .{
+            .representative_entry_index = representative_entry_index,
+            .result = selectionErrorResult(allocator, filename, "selected chain not found: {s}", .{missing_chain}),
+        };
+    }
+
+    const source_indices: []const usize = if (ctx.config.jsonl_include_atom_identity)
+        selectedSourceAtomIndices(allocator, source_input, entry.chains) catch |err| {
+            return .{
+                .representative_entry_index = representative_entry_index,
+                .result = selectionErrorResult(allocator, filename, "selection source-index mapping failed: {s}", .{@errorName(err)}),
+            };
+        }
+    else
+        &.{};
+    const selected_input = copySelectedAtomInput(allocator, source_input, entry.chains) catch |err| {
+        return .{
+            .representative_entry_index = representative_entry_index,
+            .result = selectionErrorResult(allocator, filename, "selection failed: {s}", .{@errorName(err)}),
+        };
+    };
+
+    _ = ctx.counter.calculation_count.fetchAdd(1, .monotonic);
+    const result = switch (ctx.config.precision) {
+        .f64 => calculatePreparedInputResult(
+            f64,
+            allocator,
+            ctx.io,
+            allocator,
+            selected_input,
+            null,
+            filename,
+            ctx.config,
+            ctx.sasa_threads,
+            ctx.luts.f64Ptr(),
+            ctx.luts.coarseF64Ptr(),
+            ctx.luts.fineF64Ptr(),
+        ),
+        .f32 => calculatePreparedInputResult(
+            f32,
+            allocator,
+            ctx.io,
+            allocator,
+            selected_input,
+            null,
+            filename,
+            ctx.config,
+            ctx.sasa_threads,
+            ctx.luts.f32Ptr(),
+            ctx.luts.coarseF32Ptr(),
+            ctx.luts.fineF32Ptr(),
+        ),
+    };
+    if (result.status != .ok) {
+        return .{
+            .representative_entry_index = representative_entry_index,
+            .result = result,
+        };
+    }
+
+    const identity: ?json_writer.SelectionAtomIdentity = if (ctx.config.jsonl_include_atom_identity)
+        buildSelectionAtomIdentity(allocator, selected_input, source_indices) catch |err| {
+            return .{
+                .representative_entry_index = representative_entry_index,
+                .result = selectionErrorResult(allocator, filename, "atom identity failed: {s}", .{@errorName(err)}),
+            };
+        }
+    else
+        null;
+
+    return .{
+        .representative_entry_index = representative_entry_index,
+        .result = result,
+        .atom_identity = identity,
+    };
+}
+
+fn processSelectionMapFile(ctx: *SelectionMapContext, allocator: Allocator, filename: []const u8) !void {
+    const map_indices = ctx.map.getIndices(filename) orelse
+        return writeSelectionSourceErrorRows(ctx, allocator, filename, null, "selection chain map entry not found");
+
+    const first_type = ctx.map.entries[map_indices[0]].asym_id_type;
+    for (map_indices[1..]) |entry_index| {
+        if (ctx.map.entries[entry_index].asym_id_type != first_type) {
+            return writeSelectionSourceErrorRows(
+                ctx,
+                allocator,
+                filename,
+                map_indices,
+                "selections for one file must use the same asym_id_type",
+            );
+        }
+    }
+
+    var source_config = ctx.config;
+    source_config.chain_filter = null;
+    source_config.use_auth_chain = first_type == .auth;
+    const input_path = try std.fs.path.join(allocator, &.{ ctx.input_dir, filename });
+
+    _ = ctx.counter.read_parse_count.fetchAdd(1, .monotonic);
+    var source_parsed = readInputFile(allocator, ctx.io, input_path, source_config) catch |err| {
+        const message = try std.fmt.allocPrint(allocator, "read/parse failed: {s}", .{@errorName(err)});
+        return writeSelectionSourceErrorRows(ctx, allocator, filename, map_indices, message);
+    };
+    defer source_parsed.deinit();
+
+    _ = ctx.counter.classifier_count.fetchAdd(1, .monotonic);
+    workflowClassifySourceInput(&source_parsed.input, source_parsed.inlineCcdPtr(), input_path, source_config) catch |err| {
+        const message = try std.fmt.allocPrint(allocator, "classifier failed: {s}", .{@errorName(err)});
+        return writeSelectionSourceErrorRows(ctx, allocator, filename, map_indices, message);
+    };
+
+    var groups = std.ArrayListUnmanaged(SelectionGroup).empty;
+    for (map_indices) |entry_index| {
+        const entry = ctx.map.entries[entry_index];
+        var group_index: ?usize = null;
+        for (groups.items, 0..) |group, i| {
+            const representative = ctx.map.entries[group.representative_entry_index];
+            if (sameCanonicalChainSet(entry.chains, representative.chains)) {
+                group_index = i;
+                break;
+            }
+        }
+        if (group_index == null) {
+            try groups.append(allocator, calculateSelectionGroup(ctx, allocator, filename, source_parsed.input, entry_index));
+        }
+    }
+
+    for (map_indices) |entry_index| {
+        const entry = ctx.map.entries[entry_index];
+        const group = for (groups.items) |candidate| {
+            const representative = ctx.map.entries[candidate.representative_entry_index];
+            if (sameCanonicalChainSet(entry.chains, representative.chains)) break candidate;
+        } else unreachable;
+
+        if (group.result.status == .ok) {
+            try writeSelectionSuccess(ctx.jsonl_stream, allocator, entry, group.result, group.atom_identity);
+            _ = ctx.counter.successful.fetchAdd(1, .monotonic);
+        } else {
+            try writeSelectionError(
+                ctx.jsonl_stream,
+                allocator,
+                filename,
+                entry.id orelse filename,
+                entry.chains,
+                group.result.error_msg orelse "unknown error",
+            );
+            _ = ctx.counter.failed.fetchAdd(1, .monotonic);
+        }
+    }
+
+    for (groups.items) |group| {
+        if (group.result.status == .ok) {
+            _ = ctx.counter.total_sasa_time_ns.fetchAdd(group.result.sasa_time_ns, .monotonic);
+        }
+    }
+}
+
+fn selectionMapWorker(ctx: *SelectionMapContext) void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator);
+    defer arena.deinit();
+
+    while (true) {
+        const file_index = ctx.next_file.fetchAdd(1, .monotonic);
+        if (file_index >= ctx.files.len) break;
+        const filename = ctx.files[file_index];
+        defer {
+            _ = ctx.processed_count.fetchAdd(1, .release);
+            ctx.progress_node.completeOne();
+        }
+
+        processSelectionMapFile(ctx, arena.allocator(), filename) catch |err| {
+            ctx.worker_failed.store(true, .release);
+            std.debug.print("Error running selection map on '{s}': {s}\n", .{ filename, @errorName(err) });
+        };
+        _ = arena.reset(.retain_capacity);
+    }
+}
+
+fn runSelectionMapBatch(
+    allocator: Allocator,
+    io: std.Io,
+    input_dir: []const u8,
+    config: BatchConfig,
+    jsonl_output_path: ?[]const u8,
+    map: *const chain_map.ChainMap,
+) !SelectionMapBatchStats {
+    if (config.output_format != .jsonl) return error.MultiSelectionMapRequiresJsonl;
+    if (!config.jsonl_include_total_area) return error.SelectionMapRequiresTotalArea;
+    if (config.jsonl_include_atom_identity and !config.jsonl_include_atom_areas) {
+        return error.AtomIdentityRequiresAtomAreas;
+    }
+
+    const files = try scanDirectory(allocator, io, input_dir);
+    defer freeScannedFiles(allocator, files);
+    try validateMappedChainInputFormats(files, true);
+
+    var luts = try BatchLuts.init(allocator, config);
+    defer luts.deinit();
+
+    const jsonl_file = if (jsonl_output_path) |path|
+        try std.Io.Dir.cwd().createFile(io, path, .{})
+    else
+        std.Io.File.stdout();
+    defer if (jsonl_output_path != null) jsonl_file.close(io);
+    var jsonl_buffer: [64 * 1024]u8 = undefined;
+    var jsonl_stream = JsonlStreamWriter.init(jsonl_file, io, jsonlOptions(config), &jsonl_buffer);
+    errdefer jsonl_stream.flush() catch {};
+
+    var discovered_files = std.StringHashMapUnmanaged(void){};
+    defer discovered_files.deinit(allocator);
+    for (files) |filename| try discovered_files.put(allocator, filename, {});
+
+    var progress_root: std.Progress.Node = if (shouldShowProgress(config))
+        std.Progress.start(io, .{ .root_name = "Processing files", .estimated_total_items = files.len })
+    else
+        .none;
+    defer progress_root.end();
+
+    const file_threads = effectiveWorkflowFileThreads(config, files.len);
+    const sasa_threads = if (file_threads > 1) 1 else effectiveWorkflowSasaThreads(config);
+    var ctx = SelectionMapContext{
+        .files = files,
+        .input_dir = input_dir,
+        .map = map,
+        .config = config,
+        .sasa_threads = sasa_threads,
+        .luts = &luts,
+        .jsonl_stream = &jsonl_stream,
+        .next_file = std.atomic.Value(usize).init(0),
+        .processed_count = std.atomic.Value(usize).init(0),
+        .progress_node = progress_root,
+        .io = io,
+    };
+
+    if (file_threads > 1 and files.len > 1) {
+        const threads = try allocator.alloc(std.Thread, file_threads);
+        defer allocator.free(threads);
+        var spawned_count: usize = 0;
+        errdefer joinSpawnedThreads(threads, spawned_count);
+        for (threads) |*thread| {
+            thread.* = try std.Thread.spawn(.{}, selectionMapWorker, .{&ctx});
+            spawned_count += 1;
+        }
+        joinSpawnedThreads(threads, spawned_count);
+    } else {
+        selectionMapWorker(&ctx);
+    }
+
+    if (ctx.processed_count.load(.acquire) != files.len) return error.SelectionMapWorkerFailed;
+
+    for (map.entries) |entry| {
+        if (discovered_files.contains(entry.filename)) continue;
+        var error_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer error_arena.deinit();
+        try writeSelectionError(
+            &jsonl_stream,
+            error_arena.allocator(),
+            entry.filename,
+            entry.id orelse entry.filename,
+            entry.chains,
+            "input structure not found",
+        );
+        _ = ctx.counter.failed.fetchAdd(1, .monotonic);
+    }
+
+    try jsonl_stream.flush();
+    if (jsonl_stream.hasError()) return error.JsonlWriteFailed;
+    if (ctx.worker_failed.load(.acquire)) return error.SelectionMapWorkerFailed;
+
+    return .{
+        .successful = ctx.counter.successful.load(.monotonic),
+        .failed = ctx.counter.failed.load(.monotonic),
+        .total_sasa_time_ns = ctx.counter.total_sasa_time_ns.load(.monotonic),
+        .read_parse_count = ctx.counter.read_parse_count.load(.monotonic),
+        .classifier_count = ctx.counter.classifier_count.load(.monotonic),
+        .calculation_count = ctx.counter.calculation_count.load(.monotonic),
+        .file_threads = file_threads,
+        .sasa_threads = sasa_threads,
+    };
+}
+
 fn effectiveWorkflowSasaThreads(config: BatchConfig) usize {
     return if (config.n_threads == 0)
         std.Thread.getCpuCount() catch 1
@@ -4428,6 +4928,10 @@ fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void 
             };
             config.chain_map = &loaded_chain_map.?;
         }
+        if (config.jsonl_include_atom_identity and loaded_chain_map == null) {
+            std.debug.print("Error: output.jsonl.atom_identity is supported only for chain_map jobs\n", .{});
+            return error.AtomIdentityRequiresSelectionMap;
+        }
         try validateBitmaskCorrectionConfig(config);
         validateBatchOutputFormat(config.output_format) catch {
             std.debug.print("Error: freesasa and rsa output formats are only supported by the calc command\n", .{});
@@ -4464,6 +4968,29 @@ fn runWorkflowJobFirst(allocator: Allocator, io: std.Io, args: BatchArgs) !void 
 
         if (!config.quiet) {
             std.debug.print("Workflow job: {s}\n", .{job.name});
+        }
+
+        if (loaded_chain_map != null and config.output_format == .jsonl) {
+            const stats = runSelectionMapBatch(
+                allocator,
+                io,
+                input_dir,
+                config,
+                jsonl_output_path,
+                &loaded_chain_map.?,
+            ) catch |err| {
+                std.debug.print("Error running selection-map workflow job '{s}': {s}\n", .{ job.name, @errorName(err) });
+                return err;
+            };
+            successful += stats.successful;
+            failed += stats.failed;
+            continue;
+        }
+        if (loaded_chain_map) |*map| {
+            if (map.hasMultipleSelections()) {
+                std.debug.print("Error: chain maps with multiple selections per file require format = \"jsonl\"\n", .{});
+                return error.MultiSelectionMapRequiresJsonl;
+            }
         }
 
         var result = runBatch(allocator, io, input_dir, job_output_dir, config, jsonl_output_path) catch |err| {
@@ -4566,6 +5093,10 @@ fn runWorkflowFileFirst(allocator: Allocator, io: std.Io, args: BatchArgs, pre_s
         config.sdf_ccd = if (sdf_ccd != null) &sdf_ccd.? else null;
         if (custom_classifier) |*c| config.custom_classifier = c;
         applyWorkflowJobOverrides(&config, args, job);
+        if (config.jsonl_include_atom_identity) {
+            std.debug.print("Error: output.jsonl.atom_identity is supported only for chain_map jobs\n", .{});
+            return error.AtomIdentityRequiresSelectionMap;
+        }
         try validateBitmaskCorrectionConfig(config);
         validateBatchOutputFormat(config.output_format) catch {
             std.debug.print("Error: freesasa and rsa output formats are only supported by the calc command\n", .{});
@@ -5804,6 +6335,170 @@ test "workflow chain map selects per-file PDB and mmCIF chain complexes" {
         found += 1;
     }
     try std.testing.expectEqual(@as(usize, 3), found);
+}
+
+test "selection map parses and classifies once, reuses chain sets, and emits joinable JSONL" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const input_path = try std.fs.path.join(allocator, &.{ input_dir, "multi.pdb" });
+    defer allocator.free(input_path);
+    const output_path = try std.fs.path.join(allocator, &.{ root, "selections.jsonl" });
+    defer allocator.free(output_path);
+
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = input_path,
+        .data = "ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00 20.00           N  \n" ++
+            "ATOM      2  CA  GLY A   1       1.500   0.000   0.000  1.00 20.00           C  \n" ++
+            "ATOM      3  N   ALA B   2       3.000   0.000   0.000  1.00 20.00           N  \n" ++
+            "ATOM      4  CA  ALA B   2       4.500   0.000   0.000  1.00 20.00           C  \n" ++
+            "ATOM      5  N   SER C   3       6.000   0.000   0.000  1.00 20.00           N  \n" ++
+            "ATOM      6  CA  SER C   3       7.500   0.000   0.000  1.00 20.00           C  \n" ++
+            "END\n",
+    });
+
+    var map = try chain_map.parseCsv(
+        allocator,
+        "filename,id,chains,asym_id_type\n" ++
+            "multi.pdb,a,A,label\n" ++
+            "multi.pdb,bc,\"B,C\",label\n" ++
+            "multi.pdb,abc,\"A,B,C\",label\n" ++
+            "multi.pdb,bc-copy,\"C,B\",label\n" ++
+            "multi.pdb,bad,Z,label\n" ++
+            "absent.pdb,absent,A,label\n",
+    );
+    defer map.deinit();
+
+    const stats = try runSelectionMapBatch(allocator, std.testing.io, input_dir, .{
+        .n_threads = 4,
+        .n_points = 128,
+        .use_bitmask = true,
+        .precision = .f64,
+        .classifier_type = .ccd,
+        .include_hetatm = true,
+        .output_format = .jsonl,
+        .store_atom_areas = true,
+        .residue_map = true,
+        .jsonl_include_atom_areas = true,
+        .jsonl_include_atom_identity = true,
+        .quiet = true,
+    }, output_path, &map);
+
+    try std.testing.expectEqual(@as(usize, 4), stats.successful);
+    try std.testing.expectEqual(@as(usize, 2), stats.failed);
+    try std.testing.expectEqual(@as(usize, 1), stats.read_parse_count);
+    try std.testing.expectEqual(@as(usize, 1), stats.classifier_count);
+    try std.testing.expectEqual(@as(usize, 3), stats.calculation_count);
+    try std.testing.expectEqual(@as(usize, 1), stats.file_threads);
+    try std.testing.expectEqual(@as(usize, 4), stats.sasa_threads);
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(65536));
+    defer allocator.free(content);
+    const expected_ids = [_][]const u8{ "a", "bc", "abc", "bc-copy", "bad", "absent" };
+    var row_index: usize = 0;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const object = parsed.value.object;
+        try std.testing.expectEqualStrings(expected_ids[row_index], object.get("id").?.string);
+        try std.testing.expect(object.get("filename") != null);
+        try std.testing.expect(object.get("chains") != null);
+        if (row_index < 4) {
+            try std.testing.expectEqualStrings("ok", object.get("status").?.string);
+            try std.testing.expect(object.get("total_area") != null);
+            const areas = object.get("atom_areas").?.array.items;
+            const source_indices = object.get("source_atom_index").?.array.items;
+            try std.testing.expectEqual(areas.len, source_indices.len);
+            try std.testing.expectEqual(areas.len, object.get("atom_element").?.array.items.len);
+            try std.testing.expect(object.get("residue_sasa") != null);
+            if (std.mem.eql(u8, expected_ids[row_index], "a")) {
+                try std.testing.expectEqual(@as(i64, 0), source_indices[0].integer);
+                try std.testing.expectEqual(@as(i64, 1), source_indices[1].integer);
+            } else if (std.mem.eql(u8, expected_ids[row_index], "bc") or
+                std.mem.eql(u8, expected_ids[row_index], "bc-copy"))
+            {
+                try std.testing.expectEqual(@as(i64, 2), source_indices[0].integer);
+                try std.testing.expectEqual(@as(i64, 5), source_indices[3].integer);
+            } else {
+                try std.testing.expectEqual(@as(i64, 0), source_indices[0].integer);
+                try std.testing.expectEqual(@as(i64, 5), source_indices[5].integer);
+            }
+        } else {
+            try std.testing.expectEqualStrings("err", object.get("status").?.string);
+            try std.testing.expect(object.get("error") != null);
+        }
+        row_index += 1;
+    }
+    try std.testing.expectEqual(expected_ids.len, row_index);
+}
+
+test "selection map parallelizes files and keeps internal SASA single-threaded" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const output_path = try std.fs.path.join(allocator, &.{ root, "parallel.jsonl" });
+    defer allocator.free(output_path);
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+
+    const pdb =
+        "ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "ATOM      2  CA  GLY A   1       1.500   0.000   0.000  1.00 20.00           C  \n" ++
+        "END\n";
+    for ([_][]const u8{ "one.pdb", "two.pdb" }) |filename| {
+        const path = try std.fs.path.join(allocator, &.{ input_dir, filename });
+        defer allocator.free(path);
+        try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = path, .data = pdb });
+    }
+
+    var map = try chain_map.parseCsv(
+        allocator,
+        "filename,id,chains\n" ++
+            "one.pdb,one,A\n" ++
+            "two.pdb,two,A\n",
+    );
+    defer map.deinit();
+    const stats = try runSelectionMapBatch(allocator, std.testing.io, input_dir, .{
+        .n_threads = 4,
+        .n_points = 8,
+        .classifier_type = .naccess,
+        .output_format = .jsonl,
+        .store_atom_areas = true,
+        .quiet = true,
+    }, output_path, &map);
+
+    try std.testing.expectEqual(@as(usize, 2), stats.file_threads);
+    try std.testing.expectEqual(@as(usize, 1), stats.sasa_threads);
+    try std.testing.expectEqual(@as(usize, 2), stats.read_parse_count);
+    try std.testing.expectEqual(@as(usize, 2), stats.classifier_count);
+    try std.testing.expectEqual(@as(usize, 2), stats.calculation_count);
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(8192));
+    defer allocator.free(content);
+    var row_count: usize = 0;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        try std.testing.expectEqualStrings("ok", parsed.value.object.get("status").?.string);
+        row_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 2), row_count);
 }
 
 test "workflow BSA analysis writes analysis JSONL" {

--- a/src/chain_map.zig
+++ b/src/chain_map.zig
@@ -15,11 +15,13 @@ pub const AsymIdType = enum {
 
 pub const Entry = struct {
     filename: []const u8,
+    id: ?[]const u8,
     chains: []const []const u8,
     asym_id_type: AsymIdType,
 
     fn deinit(self: Entry, allocator: Allocator) void {
         allocator.free(self.filename);
+        if (self.id) |id| allocator.free(id);
         for (self.chains) |chain| allocator.free(chain);
         allocator.free(self.chains);
     }
@@ -28,18 +30,34 @@ pub const Entry = struct {
 pub const ChainMap = struct {
     allocator: Allocator,
     entries: []Entry,
-    index: std.StringHashMapUnmanaged(usize),
+    index: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(usize)),
 
     pub fn deinit(self: *ChainMap) void {
+        var values = self.index.valueIterator();
+        while (values.next()) |indices| indices.deinit(self.allocator);
         self.index.deinit(self.allocator);
         for (self.entries) |entry| entry.deinit(self.allocator);
         self.allocator.free(self.entries);
         self.* = undefined;
     }
 
+    pub fn getIndices(self: *const ChainMap, filename: []const u8) ?[]const usize {
+        const indices = self.index.get(filename) orelse return null;
+        return indices.items;
+    }
+
+    /// Return the first selection for compatibility with one-row-per-file maps.
     pub fn get(self: *const ChainMap, filename: []const u8) ?Entry {
-        const index = self.index.get(filename) orelse return null;
-        return self.entries[index];
+        const indices = self.getIndices(filename) orelse return null;
+        return self.entries[indices[0]];
+    }
+
+    pub fn hasMultipleSelections(self: *const ChainMap) bool {
+        var values = self.index.valueIterator();
+        while (values.next()) |indices| {
+            if (indices.items.len > 1) return true;
+        }
+        return false;
     }
 };
 
@@ -111,6 +129,7 @@ pub fn parseCsv(allocator: Allocator, content: []const u8) !ChainMap {
     defer if (header) |fields| freeFields(allocator, fields);
 
     var filename_col: ?usize = null;
+    var id_col: ?usize = null;
     var chains_col: ?usize = null;
     var asym_id_type_col: ?usize = null;
 
@@ -124,6 +143,7 @@ pub fn parseCsv(allocator: Allocator, content: []const u8) !ChainMap {
             for (fields, 0..) |field, i| {
                 const normalized = if (i == 0) std.mem.trimStart(u8, field, "\xEF\xBB\xBF") else field;
                 if (std.ascii.eqlIgnoreCase(normalized, "filename")) filename_col = i;
+                if (std.ascii.eqlIgnoreCase(normalized, "id")) id_col = i;
                 if (std.ascii.eqlIgnoreCase(normalized, "chains")) chains_col = i;
                 if (std.ascii.eqlIgnoreCase(normalized, "asym_id_type")) asym_id_type_col = i;
             }
@@ -143,7 +163,14 @@ pub fn parseCsv(allocator: Allocator, content: []const u8) !ChainMap {
             try parseAsymIdTypeOrDefault(fields[col])
         else
             AsymIdType.label;
-        try appendEntry(allocator, &entries, fields[filename_col.?], fields[chains_col.?], asym_id_type);
+        try appendEntry(
+            allocator,
+            &entries,
+            fields[filename_col.?],
+            if (id_col) |col| fields[col] else null,
+            fields[chains_col.?],
+            asym_id_type,
+        );
     }
 
     if (header == null) return error.MissingChainMapHeader;
@@ -152,6 +179,7 @@ pub fn parseCsv(allocator: Allocator, content: []const u8) !ChainMap {
 
 const JsonEntry = struct {
     filename: []const u8,
+    id: ?[]const u8 = null,
     chains: []const []const u8,
     asym_id_type: ?[]const u8 = null,
 };
@@ -165,7 +193,7 @@ pub fn parseJson(allocator: Allocator, content: []const u8) !ChainMap {
 
     for (parsed.value) |json_entry| {
         const asym_id_type = try parseAsymIdTypeOrDefault(json_entry.asym_id_type orelse "");
-        try appendEntryFromChains(allocator, &entries, json_entry.filename, json_entry.chains, asym_id_type);
+        try appendEntryFromChains(allocator, &entries, json_entry.filename, json_entry.id, json_entry.chains, asym_id_type);
     }
     return finish(allocator, &entries);
 }
@@ -272,24 +300,26 @@ fn appendEntry(
     allocator: Allocator,
     entries: *std.ArrayListUnmanaged(Entry),
     filename_value: []const u8,
+    id_value: ?[]const u8,
     chains_value: []const u8,
     asym_id_type: AsymIdType,
 ) !void {
     const owned_chains = try parseCommaSeparatedChains(allocator, chains_value);
     errdefer freeChains(allocator, owned_chains);
-    try appendOwnedEntry(allocator, entries, filename_value, owned_chains, asym_id_type);
+    try appendOwnedEntry(allocator, entries, filename_value, id_value, owned_chains, asym_id_type);
 }
 
 fn appendEntryFromChains(
     allocator: Allocator,
     entries: *std.ArrayListUnmanaged(Entry),
     filename_value: []const u8,
+    id_value: ?[]const u8,
     chain_values: []const []const u8,
     asym_id_type: AsymIdType,
 ) !void {
     const chains = try dupeChains(allocator, chain_values);
     errdefer freeChains(allocator, chains);
-    try appendOwnedEntry(allocator, entries, filename_value, chains, asym_id_type);
+    try appendOwnedEntry(allocator, entries, filename_value, id_value, chains, asym_id_type);
 }
 
 fn appendInterfaceEntryCsv(
@@ -328,14 +358,21 @@ fn appendOwnedEntry(
     allocator: Allocator,
     entries: *std.ArrayListUnmanaged(Entry),
     filename_value: []const u8,
+    id_value: ?[]const u8,
     chains: []const []const u8,
     asym_id_type: AsymIdType,
 ) !void {
     const filename = try validateFilename(filename_value);
     const owned_filename = try allocator.dupe(u8, filename);
     errdefer allocator.free(owned_filename);
+    const owned_id = if (id_value) |value| blk: {
+        const id = std.mem.trim(u8, value, " \t\r");
+        break :blk if (id.len == 0) null else try allocator.dupe(u8, try validateSelectionId(id));
+    } else null;
+    errdefer if (owned_id) |id| allocator.free(id);
     try entries.append(allocator, .{
         .filename = owned_filename,
+        .id = owned_id,
         .chains = chains,
         .asym_id_type = asym_id_type,
     });
@@ -374,11 +411,33 @@ fn finish(allocator: Allocator, entries: *std.ArrayListUnmanaged(Entry)) !ChainM
         allocator.free(owned_entries);
     }
 
-    var index = std.StringHashMapUnmanaged(usize){};
-    errdefer index.deinit(allocator);
+    var index = std.StringHashMapUnmanaged(std.ArrayListUnmanaged(usize)){};
+    errdefer {
+        var values = index.valueIterator();
+        while (values.next()) |indices| indices.deinit(allocator);
+        index.deinit(allocator);
+    }
     for (owned_entries, 0..) |entry, i| {
-        if (index.contains(entry.filename)) return error.DuplicateFilename;
-        try index.put(allocator, entry.filename, i);
+        const result = try index.getOrPut(allocator, entry.filename);
+        if (!result.found_existing) result.value_ptr.* = .empty;
+        try result.value_ptr.append(allocator, i);
+    }
+    var values = index.valueIterator();
+    while (values.next()) |indices| {
+        if (indices.items.len <= 1) continue;
+        const first_type = owned_entries[indices.items[0]].asym_id_type;
+        for (indices.items) |entry_index| {
+            const entry = owned_entries[entry_index];
+            if (entry.id == null) return error.MissingSelectionId;
+            if (entry.asym_id_type != first_type) return error.MixedSelectionAsymIdType;
+        }
+    }
+    var ids = std.StringHashMapUnmanaged(void){};
+    defer ids.deinit(allocator);
+    for (owned_entries) |entry| {
+        const id = entry.id orelse entry.filename;
+        if (ids.contains(id)) return error.DuplicateSelectionId;
+        try ids.put(allocator, id, {});
     }
 
     return .{
@@ -449,6 +508,12 @@ fn validateFilename(filename_value: []const u8) ![]const u8 {
 fn validateInterfaceId(id_value: []const u8) ![]const u8 {
     const id = std.mem.trim(u8, id_value, " \t\r");
     if (id.len == 0) return error.EmptyInterfaceId;
+    return id;
+}
+
+fn validateSelectionId(id_value: []const u8) ![]const u8 {
+    const id = std.mem.trim(u8, id_value, " \t\r");
+    if (id.len == 0) return error.EmptySelectionId;
     return id;
 }
 
@@ -605,14 +670,71 @@ test "parse JSON chain map defaults to label IDs" {
     try std.testing.expectEqual(AsymIdType.auth, map.get("2xyz.cif").?.asym_id_type);
 }
 
-test "reject duplicate chain map filenames" {
+test "parse multiple CSV selections for one filename with globally unique IDs" {
+    var map = try parseCsv(
+        std.testing.allocator,
+        "filename,id,chains,asym_id_type\n" ++
+            "1abc.cif,a,A,label\n" ++
+            "1abc.cif,bc,\"B,C\",label\n" ++
+            "2xyz.cif,other,X,auth\n",
+    );
+    defer map.deinit();
+
+    const indices = map.getIndices("1abc.cif").?;
+    try std.testing.expectEqual(@as(usize, 2), indices.len);
+    try std.testing.expectEqualStrings("a", map.entries[indices[0]].id.?);
+    try std.testing.expectEqualStrings("bc", map.entries[indices[1]].id.?);
+    try std.testing.expectEqualStrings("B", map.entries[indices[1]].chains[0]);
+    try std.testing.expectEqualStrings("C", map.entries[indices[1]].chains[1]);
+}
+
+test "parse multiple JSON selections for one filename with globally unique IDs" {
+    var map = try parseJson(std.testing.allocator,
+        \\[
+        \\  {"filename":"1abc.cif","id":"a","chains":["A"]},
+        \\  {"filename":"1abc.cif","id":"bc","chains":["B","C"]}
+        \\]
+    );
+    defer map.deinit();
+
+    const indices = map.getIndices("1abc.cif").?;
+    try std.testing.expectEqual(@as(usize, 2), indices.len);
+    try std.testing.expectEqualStrings("a", map.entries[indices[0]].id.?);
+    try std.testing.expectEqualStrings("bc", map.entries[indices[1]].id.?);
+}
+
+test "require IDs when a chain map filename appears more than once" {
     try std.testing.expectError(
-        error.DuplicateFilename,
+        error.MissingSelectionId,
         parseCsv(
             std.testing.allocator,
-            "filename,chains\n" ++
-                "1abc.cif,A\n" ++
-                "1abc.cif,B\n",
+            "filename,id,chains\n" ++
+                "1abc.cif,a,A\n" ++
+                "1abc.cif,,B\n",
+        ),
+    );
+}
+
+test "reject duplicate selection IDs across filenames" {
+    try std.testing.expectError(
+        error.DuplicateSelectionId,
+        parseCsv(
+            std.testing.allocator,
+            "filename,id,chains\n" ++
+                "1abc.cif,same,A\n" ++
+                "2xyz.cif,same,B\n",
+        ),
+    );
+}
+
+test "reject mixed asym ID types within one selection-map filename" {
+    try std.testing.expectError(
+        error.MixedSelectionAsymIdType,
+        parseCsv(
+            std.testing.allocator,
+            "filename,id,chains,asym_id_type\n" ++
+                "1abc.cif,a,A,label\n" ++
+                "1abc.cif,b,B,auth\n",
         ),
     );
 }

--- a/src/json_writer.zig
+++ b/src/json_writer.zig
@@ -569,6 +569,7 @@ pub const ResidueMap = struct {
 pub const JsonlOptions = struct {
     decimals: ?u8 = null,
     include_atom_areas: bool = true,
+    include_atom_identity: bool = false,
     include_total_area: bool = true,
 };
 
@@ -913,6 +914,263 @@ pub fn fileResultWithResidueMapToJsonlLineOptions(
         .residue_atom_start = residue_map.residue_atom_start,
         .residue_atom_count = residue_map.residue_atom_count,
         .residue_sasa = output_residue_sasa,
+    }, .{});
+}
+
+pub const SelectionAtomIdentity = struct {
+    source_atom_index: []const usize,
+    atom_chain: []const []const u8,
+    atom_residue_name: []const []const u8,
+    atom_residue_number: []const i32,
+    atom_insertion_code: []const []const u8,
+    atom_name: []const []const u8,
+    atom_element: []const []const u8,
+};
+
+pub const SelectionResultJsonl = struct {
+    filename: []const u8,
+    id: []const u8,
+    chains: []const []const u8,
+    total_area: f64,
+    atom_areas: []const f64 = &.{},
+    residue_map: ?ResidueMap = null,
+    atom_identity: ?SelectionAtomIdentity = null,
+};
+
+pub const SelectionErrorJsonl = struct {
+    filename: []const u8,
+    id: []const u8,
+    chains: []const []const u8,
+    error_message: []const u8,
+};
+
+pub fn selectionErrorToJsonlLine(allocator: Allocator, row: SelectionErrorJsonl) ![]u8 {
+    const Entry = struct {
+        status: []const u8,
+        filename: []const u8,
+        id: []const u8,
+        chains: []const []const u8,
+        @"error": []const u8,
+    };
+    return std.json.Stringify.valueAlloc(allocator, Entry{
+        .status = "err",
+        .filename = row.filename,
+        .id = row.id,
+        .chains = row.chains,
+        .@"error" = row.error_message,
+    }, .{});
+}
+
+pub fn selectionResultToJsonlLineOptions(
+    allocator: Allocator,
+    row: SelectionResultJsonl,
+    options: JsonlOptions,
+) ![]u8 {
+    if (row.atom_identity != null and !options.include_atom_identity) return error.UnexpectedAtomIdentity;
+    const output_areas = try maybeRoundJsonlFloatSlice(allocator, row.atom_areas, options);
+    defer if (options.decimals != null) allocator.free(output_areas);
+
+    var residue_chain: [][]const u8 = &.{};
+    var residue_name: [][]const u8 = &.{};
+    var residue_insertion_code: [][]const u8 = &.{};
+    if (row.residue_map) |map| {
+        residue_chain = try allocator.alloc([]const u8, map.len());
+        residue_name = try allocator.alloc([]const u8, map.len());
+        residue_insertion_code = try allocator.alloc([]const u8, map.len());
+        for (0..map.len()) |i| {
+            residue_chain[i] = if (map.residue_chain_full) |chains| chains[i] else map.residue_chain[i].slice();
+            residue_name[i] = map.residue_name[i].slice();
+            residue_insertion_code[i] = map.residue_insertion_code[i].slice();
+        }
+    }
+    defer {
+        if (row.residue_map != null) {
+            allocator.free(residue_chain);
+            allocator.free(residue_name);
+            allocator.free(residue_insertion_code);
+        }
+    }
+    const output_residue_sasa = if (row.residue_map) |map|
+        try maybeRoundJsonlFloatSlice(allocator, map.residue_sasa, options)
+    else
+        &.{};
+    defer if (row.residue_map != null and options.decimals != null) allocator.free(output_residue_sasa);
+
+    if (row.atom_identity) |identity| {
+        if (!options.include_atom_areas) return error.AtomIdentityRequiresAtomAreas;
+        if (row.residue_map) |map| {
+            const Entry = struct {
+                status: []const u8,
+                filename: []const u8,
+                id: []const u8,
+                chains: []const []const u8,
+                total_area: f64,
+                atom_areas: []const f64,
+                source_atom_index: []const usize,
+                atom_chain: []const []const u8,
+                atom_residue_name: []const []const u8,
+                atom_residue_number: []const i32,
+                atom_insertion_code: []const []const u8,
+                atom_name: []const []const u8,
+                atom_element: []const []const u8,
+                residue_chain: []const []const u8,
+                residue_name: []const []const u8,
+                residue_number: []const i32,
+                residue_insertion_code: []const []const u8,
+                residue_atom_start: []const usize,
+                residue_atom_count: []const usize,
+                residue_sasa: []const f64,
+            };
+            return std.json.Stringify.valueAlloc(allocator, Entry{
+                .status = "ok",
+                .filename = row.filename,
+                .id = row.id,
+                .chains = row.chains,
+                .total_area = maybeRoundJsonlFloat(row.total_area, options),
+                .atom_areas = output_areas,
+                .source_atom_index = identity.source_atom_index,
+                .atom_chain = identity.atom_chain,
+                .atom_residue_name = identity.atom_residue_name,
+                .atom_residue_number = identity.atom_residue_number,
+                .atom_insertion_code = identity.atom_insertion_code,
+                .atom_name = identity.atom_name,
+                .atom_element = identity.atom_element,
+                .residue_chain = residue_chain,
+                .residue_name = residue_name,
+                .residue_number = map.residue_number,
+                .residue_insertion_code = residue_insertion_code,
+                .residue_atom_start = map.residue_atom_start,
+                .residue_atom_count = map.residue_atom_count,
+                .residue_sasa = output_residue_sasa,
+            }, .{});
+        }
+        const Entry = struct {
+            status: []const u8,
+            filename: []const u8,
+            id: []const u8,
+            chains: []const []const u8,
+            total_area: f64,
+            atom_areas: []const f64,
+            source_atom_index: []const usize,
+            atom_chain: []const []const u8,
+            atom_residue_name: []const []const u8,
+            atom_residue_number: []const i32,
+            atom_insertion_code: []const []const u8,
+            atom_name: []const []const u8,
+            atom_element: []const []const u8,
+        };
+        return std.json.Stringify.valueAlloc(allocator, Entry{
+            .status = "ok",
+            .filename = row.filename,
+            .id = row.id,
+            .chains = row.chains,
+            .total_area = maybeRoundJsonlFloat(row.total_area, options),
+            .atom_areas = output_areas,
+            .source_atom_index = identity.source_atom_index,
+            .atom_chain = identity.atom_chain,
+            .atom_residue_name = identity.atom_residue_name,
+            .atom_residue_number = identity.atom_residue_number,
+            .atom_insertion_code = identity.atom_insertion_code,
+            .atom_name = identity.atom_name,
+            .atom_element = identity.atom_element,
+        }, .{});
+    }
+
+    if (row.residue_map) |map| {
+        if (options.include_atom_areas) {
+            const Entry = struct {
+                status: []const u8,
+                filename: []const u8,
+                id: []const u8,
+                chains: []const []const u8,
+                total_area: f64,
+                atom_areas: []const f64,
+                residue_chain: []const []const u8,
+                residue_name: []const []const u8,
+                residue_number: []const i32,
+                residue_insertion_code: []const []const u8,
+                residue_atom_start: []const usize,
+                residue_atom_count: []const usize,
+                residue_sasa: []const f64,
+            };
+            return std.json.Stringify.valueAlloc(allocator, Entry{
+                .status = "ok",
+                .filename = row.filename,
+                .id = row.id,
+                .chains = row.chains,
+                .total_area = maybeRoundJsonlFloat(row.total_area, options),
+                .atom_areas = output_areas,
+                .residue_chain = residue_chain,
+                .residue_name = residue_name,
+                .residue_number = map.residue_number,
+                .residue_insertion_code = residue_insertion_code,
+                .residue_atom_start = map.residue_atom_start,
+                .residue_atom_count = map.residue_atom_count,
+                .residue_sasa = output_residue_sasa,
+            }, .{});
+        }
+        const Entry = struct {
+            status: []const u8,
+            filename: []const u8,
+            id: []const u8,
+            chains: []const []const u8,
+            total_area: f64,
+            residue_chain: []const []const u8,
+            residue_name: []const []const u8,
+            residue_number: []const i32,
+            residue_insertion_code: []const []const u8,
+            residue_atom_start: []const usize,
+            residue_atom_count: []const usize,
+            residue_sasa: []const f64,
+        };
+        return std.json.Stringify.valueAlloc(allocator, Entry{
+            .status = "ok",
+            .filename = row.filename,
+            .id = row.id,
+            .chains = row.chains,
+            .total_area = maybeRoundJsonlFloat(row.total_area, options),
+            .residue_chain = residue_chain,
+            .residue_name = residue_name,
+            .residue_number = map.residue_number,
+            .residue_insertion_code = residue_insertion_code,
+            .residue_atom_start = map.residue_atom_start,
+            .residue_atom_count = map.residue_atom_count,
+            .residue_sasa = output_residue_sasa,
+        }, .{});
+    }
+
+    if (options.include_atom_areas) {
+        const Entry = struct {
+            status: []const u8,
+            filename: []const u8,
+            id: []const u8,
+            chains: []const []const u8,
+            total_area: f64,
+            atom_areas: []const f64,
+        };
+        return std.json.Stringify.valueAlloc(allocator, Entry{
+            .status = "ok",
+            .filename = row.filename,
+            .id = row.id,
+            .chains = row.chains,
+            .total_area = maybeRoundJsonlFloat(row.total_area, options),
+            .atom_areas = output_areas,
+        }, .{});
+    }
+
+    const Entry = struct {
+        status: []const u8,
+        filename: []const u8,
+        id: []const u8,
+        chains: []const []const u8,
+        total_area: f64,
+    };
+    return std.json.Stringify.valueAlloc(allocator, Entry{
+        .status = "ok",
+        .filename = row.filename,
+        .id = row.id,
+        .chains = row.chains,
+        .total_area = maybeRoundJsonlFloat(row.total_area, options),
     }, .{});
 }
 
@@ -1489,6 +1747,61 @@ test "BSA analysis error JSONL includes stable ID" {
 
     try std.testing.expectEqualStrings(
         "{\"status\":\"err\",\"filename\":\"bad.cif\",\"id\":\"interaction-bad\",\"analysis\":\"bsa\",\"name\":\"interfaces\",\"error\":\"read/parse failed: InvalidFormat\"}",
+        line,
+    );
+}
+
+test "selection JSONL includes stable ID chains and opt-in source atom identity" {
+    const source_atom_index = [_]usize{ 0, 2 };
+    const atom_chain = [_][]const u8{ "A", "C" };
+    const atom_residue_name = [_][]const u8{ "GLY", "SER" };
+    const atom_residue_number = [_]i32{ 1, 3 };
+    const atom_insertion_code = [_][]const u8{ "", "" };
+    const atom_name = [_][]const u8{ "N", "CA" };
+    const atom_element = [_][]const u8{ "N", "C" };
+    const chains = [_][]const u8{ "A", "C" };
+    const areas = [_]f64{ 10.123, 20.456 };
+
+    const line = try selectionResultToJsonlLineOptions(std.testing.allocator, .{
+        .filename = "complex.cif",
+        .id = "ac",
+        .chains = chains[0..],
+        .total_area = 30.579,
+        .atom_areas = areas[0..],
+        .atom_identity = .{
+            .source_atom_index = source_atom_index[0..],
+            .atom_chain = atom_chain[0..],
+            .atom_residue_name = atom_residue_name[0..],
+            .atom_residue_number = atom_residue_number[0..],
+            .atom_insertion_code = atom_insertion_code[0..],
+            .atom_name = atom_name[0..],
+            .atom_element = atom_element[0..],
+        },
+    }, .{ .decimals = 2, .include_atom_identity = true });
+    defer std.testing.allocator.free(line);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, line, .{});
+    defer parsed.deinit();
+    const object = parsed.value.object;
+    try std.testing.expectEqualStrings("ok", object.get("status").?.string);
+    try std.testing.expectEqualStrings("ac", object.get("id").?.string);
+    try std.testing.expectEqual(@as(usize, 2), object.get("chains").?.array.items.len);
+    try std.testing.expectEqual(@as(i64, 2), object.get("source_atom_index").?.array.items[1].integer);
+    try std.testing.expectEqualStrings("N", object.get("atom_element").?.array.items[0].string);
+}
+
+test "selection error JSONL preserves requested ID and chains" {
+    const chains = [_][]const u8{"Z"};
+    const line = try selectionErrorToJsonlLine(std.testing.allocator, .{
+        .filename = "complex.cif",
+        .id = "missing",
+        .chains = chains[0..],
+        .error_message = "selected chain not found: Z",
+    });
+    defer std.testing.allocator.free(line);
+
+    try std.testing.expectEqualStrings(
+        "{\"status\":\"err\",\"filename\":\"complex.cif\",\"id\":\"missing\",\"chains\":[\"Z\"],\"error\":\"selected chain not found: Z\"}",
         line,
     );
 }

--- a/src/workflow_manifest.zig
+++ b/src/workflow_manifest.zig
@@ -34,6 +34,7 @@ pub const Output = struct {
 
 pub const JsonlOutput = struct {
     atom_areas: ?bool = null,
+    atom_identity: ?bool = null,
     total_area: ?bool = null,
     decimals: ?u8 = null,
     metadata: ?[]const u8 = null,
@@ -249,9 +250,10 @@ fn parseOutput(table: toml_parser.Table) WorkflowError!Output {
 }
 
 fn parseOutputJsonl(table: toml_parser.Table) WorkflowError!JsonlOutput {
-    try rejectUnknownFields(table.entries, &.{ "atom_areas", "total_area", "decimals", "metadata" });
+    try rejectUnknownFields(table.entries, &.{ "atom_areas", "atom_identity", "total_area", "decimals", "metadata" });
     const output = JsonlOutput{
         .atom_areas = try optionalBool(table.entries, "atom_areas"),
+        .atom_identity = try optionalBool(table.entries, "atom_identity"),
         .total_area = try optionalBool(table.entries, "total_area"),
         .decimals = try optionalU8(table.entries, "decimals"),
         .metadata = try optionalString(table.entries, "metadata"),
@@ -758,6 +760,7 @@ test "parse output jsonl workflow options" {
         \\
         \\[output.jsonl]
         \\atom_areas = false
+        \\atom_identity = true
         \\total_area = true
         \\decimals = 3
         \\metadata = "sidecar"
@@ -769,6 +772,7 @@ test "parse output jsonl workflow options" {
     defer workflow.deinit();
 
     try std.testing.expectEqual(false, workflow.output.jsonl.atom_areas.?);
+    try std.testing.expectEqual(true, workflow.output.jsonl.atom_identity.?);
     try std.testing.expectEqual(true, workflow.output.jsonl.total_area.?);
     try std.testing.expectEqual(@as(u8, 3), workflow.output.jsonl.decimals.?);
     try std.testing.expectEqualStrings("sidecar", workflow.output.jsonl.metadata.?);

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -10,6 +10,7 @@ All notable changes to zsasa. See [GitHub Releases](https://github.com/N283T/zsa
 
 ### Added
 
+- **Parse-once SASA selection maps**: allow ordinary workflow chain maps to request multiple globally identified chain selections per structure, reuse one parsed/classified input and duplicate chain-set calculations, emit per-selection JSONL success/error rows, and optionally include stable source-indexed atom identity metadata.
 - **Multi-interface BSA workflows**: allow CSV and JSON interface maps to request multiple stable-ID interfaces per structure while reusing one parsed/classified input, emitting per-interface success/error JSONL rows, auditable residue SASA components, and opt-in atom-level detail. (#408)
 
 ### Fixed

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -319,6 +319,12 @@ filename. The command writes one JSONL success or error row per requested
 interface; residue components and opt-in atom detail are configured in the
 workflow. See [Workflow Files](../guide/workflows.md#bsa-analysis).
 
+Ordinary SASA workflow `chain_map` files may also contain multiple stable-ID
+rows per filename. zsasa parses and classifies each source once, reuses
+identical chain-set calculations, and emits primitive SASA JSONL rows for
+downstream analysis. See
+[Per-file Chain Maps](../guide/workflows.md#per-file-chain-maps).
+
 ### Trajectory Analysis
 
 ```bash

--- a/website/docs/guide/batch.md
+++ b/website/docs/guide/batch.md
@@ -165,7 +165,9 @@ For named multi-job runs such as chain A, chain B, and AB complex calculations, 
 When the desired chain set differs by input file, use a workflow
 [`chain_map`](workflows.md#per-file-chain-maps). Chain maps accept CSV or JSON
 and can choose `label` or `auth` chain IDs independently for each mmCIF or
-BinaryCIF file.
+BinaryCIF file. Multiple stable-ID rows for one filename are calculated from
+one parsed/classified structure, with optional source-indexed atom identity for
+joining primitive SASA selections downstream.
 
 ## When to Use Workflow Files
 

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -127,30 +127,84 @@ name = "selected_complexes"
 chain_map = "chains.csv"
 ```
 
-The CSV must contain `filename` and `chains` columns. `asym_id_type` is optional
-and defaults to `label`:
+The CSV must contain `filename` and `chains` columns. Add a globally unique
+`id` for each requested selection when a filename appears more than once.
+`asym_id_type` is optional and defaults to `label`:
 
 ```csv
-filename,chains,asym_id_type
-1abc.pdb,"A,C",label
-2xyz.cif,"A,C",auth
-3def.cif,"B,D",label
+filename,id,chains,asym_id_type
+1111.cif,a,A,label
+1111.cif,bc,"B,C",label
+1111.cif,abc,"A,B,C",label
+2222.cif,a_2222,X,label
+2222.cif,b_2222,Y,label
+2222.cif,complex_2222,"X,Y",label
 ```
 
 `chains` is a comma-separated set. A row containing `A,C` calculates the SASA
 of the A+C complex: atoms in both chains are included and occlude each other.
-It does not calculate A and C independently. A map has one selection per
-filename; to calculate multiple selections for each file, add multiple named
-workflow jobs with separate chain maps.
+It does not calculate A and C independently. The first three rows above emit
+the reusable primitive results SASA(A), SASA(B+C), and SASA(A+B+C). This path
+does not calculate ΔSASA or BSA; derive those quantities downstream.
 
 JSON chain maps are also accepted:
 
 ```json
 [
-  {"filename": "1abc.pdb", "chains": ["A", "C"], "asym_id_type": "label"},
-  {"filename": "2xyz.cif", "chains": ["A", "C"], "asym_id_type": "auth"}
+  {"filename": "1111.cif", "id": "a", "chains": ["A"], "asym_id_type": "label"},
+  {"filename": "1111.cif", "id": "bc", "chains": ["B", "C"], "asym_id_type": "label"},
+  {"filename": "1111.cif", "id": "abc", "chains": ["A", "B", "C"], "asym_id_type": "label"}
 ]
 ```
+
+For a repeated filename, every row must have an `id`, IDs must be unique across
+the whole map, and all rows must use the same `asym_id_type`. Legacy maps with
+one row per filename may omit `id`; the output ID then defaults to the
+filename, preserving one result per structure.
+
+zsasa groups map rows by filename. It reads/decompresses, parses, and classifies
+each discovered structure once, then calculates its selections from that
+prepared input. Chain sets are canonicalized as sets, so requests such as
+`["B", "C"]` and `["C", "B"]` share one SASA calculation while still emitting
+separate rows with their requested IDs and chain order.
+
+Workflow `threads` controls concurrent structure-file workers. With more than
+one file worker, every individual SASA calculation uses one internal thread to
+avoid nested oversubscription. With one file, the configured threads are
+available to its SASA calculations. Progress advances once per discovered
+structure after all of its selections finish.
+
+Multi-selection maps require JSONL output. Each requested selection produces a
+complete, non-interleaved success or error row:
+
+```json
+{"status":"ok","filename":"1111.cif","id":"bc","chains":["B","C"],"total_area":1234.5,"atom_areas":[12.3,0]}
+{"status":"err","filename":"1111.cif","id":"missing","chains":["Z"],"error":"selected chain not found: Z"}
+```
+
+Success rows always include `filename`, `id`, `chains`, and `total_area`.
+`atom_areas` follows `[output.jsonl].atom_areas`, and residue arrays follow
+`[calculation].residue_map`. Missing map rows, missing input structures,
+missing selected chains, and per-selection calculation failures are emitted as
+error rows without discarding other selections for the same structure.
+
+For stable atom joins across selections, enable identity metadata together with
+atom areas:
+
+```toml
+[output.jsonl]
+atom_areas = true
+atom_identity = true
+```
+
+This adds parallel `source_atom_index`, `atom_chain`, `atom_residue_name`,
+`atom_residue_number`, `atom_insertion_code`, `atom_name`, and `atom_element`
+arrays. `source_atom_index` is zero-based in the once-parsed source atom array
+after configured model, alternate-location, hydrogen, and HETATM filtering. It
+therefore aligns atoms across A, B+C, and A+B+C rows from the same source and
+settings. `atom_element` supports downstream polar/apolar classification
+without adding this metadata when atom output is disabled. `atom_identity`
+currently applies only to `chain_map` jobs and requires `atom_areas = true`.
 
 For mmCIF and BinaryCIF, `label` matches `_atom_site.label_asym_id` and `auth`
 matches `_atom_site.auth_asym_id`. PDB has one chain-ID field, so `label` and
@@ -160,9 +214,9 @@ Filenames must be basenames that exactly match files in the input directory,
 including their structure and compression extensions. Every discovered
 structure must have one map entry; a missing entry is written as a failed batch
 result. Keep a JSON chain map outside the input directory because `.json` is
-also a supported structure-input extension. Duplicate filenames, empty chain
-lists, and jobs that specify both
-`chains` and `chain_map` are rejected. Chain maps are supported for PDB,
+also a supported structure-input extension. Missing/duplicate IDs, mixed
+`asym_id_type` values for one filename, empty chain lists, and jobs that specify
+both `chains` and `chain_map` are rejected. Chain maps are supported for PDB,
 mmCIF, and BinaryCIF inputs, not JSON atom arrays or SDF molecule batches.
 
 ## BSA / ΔSASA Analysis {#bsa-analysis}
@@ -406,15 +460,18 @@ format = "jsonl"
 
 [output.jsonl]
 atom_areas = false    # omit per-atom SASA arrays
+atom_identity = false # chain-map-only stable atom identity arrays
 total_area = true     # keep per-structure totals
 decimals = 3          # round JSONL floating-point values
 metadata = "sidecar"  # none | sidecar
 ```
 
-Defaults preserve the CLI JSONL schema: `atom_areas = true`, `total_area = true`,
-full precision, and no metadata sidecar. When `metadata = "sidecar"` is set,
-workflow batch jobs write a `<job>.meta.json` file next to `<job>.jsonl` with
-the effective JSONL and calculation settings.
+Defaults preserve the CLI JSONL schema: `atom_areas = true`,
+`atom_identity = false`, `total_area = true`, full precision, and no metadata
+sidecar. `atom_identity` is available only for chain-map jobs and requires atom
+areas. Selection-map JSONL also requires `total_area = true`. When
+`metadata = "sidecar"` is set, workflow batch jobs write a `<job>.meta.json`
+file next to `<job>.jsonl` with the effective JSONL and calculation settings.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

- allow ordinary workflow chain maps to contain multiple globally identified selections per filename
- group work by structure so each input is read/decompressed, parsed, and classified once, while canonical duplicate chain sets reuse one SASA calculation
- process structures with file-level workers, keep nested SASA calculations single-threaded in the multi-file path, and report file-based progress
- emit thread-safe per-selection JSONL success/error rows with `filename`, `id`, `chains`, and `total_area`
- add opt-in source-indexed atom identity metadata for safe joins across primitive A, B+C, and A+B+C SASA rows
- preserve one-row legacy maps by defaulting missing IDs to the filename
- document the CSV/JSON schemas, execution semantics, output fields, and downstream primitive-SASA workflow

## Validation

- `zig fmt --check src/`
- `zig build test --summary all` (1775 passed, 3 skipped)
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa --help`
- `./zig-out/bin/zsasa --version`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json`
- `cd website && npm ci && npm run build`

## Notes

This is an ordinary SASA workflow path only. It emits reusable primitive SASA results and does not calculate ΔSASA or BSA.