### PR TITLE
fix: schedule selection maps by estimated cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Parse-once SASA selection maps**: allow ordinary workflow chain maps to request multiple globally identified chain selections per structure, reuse one parsed/classified input and duplicate chain-set calculations, emit per-selection JSONL success/error rows, and optionally include stable source-indexed atom identity metadata.
 - **Multi-interface BSA workflows**: allow CSV and JSON interface maps to request multiple stable-ID interfaces per structure while reusing one parsed/classified input, emitting per-interface success/error JSONL rows, auditable residue SASA components, and opt-in atom-level detail. (#408)
 
+### Changed
+
+- **Selection-map tail scheduling**: claim ordinary multi-selection chain-map files in deterministic longest-processing-time-first order using selection count, while preserving generic batch, BSA, and legacy one-row map ordering.
+
 ### Fixed
 
 - **BSA workflow parallelism and progress**: apply workflow thread counts to concurrent structure-file workers, keep partner and complex SASA calculations single-threaded in the multi-file path, serialize concurrent JSONL rows safely, and report completed structure files through the standard terminal progress display.

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -4237,6 +4237,31 @@ const SelectionGroup = struct {
     atom_identity: ?json_writer.SelectionAtomIdentity = null,
 };
 
+fn selectionMapEstimatedFileCost(map: *const chain_map.ChainMap, filename: []const u8) usize {
+    return if (map.getIndices(filename)) |indices| indices.len else 0;
+}
+
+fn sortSelectionMapFilesByEstimatedCost(files: [][]const u8, map: *const chain_map.ChainMap) void {
+    std.mem.sort([]const u8, files, map, struct {
+        fn lessThan(chain_map_value: *const chain_map.ChainMap, a: []const u8, b: []const u8) bool {
+            const a_cost = selectionMapEstimatedFileCost(chain_map_value, a);
+            const b_cost = selectionMapEstimatedFileCost(chain_map_value, b);
+            if (a_cost != b_cost) return a_cost > b_cost;
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.lessThan);
+}
+
+fn scheduleSelectionMapFiles(files: [][]const u8, map: *const chain_map.ChainMap) void {
+    if (map.hasMultipleSelections()) sortSelectionMapFilesByEstimatedCost(files, map);
+}
+
+fn claimSelectionMapFile(files: []const []const u8, next_file: *std.atomic.Value(usize)) ?[]const u8 {
+    const file_index = next_file.fetchAdd(1, .monotonic);
+    if (file_index >= files.len) return null;
+    return files[file_index];
+}
+
 const SelectionMapContext = struct {
     files: []const []const u8,
     input_dir: []const u8,
@@ -4587,9 +4612,7 @@ fn selectionMapWorker(ctx: *SelectionMapContext) void {
     defer arena.deinit();
 
     while (true) {
-        const file_index = ctx.next_file.fetchAdd(1, .monotonic);
-        if (file_index >= ctx.files.len) break;
-        const filename = ctx.files[file_index];
+        const filename = claimSelectionMapFile(ctx.files, &ctx.next_file) orelse break;
         defer {
             _ = ctx.processed_count.fetchAdd(1, .release);
             ctx.progress_node.completeOne();
@@ -4620,6 +4643,7 @@ fn runSelectionMapBatch(
     const files = try scanDirectory(allocator, io, input_dir);
     defer freeScannedFiles(allocator, files);
     try validateMappedChainInputFormats(files, true);
+    scheduleSelectionMapFiles(files, map);
 
     var luts = try BatchLuts.init(allocator, config);
     defer luts.deinit();
@@ -6335,6 +6359,133 @@ test "workflow chain map selects per-file PDB and mmCIF chain complexes" {
         found += 1;
     }
     try std.testing.expectEqual(@as(usize, 3), found);
+}
+
+test "selection map LPT claims highest-cost files first with deterministic ties" {
+    const allocator = std.testing.allocator;
+    var map = try chain_map.parseCsv(
+        allocator,
+        "filename,id,chains\n" ++
+            "z-heavy.pdb,z1,A\n" ++
+            "z-heavy.pdb,z2,B\n" ++
+            "z-heavy.pdb,z3,C\n" ++
+            "a-heavy.pdb,a1,A\n" ++
+            "a-heavy.pdb,a2,B\n" ++
+            "a-heavy.pdb,a3,C\n" ++
+            "middle.pdb,m1,A\n" ++
+            "middle.pdb,m2,B\n" ++
+            "light.pdb,light,A\n",
+    );
+    defer map.deinit();
+
+    var files = [_][]const u8{
+        "z-heavy.pdb",
+        "unmapped.pdb",
+        "light.pdb",
+        "middle.pdb",
+        "a-heavy.pdb",
+    };
+    scheduleSelectionMapFiles(files[0..], &map);
+
+    var next_file = std.atomic.Value(usize).init(0);
+    const expected = [_][]const u8{
+        "a-heavy.pdb",
+        "z-heavy.pdb",
+        "middle.pdb",
+        "light.pdb",
+        "unmapped.pdb",
+    };
+    for (expected) |filename| {
+        try std.testing.expectEqualStrings(filename, claimSelectionMapFile(files[0..], &next_file).?);
+    }
+    try std.testing.expect(claimSelectionMapFile(files[0..], &next_file) == null);
+}
+
+test "selection map scheduling leaves legacy one-row file order unchanged" {
+    const allocator = std.testing.allocator;
+    var map = try chain_map.parseCsv(
+        allocator,
+        "filename,chains\n" ++
+            "charlie.pdb,A\n" ++
+            "alpha.pdb,A\n" ++
+            "bravo.pdb,A\n",
+    );
+    defer map.deinit();
+
+    var files = [_][]const u8{ "alpha.pdb", "bravo.pdb", "charlie.pdb" };
+    scheduleSelectionMapFiles(files[0..], &map);
+
+    try std.testing.expectEqualStrings("alpha.pdb", files[0]);
+    try std.testing.expectEqualStrings("bravo.pdb", files[1]);
+    try std.testing.expectEqualStrings("charlie.pdb", files[2]);
+}
+
+test "selection map LPT preserves JSONL results while processing a heavy file first" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPath(std.testing.io, &root_buf);
+    const root = root_buf[0..root_len];
+    const input_dir = try std.fs.path.join(allocator, &.{ root, "input" });
+    defer allocator.free(input_dir);
+    const output_path = try std.fs.path.join(allocator, &.{ root, "lpt.jsonl" });
+    defer allocator.free(output_path);
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, input_dir);
+
+    const pdb =
+        "ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "ATOM      2  N   ALA B   2       4.000   0.000   0.000  1.00 20.00           N  \n" ++
+        "END\n";
+    for ([_][]const u8{ "a-light.pdb", "z-heavy.pdb" }) |filename| {
+        const path = try std.fs.path.join(allocator, &.{ input_dir, filename });
+        defer allocator.free(path);
+        try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = path, .data = pdb });
+    }
+
+    var map = try chain_map.parseCsv(
+        allocator,
+        "filename,id,chains\n" ++
+            "a-light.pdb,light,A\n" ++
+            "z-heavy.pdb,heavy-a,A\n" ++
+            "z-heavy.pdb,heavy-b,B\n" ++
+            "z-heavy.pdb,heavy-ab,\"A,B\"\n",
+    );
+    defer map.deinit();
+
+    const stats = try runSelectionMapBatch(allocator, std.testing.io, input_dir, .{
+        .n_threads = 1,
+        .n_points = 1,
+        .classifier_type = .naccess,
+        .output_format = .jsonl,
+        .store_atom_areas = true,
+        .quiet = true,
+    }, output_path, &map);
+
+    try std.testing.expectEqual(@as(usize, 4), stats.successful);
+    try std.testing.expectEqual(@as(usize, 0), stats.failed);
+    try std.testing.expectEqual(@as(usize, 2), stats.read_parse_count);
+    try std.testing.expectEqual(@as(usize, 2), stats.classifier_count);
+    try std.testing.expectEqual(@as(usize, 4), stats.calculation_count);
+
+    const content = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, output_path, allocator, .limited(16384));
+    defer allocator.free(content);
+    const expected_ids = [_][]const u8{ "heavy-a", "heavy-b", "heavy-ab", "light" };
+    var row_index: usize = 0;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const object = parsed.value.object;
+        try std.testing.expectEqualStrings("ok", object.get("status").?.string);
+        try std.testing.expectEqualStrings(expected_ids[row_index], object.get("id").?.string);
+        try std.testing.expect(object.get("total_area") != null);
+        try std.testing.expect(object.get("atom_areas") != null);
+        row_index += 1;
+    }
+    try std.testing.expectEqual(expected_ids.len, row_index);
 }
 
 test "selection map parses and classifies once, reuses chain sets, and emits joinable JSONL" {

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -13,6 +13,10 @@ All notable changes to zsasa. See [GitHub Releases](https://github.com/N283T/zsa
 - **Parse-once SASA selection maps**: allow ordinary workflow chain maps to request multiple globally identified chain selections per structure, reuse one parsed/classified input and duplicate chain-set calculations, emit per-selection JSONL success/error rows, and optionally include stable source-indexed atom identity metadata.
 - **Multi-interface BSA workflows**: allow CSV and JSON interface maps to request multiple stable-ID interfaces per structure while reusing one parsed/classified input, emitting per-interface success/error JSONL rows, auditable residue SASA components, and opt-in atom-level detail. (#408)
 
+### Changed
+
+- **Selection-map tail scheduling**: claim ordinary multi-selection chain-map files in deterministic longest-processing-time-first order using selection count, while preserving generic batch, BSA, and legacy one-row map ordering.
+
 ### Fixed
 
 - **BSA workflow parallelism**: apply workflow thread counts to concurrent structure-file workers, keep partner and complex SASA calculations single-threaded in the multi-file path, and serialize concurrent JSONL rows safely.

--- a/website/docs/guide/workflows.md
+++ b/website/docs/guide/workflows.md
@@ -174,6 +174,16 @@ avoid nested oversubscription. With one file, the configured threads are
 available to its SASA calculations. Progress advances once per discovered
 structure after all of its selections finish.
 
+For multi-selection maps, zsasa schedules discovered structures by descending
+selection count before file workers claim them. Filename order breaks equal-cost
+ties deterministically. This longest-processing-time-first estimate starts
+selection-heavy structures early to reduce the file-level tail without reading
+or parsing inputs during scheduling. Generic batch scans, BSA workflows, and
+legacy one-row-per-file maps keep their existing order. Selection calculations
+within a structure remain serial, so exceptionally heavy final structures can
+still leave residual tail latency; bounded parse-once work stealing is tracked
+in [GitHub issue #413](https://github.com/N283T/zsasa/issues/413).
+
 Multi-selection maps require JSONL output. Each requested selection produces a
 complete, non-interleaved success or error row:
 


### PR DESCRIPTION
## Summary

- schedule ordinary multi-selection `chain_map` structure files in deterministic longest-processing-time-first order
- use requested selection count as a cheap pre-parse cost estimate, with filename as the tie-breaker
- keep generic scan order, BSA scheduling, and legacy one-row map order unchanged
- preserve file-level workers, single-threaded per-selection calculations in multi-file runs, parse-once ownership, deduplication, JSONL/error behavior, and file-based progress
- document the behavior and its remaining file-granular tail

## Why

Structure discovery is lexicographic, while selections for each parsed structure are serial. A selection-heavy structure near the end of the filename order can therefore become the final file after most workers have exited, collapsing CPU utilization. Starting high-selection files first reduces that tail without any input read, decompression, parse, or classification during scheduling.

## Scope

This PR implements the first-stage LPT fix only. Parse-once selection work stealing would require shared immutable source lifetimes, bounded active parsed contexts, exact once-only finalization, and a single global worker budget. That design and its invariants/test plan are tracked in #413 rather than destabilizing the ownership model introduced by #412.

## Expected impact

The 518 production files with at least 128 selections (44.5% of all selections), including the 22 files above 1,024 selections, will be admitted at the front of the worker queue instead of potentially remaining at the lexicographic tail. The exact makespan gain remains workload- and filename-dependent; residual tail is still possible because selections within one structure remain serial.

## Validation

- `zig fmt --check src/`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `./zig-out/bin/zsasa --help`
- `./zig-out/bin/zsasa --version`
- `./zig-out/bin/zsasa calc examples/1ubq.pdb /tmp/zsasa-check/output.json`
- `cd website && npm ci && npm run build`

Focused tests cover heavy-first claims, deterministic filename ties, successful JSONL output after reordering, exactly-once preparation counters, and unchanged one-row map ordering.